### PR TITLE
Fix/quit on bad env vars

### DIFF
--- a/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentStateProvider.cs
+++ b/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentStateProvider.cs
@@ -12,10 +12,11 @@ namespace Elastic.Configuration.EnvironmentBased
 		
 		string HomeDirectoryUserVariable { get; }
 		string HomeDirectoryMachineVariable { get; }
+		string HomeDirectoryProcessVariable { get; }
 		
-
 		string ConfigDirectoryUserVariable { get; }
 		string ConfigDirectoryMachineVariable { get; }
+		string ConfigDirectoryProcessVariable { get; }
 
 		string GetEnvironmentVariable(string variable);
 
@@ -29,15 +30,17 @@ namespace Elastic.Configuration.EnvironmentBased
 
 		public string HomeDirectoryUserVariable => Environment.GetEnvironmentVariable("ES_HOME", EnvironmentVariableTarget.User);
 		public string HomeDirectoryMachineVariable => Environment.GetEnvironmentVariable("ES_HOME", EnvironmentVariableTarget.Machine);
+		public string HomeDirectoryProcessVariable => Environment.GetEnvironmentVariable("ES_HOME", EnvironmentVariableTarget.Process);
 		public string RunningExecutableLocation => new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
 
 		public string ConfigDirectoryUserVariable => Environment.GetEnvironmentVariable("ES_CONFIG", EnvironmentVariableTarget.User);
 		public string ConfigDirectoryMachineVariable => Environment.GetEnvironmentVariable("ES_CONFIG", EnvironmentVariableTarget.Machine);
+		public string ConfigDirectoryProcessVariable => Environment.GetEnvironmentVariable("ES_CONFIG", EnvironmentVariableTarget.Process);
 
 		public string GetEnvironmentVariable(string variable) =>
-			Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.Machine)
+			Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.Process)
 			?? Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User)
-			?? Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.Process);
+			?? Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.Machine);
 
 		public void SetEsHomeEnvironmentVariable(string esHome) =>
 			Environment.SetEnvironmentVariable("ES_HOME", esHome, EnvironmentVariableTarget.Machine);
@@ -71,6 +74,7 @@ namespace Elastic.Configuration.EnvironmentBased
 
 		public string TargetInstallationDirectory => new []
 			{
+				StateProvider.HomeDirectoryProcessVariable,
 				StateProvider.HomeDirectoryUserVariable,
 				StateProvider.HomeDirectoryMachineVariable,
 			}
@@ -78,6 +82,7 @@ namespace Elastic.Configuration.EnvironmentBased
 
 		public string TargetInstallationConfigDirectory => new []
 			{
+				StateProvider.ConfigDirectoryProcessVariable,
 				StateProvider.ConfigDirectoryUserVariable,
 				StateProvider.ConfigDirectoryMachineVariable,
 			}
@@ -85,6 +90,7 @@ namespace Elastic.Configuration.EnvironmentBased
 
 		public string HomeDirectory => new []
 			{
+				StateProvider.HomeDirectoryProcessVariable,
 				StateProvider.HomeDirectoryUserVariable,
 				StateProvider.HomeDirectoryMachineVariable,
 				this.HomeDirectoryInferred
@@ -97,6 +103,7 @@ namespace Elastic.Configuration.EnvironmentBased
 			{
 				var variableOption = new []
 				{
+					StateProvider.ConfigDirectoryProcessVariable,
 					StateProvider.ConfigDirectoryUserVariable,
 					StateProvider.ConfigDirectoryMachineVariable,
 				}.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));

--- a/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentStateProvider.cs
+++ b/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentStateProvider.cs
@@ -8,13 +8,16 @@ namespace Elastic.Configuration.EnvironmentBased
 
 	public interface IElasticsearchEnvironmentStateProvider
 	{
+		string RunningExecutableLocation { get; }
+		
 		string HomeDirectoryUserVariable { get; }
 		string HomeDirectoryMachineVariable { get; }
-		string RunningExecutableLocation { get; }
+		
 
 		string ConfigDirectoryUserVariable { get; }
 		string ConfigDirectoryMachineVariable { get; }
 
+		string GetEnvironmentVariable(string variable);
 
 		void SetEsHomeEnvironmentVariable(string esHome);
 		void SetEsConfigEnvironmentVariable(string esConfig);
@@ -31,6 +34,10 @@ namespace Elastic.Configuration.EnvironmentBased
 		public string ConfigDirectoryUserVariable => Environment.GetEnvironmentVariable("ES_CONFIG", EnvironmentVariableTarget.User);
 		public string ConfigDirectoryMachineVariable => Environment.GetEnvironmentVariable("ES_CONFIG", EnvironmentVariableTarget.Machine);
 
+		public string GetEnvironmentVariable(string variable) =>
+			Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.Machine)
+			?? Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User)
+			?? Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.Process);
 
 		public void SetEsHomeEnvironmentVariable(string esHome) =>
 			Environment.SetEnvironmentVariable("ES_HOME", esHome, EnvironmentVariableTarget.Machine);
