### PR TITLE
Build multiple MSI versions

### DIFF
--- a/build/scripts/BuildConfig.fsx
+++ b/build/scripts/BuildConfig.fsx
@@ -60,7 +60,7 @@ namespace Elastic.Installer.Domain
 }
 """
 
-    let versionGuid (productVersions: ProductVersion list) =
+    let versionGuid (productVersions: ProductVersions list) =
         let config = TypedConfig()
         config.Load sourceYaml
         tracefn "found %i elasticsearch known versions" config.elasticsearch.known_versions.Count
@@ -68,22 +68,25 @@ namespace Elastic.Installer.Domain
 
         productVersions
         |> List.iter(fun p ->
-            let version = p.Version.FullVersion
-            match p.Product with
-            | Elasticsearch ->
-                match config.elasticsearch.known_versions |> Seq.tryFind (fun v -> v.version = version) with
-                | Some _ -> ()
-                | None ->
-                    let newGuid = Guid.NewGuid()
-                    let newVersion = new TypedConfig.elasticsearch_Type.known_versions_Item_Type(version=version, guid=newGuid)
-                    config.elasticsearch.known_versions.Add newVersion
-            | Kibana ->
-                match config.kibana.known_versions |> Seq.tryFind (fun v -> v.version = version) with
-                | Some _ -> ()
-                | None ->
-                    let newGuid = Guid.NewGuid()
-                    let newVersion = new TypedConfig.kibana_Type.known_versions_Item_Type(version=version, guid=newGuid)
-                    config.kibana.known_versions.Add newVersion
+            p.Versions
+            |> List.iter(fun v ->              
+                let version = v.FullVersion
+                match p.Product with
+                | Elasticsearch ->
+                    match config.elasticsearch.known_versions |> Seq.tryFind (fun v -> v.version = version) with
+                    | Some _ -> ()
+                    | None ->
+                        let newGuid = Guid.NewGuid()
+                        let newVersion = new TypedConfig.elasticsearch_Type.known_versions_Item_Type(version=version, guid=newGuid)
+                        config.elasticsearch.known_versions.Add newVersion
+                | Kibana ->
+                    match config.kibana.known_versions |> Seq.tryFind (fun v -> v.version = version) with
+                    | Some _ -> ()
+                    | None ->
+                        let newGuid = Guid.NewGuid()
+                        let newVersion = new TypedConfig.kibana_Type.known_versions_Item_Type(version=version, guid=newGuid)
+                        config.kibana.known_versions.Add newVersion
+            )
         )
 
         config.Save sourceYaml

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","93a02f")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","15bc3a")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "93a02f";
+        internal const System.String AssemblyMetadata_GitBuildHash = "15bc3a";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Upgrade/SilentInstall-Upgrade.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Upgrade/SilentInstall-Upgrade.Tests.ps1
@@ -1,0 +1,143 @@
+$currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
+Set-Location $currentDir
+
+# mapped sync folder for common scripts
+. $currentDir\..\common\Utils.ps1
+. $currentDir\..\common\CommonTests.ps1
+
+Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous version" {
+
+	$previousVersion = $env:PreviousEsVersion
+	$credentials = "elastic:changeme"
+
+    Invoke-SilentInstall -Version $previousVersion
+
+    Context-ElasticsearchService
+
+    Context-PingNode -XPackSecurityInstalled $true
+
+    $ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+    Context-EsHomeEnvironmentVariable -Expected $ExpectedHomeFolder
+
+    $ProfileFolder = $env:ALLUSERSPROFILE
+    $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
+
+    Context-EsConfigEnvironmentVariable -Expected $ExpectedConfigFolder
+
+    Context-PluginsInstalled
+
+    Context-MsiRegistered -Expected @{
+		Name = "Elasticsearch $previousVersion"
+		Caption = "Elasticsearch $previousVersion"
+		Version = $previousVersion
+	}
+
+    Context-ServiceRunningUnderAccount -Expected "LocalSystem"
+
+    Context-EmptyEventLog
+
+	Context-ClusterNameAndNodeName -Expected @{ Credentials = $credentials }
+
+    Context-ElasticsearchConfiguration
+
+    Context-JvmOptions
+
+	# Insert some data
+	Context-InsertData -Credentials "elastic:changeme"
+}
+
+Describe -Tag 'PreviousVersion' "Silent Install upgrade -Upgrade to new version" {
+
+	$version = $env:EsVersion
+	$credentials = "elastic:changeme"
+
+    Invoke-SilentInstall -Version $version
+
+    Context-ElasticsearchService
+
+    Context-PingNode -XPackSecurityInstalled $true
+
+    $ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+    Context-EsHomeEnvironmentVariable -Expected $ExpectedHomeFolder
+
+    $ProfileFolder = $env:ALLUSERSPROFILE
+    $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
+
+    Context-EsConfigEnvironmentVariable -Expected $ExpectedConfigFolder
+
+    Context-PluginsInstalled
+
+    Context-MsiRegistered
+
+    Context-ServiceRunningUnderAccount -Expected "LocalSystem"
+
+    Context-EmptyEventLog
+
+	Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:changeme" }
+
+    Context-ElasticsearchConfiguration
+
+    Context-JvmOptions
+
+	# Check inserted data still exists
+	Context-ReadData -Credentials $credentials
+}
+
+Describe -Tag 'PreviousVersion' "Silent Uninstall upgrade - Uninstall new version" {
+
+	$version = $env:EsVersion
+
+    Invoke-SilentUninstall -Version $version
+
+    Context "Ping node" {
+        It "Elasticsearch node should not be running" {
+            try {
+                $Response = Invoke-RestMethod http://localhost:9200
+                $Response | Should Be $null
+            }
+            catch {
+                $_.Exception.Message | Should Be "Unable to connect to the remote server"
+            }
+        }
+    }
+
+    Context "ES_CONFIG Environment Variable" {
+        $EsConfig = Get-MachineEnvironmentVariable "ES_CONFIG"
+        It "ES_CONFIG Environment variable should be null" {
+            $EsConfig | Should Be $null
+        }
+    }
+
+    Context "ES_HOME Environment Variable" {
+        $EsConfig = Get-MachineEnvironmentVariable "ES_HOME"
+        It "ES_HOME Environment variable should be null" {
+            $EsConfig | Should Be $null
+        }
+    }
+
+    Context "MSI Product" {
+        $Product = Get-ElasticsearchWin32Product
+        It "MSI should not be registered" {
+            $Product | Should Be $null
+        }
+    }
+
+    Context "Elasticsearch Service" {
+        $Service = Get-ElasticsearchWin32Service
+        It "Service should not be registered" {
+            $Service | Should Be $null
+        }
+    }
+
+    Context "Installation directory" {
+        $ProgramFiles = Get-ProgramFilesFolder
+        $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+        It "Installation directory should not exist" {
+            $ExpectedHomeFolder | Should Not Exist
+        }
+    }
+}


### PR DESCRIPTION
Allow the ability to specify multiple versions of a product to build, using comma separated versions. This is useful for integration tests that need to test upgrades