### PR TITLE
xunit.runner.console 2.2.0-beta3-build3330 missing

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -44,4 +44,4 @@ group build
     nuget System.Management.Automation
 
     source https://www.myget.org/F/xunit/
-    nuget xunit.runner.console 2.2.0-beta3-build3330
+    nuget xunit.runner.console 2.2.0

--- a/paket.lock
+++ b/paket.lock
@@ -131,7 +131,7 @@ NUGET
     System.Management.Automation (6.1.7601.17515)
     Zlib.Portable (1.11) - framework: >= netstandard11, portable-net45+sl5+win8, portable-net45+win8, portable-net45+win8+wp8+wpa81
   remote: https://www.myget.org/F/xunit
-    xunit.runner.console (2.2.0-beta3-build3330)
+    xunit.runner.console (2.2.0)
 
 GROUP tests
 NUGET


### PR DESCRIPTION
I was not able to find xunit.runner.console 2.2.0-beta3-build3330, but was able to build the msi using xunit.runner.console 2.2.0.