@@ -99,6 +106,8 @@ namespace Elastic.Configuration.EnvironmentBased
 				return string.IsNullOrEmpty(homeDir) ? null : Path.Combine(homeDir, "config");
 			}
         }
+
+		public string GetEnvironmentVariable(string variable) => this.StateProvider.GetEnvironmentVariable(variable);
 
 		public void SetEsHomeEnvironmentVariable(string esHome) => StateProvider.SetEsHomeEnvironmentVariable(esHome);
 

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","c568d3")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","8031d4")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "c568d3";
+        internal const System.String AssemblyMetadata_GitBuildHash = "8031d4";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts/ExceptionExtensions.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/ExceptionExtensions.cs
@@ -8,11 +8,14 @@ namespace Elastic.ProcessHosts
 		public static void ToConsole(this Exception e, string prefix)
 		{
 			Console.ForegroundColor = ConsoleColor.Red;
-			if (e is StartupException)
+			var startUpException = e as StartupException;
+			if (startUpException != null)
 				Console.Error.WriteLine(e.Message);
 			else
 				Console.Error.WriteLine($"{prefix}: {e}");
 			Console.ResetColor();
+			if (!string.IsNullOrWhiteSpace(startUpException?.HelpText))
+				Console.WriteLine(startUpException.HelpText);
 		}
 	}
 }

--- a/src/ProcessHosts/Elastic.ProcessHosts/Process/StartupException.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Process/StartupException.cs
@@ -4,8 +4,13 @@ namespace Elastic.ProcessHosts.Process
 {
 	public class StartupException : Exception
 	{
-		public StartupException(string message) : base(message)
+		public StartupException(string message) : base(message) { }
+
+		public StartupException(string message, string helpText) : base(message)
 		{
+			this.HelpText = helpText;
 		}
+
+		public string HelpText { get; private set; }
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Elasticsearch\Process\ElasticsearchProcessTesterStateProvider.cs" />
     <Compile Include="Elasticsearch\Process\Observing\HandlerTests.cs" />
     <Compile Include="Elasticsearch\Process\Observing\WriterTests.cs" />
+    <Compile Include="Elasticsearch\Process\Paths\BadEnvironmentVariablesTests.cs" />
     <Compile Include="Elasticsearch\Process\Paths\ElasticsearchConfigFolderTests.cs" />
     <Compile Include="Elasticsearch\Process\Paths\ElasticsearchHomeAndBinaryTests.cs" />
     <Compile Include="Elasticsearch\Process\Paths\JavaHomeAndBinaryTests.cs" />

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockElasticsearchEnvironmentStateProvider.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockElasticsearchEnvironmentStateProvider.cs
@@ -1,4 +1,7 @@
-﻿using Elastic.Configuration.EnvironmentBased;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Elastic.Configuration.EnvironmentBased;
 
 namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 {
@@ -9,10 +12,18 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 		private string _esExecutable;
 		private string _esConfigMachine;
 		private string _esConfigUser;
+		private Dictionary<string, string> _mockVariables = new Dictionary<string, string>();
 
 		public string LastSetEsHome { get; set; }
 		public string LastSetEsConfig { get; set; }
 
+		public string GetEnvironmentVariable(string variable) => _mockVariables.TryGetValue(variable, out string v) ? v : null;
+
+		public MockElasticsearchEnvironmentStateProvider EnvironmentVariables(Dictionary<string, string> variables)
+		{
+			this._mockVariables = variables;
+			return this;
+		}
 		public MockElasticsearchEnvironmentStateProvider EsHomeMachineVariable(string esHome)
 		{
 			this._esHomeMachine = esHome;

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockElasticsearchEnvironmentStateProvider.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockElasticsearchEnvironmentStateProvider.cs
@@ -9,9 +9,11 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 	{
 		private string _esHomeMachine;
 		private string _esHomeUser;
+		private string _esHomeProcess;
 		private string _esExecutable;
 		private string _esConfigMachine;
 		private string _esConfigUser;
+		private string _esConfigProcess;
 		private Dictionary<string, string> _mockVariables = new Dictionary<string, string>();
 
 		public string LastSetEsHome { get; set; }
@@ -34,6 +36,12 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 			this._esHomeUser = esHome;
 			return this;
 		}
+		public MockElasticsearchEnvironmentStateProvider EsHomeProcessVariable(string esHome)
+		{
+			this._esHomeProcess = esHome;
+			return this;
+		}
+		
 		public MockElasticsearchEnvironmentStateProvider ElasticsearchExecutable(string executable)
 		{
 			this._esExecutable = executable;
@@ -50,12 +58,20 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 			this._esConfigUser = esConfig;
 			return this;
 		}
+		public MockElasticsearchEnvironmentStateProvider EsConfigProcessVariable(string esConfig)
+		{
+			this._esConfigProcess = esConfig;
+			return this;
+		}
+		
+		public string RunningExecutableLocation => this._esExecutable;
 
 		public string HomeDirectoryUserVariable => this._esHomeUser;
 		public string HomeDirectoryMachineVariable => this._esHomeMachine;
-		public string RunningExecutableLocation => this._esExecutable;
+		public string HomeDirectoryProcessVariable => this._esHomeProcess;
 		public string ConfigDirectoryUserVariable => this._esConfigUser;
 		public string ConfigDirectoryMachineVariable => this._esConfigMachine;
+		public string ConfigDirectoryProcessVariable => this._esConfigProcess;
 
 		public void SetEsHomeEnvironmentVariable(string esHome)
 		{

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/ElasticsearchProcessTester.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/ElasticsearchProcessTester.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
 using Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks;
 using Elastic.ProcessHosts.Elasticsearch.Process;
+using Elastic.ProcessHosts.Process;
 
 namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process
 {
@@ -16,7 +17,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process
 		public static string DefaultJavaHome { get; } = @"C:\Java";
 		public static string DefaultEsHome { get; } = LocationsModel.DefaultInstallationDirectory;
 
-		private ElasticsearchProcessTester(Func<ElasticsearchProcessTesterStateProvider, ElasticsearchProcessTesterStateProvider> setup)
+		public ElasticsearchProcessTester(Func<ElasticsearchProcessTesterStateProvider, ElasticsearchProcessTesterStateProvider> setup)
 		{
 			var state = setup(new ElasticsearchProcessTesterStateProvider());
 
@@ -73,9 +74,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process
 				.ProcessArguments(args)
 			);
 
-		public static ElasticsearchProcessTester Create(Func<ElasticsearchProcessTesterStateProvider, ElasticsearchProcessTesterStateProvider> setup) =>
-			new ElasticsearchProcessTester(setup);
-
 		public static void CreateThrows(
 			Func<ElasticsearchProcessTesterStateProvider, ElasticsearchProcessTesterStateProvider> setup,
 			Action<Exception> assert)
@@ -93,7 +91,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process
 			if (created)
 				throw new Exception("Process tester expected elasticsearch.exe to throw an exception");
 		}
-
+		
 		public void Start(Action<ElasticsearchProcessTester> assert)
 		{
 			this.Process.Start();

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/BadEnvironmentVariablesTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/BadEnvironmentVariablesTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using Elastic.ProcessHosts.Process;
+using FluentAssertions;
+using Xunit;
+using static Elastic.Installer.Domain.Tests.Elasticsearch.Process.ElasticsearchProcessTester;
+using kv = System.Collections.Generic.Dictionary<string, string>;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Paths
+{
+	public class BadEnvironmentVariablesTests
+	{
+		private static void ExpectStartupException(string key, string value, Action<StartupException> assert)
+		{
+			var created = false;
+			try
+			{
+				var elasticsearchProcessTester = new ElasticsearchProcessTester(s => s
+                    .Elasticsearch(e => e
+						.EsHomeMachineVariable(DefaultEsHome)
+						.EnvironmentVariables(new kv { { key, value } }))
+                    .Java(j => j.JavaHomeMachine(DefaultJavaHome))
+                    .ConsoleSession(ConsoleSession.StartedSession)
+                    .FileSystem(fs=> s.AddJavaExe(s.AddElasticsearchLibs(fs, null)))
+                );
+				created = true;
+			}
+			catch (Exception e)
+			{
+				var se = e as StartupException;
+				if (se == null) throw new Exception("Exception was thrown but not of type StartupException see InnerException", e);
+				assert(se);
+			}
+			if (created)
+				throw new Exception($"Process tester expected elasticsearch.exe to throw an exception for {key}");
+		}
+
+		[Fact]
+		public void UserVariableWinsFromMachineVariable()
+		{
+			var badVariables = new[]
+			{
+				"ES_CLASSPATH",
+				"ES_MIN_MEM",
+				"ES_MAX_MEM",
+				"ES_HEAP_SIZE",
+				"ES_HEAP_NEWSIZE",
+				"ES_DIRECT_SIZE",
+				"ES_USE_IPV4",
+				"ES_GC_OPTS",
+				"ES_GC_LOG_FILE"
+			};
+			foreach (var v in badVariables)
+				ExpectStartupException(v, "some value", (e) =>
+				{
+					e.Message.Should().Contain("The following deprecated environment variables are");
+					e.HelpText.Should().NotBeNullOrWhiteSpace();
+				});
+		}
+
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/ElasticsearchConfigFolderTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/ElasticsearchConfigFolderTests.cs
@@ -10,6 +10,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Paths
 	{
 		private readonly string _executableParentFolder = @"C:\Alternative\Elasticsearch (x86)\weird location";
 		private string Executable => Path.Combine(_executableParentFolder, @"bin\elasticsearch.exe");
+		private const string EsConfProcess = @"c:\Elasticsearch\Process";
 		private const string EsConfUser = @"c:\Elasticsearch\UserConfig";
 		private const string EsConfMachine = @"c:\Elasticsearch\MachineConfig";
 		private const string EsConfCommandLine = @"c:\Elasticsearch\ArgCommandLine";
@@ -24,6 +25,17 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Paths
 				p.ObservableProcess.ArgsCalled.Should().NotBeNullOrEmpty().And.Contain(EsConfArg(DefaultEsConf));
 			});
 
+		[Fact] public void ProcessVariableWinsFromUserVariable() => ElasticsearchChangesOnly(e=>e
+				.EsConfigProcessVariable(EsConfProcess)
+				.EsConfigUserVariable(EsConfUser)
+				.EsConfigMachineVariable(EsConfMachine)
+				.ElasticsearchExecutable(Executable)
+			)
+			.Start(p =>
+			{
+				p.ObservableProcess.ArgsCalled.Should().NotBeNullOrEmpty().And.Contain(EsConfArg(EsConfProcess));
+			});
+		
 		[Fact] public void UserVariableWinsFromMachineVariable() => ElasticsearchChangesOnly(e=>e
 				.EsConfigUserVariable(EsConfUser)
 				.EsConfigMachineVariable(EsConfMachine)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/ElasticsearchHomeAndBinaryTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/ElasticsearchHomeAndBinaryTests.cs
@@ -11,6 +11,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Paths
 
 		private readonly string _executableParentFolder = @"C:\Alternative\Elasticsearch (x86)\weird location";
 		private string Executable => Path.Combine(_executableParentFolder, @"bin\elasticsearch.exe");
+		private const string EsHomeProcess = @"c:\Elasticsearch\Process";
 		private const string EsHomeUser = @"c:\Elasticsearch\User";
 		private const string EsHomeMachine = @"c:\Elasticsearch\Machine";
 		private const string EsHomeCommandLine = @"c:\Elasticsearch\CommandLine";
@@ -43,6 +44,18 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Paths
 				})
 			, e => { e.Message.Should().Contain("No elasticsearch jar found in:"); });
 
+		
+		[Fact] public void ProcessVariableWinsFromUserVariable() => ElasticsearchChangesOnly(e => e
+				.EsHomeProcessVariable(EsHomeProcess)
+				.EsHomeUserVariable(EsHomeUser)
+				.EsHomeMachineVariable(EsHomeMachine)
+				.ElasticsearchExecutable(Executable)
+			)
+			.Start(p =>
+			{
+				p.ObservableProcess.ArgsCalled.Should().NotBeNullOrEmpty()
+					.And.Contain(EsHomeArg(EsHomeProcess));
+			});
 		[Fact] public void UserVariableWinsFromMachineVariable() => ElasticsearchChangesOnly(e => e
 				.EsHomeUserVariable(EsHomeUser)
 				.EsHomeMachineVariable(EsHomeMachine)


### PR DESCRIPTION
* mimic elasticsearch.bat and quit on the usage of deprecated environment variables
* Also listen to ES_HOME and ES_CONF as process variables and give them precedence to all others
* StartupException now also has `HelpText` property which'll display steps to fix the startup condition on a new line before exiting. We should add this to all occorances to guide users to the happy path.

![elasticsearch-env-vars](https://cloud.githubusercontent.com/assets/245275/26601294/a8c8acfc-457f-11e7-8d0c-99d30f47cc42.gif)
