### PR TITLE
updated styling of flyout, now a window flyout that is modal

### DIFF
--- a/src/Installer/Elastic.Installer.UI/Controls/StepWithHelp.xaml
+++ b/src/Installer/Elastic.Installer.UI/Controls/StepWithHelp.xaml
@@ -3,9 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:controls="clr-namespace:Elastic.Installer.UI.Controls"
-             xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
-             xmlns:uc="http://www.quickzip.org/BaseControls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600"
              x:Name="Control">
@@ -21,16 +18,6 @@
         </Grid.RowDefinitions>
         
         <ContentControl Grid.Row="0" Margin="10,10,10,10" Grid.Column="0" Content="{Binding Path=Step, ElementName=Control}" Grid.RowSpan="3"/>
-        <metro:FlyoutsControl>
-          <metro:Flyout Header="Help" Theme="Accent" CloseButtonVisibility="Hidden" IsOpen="{TemplateBinding controls:StepWithHelp.IsOpen}" Position="Left" Width="600">
-            <ScrollViewer>
-              <uc:HtmlTextBlock Html="{TemplateBinding controls:StepWithHelp.HelpText}" TextWrapping="Wrap"
-                         Margin="3" Height="auto"></uc:HtmlTextBlock>
-            </ScrollViewer>
-            <!-- Your custom content here -->
-          </metro:Flyout>
-        </metro:FlyoutsControl>
-      
       </Grid>
     </ControlTemplate>
   </UserControl.Template>

--- a/src/Installer/Elastic.Installer.UI/Controls/StepWithHelp.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Controls/StepWithHelp.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -12,6 +13,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using MahApps.Metro.Controls;
 
 namespace Elastic.Installer.UI.Controls
 {
@@ -25,6 +27,9 @@ namespace Elastic.Installer.UI.Controls
 
 		public static readonly DependencyProperty HelpTextProperty =
 				DependencyProperty.Register("HelpText", typeof(string), typeof(StepWithHelp), new FrameworkPropertyMetadata());
+		
+		public static readonly DependencyProperty HelpHeaderTextProperty =
+				DependencyProperty.Register("HelpHeaderText", typeof(string), typeof(StepWithHelp), new FrameworkPropertyMetadata());
 		
 		public static readonly DependencyProperty IsOpenProperty =
 				DependencyProperty.Register("IsOpen", typeof(bool), typeof(StepWithHelp), new UIPropertyMetadata());
@@ -40,7 +45,11 @@ namespace Elastic.Installer.UI.Controls
 			get { return (object)GetValue(StepProperty); }
 			set { SetValue(StepProperty, value); }
 		}
-
+		public string HelpHeaderText
+		{
+			get { return (string)GetValue(HelpHeaderTextProperty); }
+			set { SetValue(HelpHeaderTextProperty, value); }
+		}
 		public string HelpText
 		{
 			get { return (string)GetValue(HelpTextProperty); }
@@ -49,11 +58,6 @@ namespace Elastic.Installer.UI.Controls
 		public StepWithHelp()
 		{
 			InitializeComponent();
-		}
-
-		public void ToggleHelp()
-		{
-			this.IsOpen = !this.IsOpen;
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml
@@ -7,6 +7,7 @@
                       
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                      xmlns:uc="http://www.quickzip.org/BaseControls"
                       mc:Ignorable="d"
                       xmlns:resx="clr-namespace:Elastic.Installer.UI.Properties"
                       xmlns:elasticsearch="clr-namespace:Elastic.Installer.Domain.Model.Elasticsearch;assembly=Elastic.Installer.Domain"
@@ -23,7 +24,16 @@
                       d:DataContext="{d:DesignInstance elasticsearch:ElasticsearchInstallationModel}"
                       Style="{DynamicResource CleanWindowStyleKey}"
                       >
-
+  <controls:MetroWindow.Flyouts>
+        <controls:FlyoutsControl BorderBrush="Gray" BorderThickness="3" x:Name="FlyoutsControl">
+          <controls:Flyout Header="Help" Theme="Adapt" CloseButtonVisibility="Visible" x:Name="FlyoutControl" IsModal="true" Width="600" IsPinned="false" Position="Left">
+            <ScrollViewer>
+              <uc:HtmlTextBlock x:Name="HelpHtmlControl" Html="" TextWrapping="Wrap" Margin="3" Height="auto" Padding="5"></uc:HtmlTextBlock>
+            </ScrollViewer>
+            <!-- Your custom content here -->
+          </controls:Flyout>
+        </controls:FlyoutsControl>
+  </controls:MetroWindow.Flyouts>
   <controls:MetroWindow.Background>
     <SolidColorBrush Color="White"></SolidColorBrush>
   </controls:MetroWindow.Background>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ using Elastic.Installer.Domain.Model.Elasticsearch.Notice;
 using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
 using Elastic.Installer.UI.Elasticsearch.Steps;
 using Elastic.Installer.UI.Shared.Steps;
+using FluentValidation.Internal;
 
 namespace Elastic.Installer.UI.Elasticsearch
 {
@@ -121,24 +122,24 @@ namespace Elastic.Installer.UI.Elasticsearch
 		private readonly IDictionary<Type, Action<IValidatableReactiveObject, StepWithHelp>> StepModelToControl =
 			new Dictionary<Type, Action<IValidatableReactiveObject, StepWithHelp>>
 		{
-			{ typeof(NoticeModel),
-					(m, s) =>  Step(s, new NoticeView { ViewModel = m as NoticeModel }, string.Format(ViewResources.MainWindow_Help, "Elasticsearch")) },
-			{ typeof(LocationsModel),
-					(m, s) => Step(s, new LocationsView { ViewModel = m as LocationsModel }, ViewResources.LocationsView_Elasticsearch_Help)  },
-			{ typeof(ServiceModel),
-					(m, s) => Step(s, new ServiceView { ViewModel = m as ServiceModel }, ViewResources.ServiceView_Elasticsearch_Help) },
-			{ typeof(ConfigurationModel),
-					(m, s) => Step(s, new ConfigurationView { ViewModel = m as ConfigurationModel }, ViewResources.ConfigurationView_Elasticsearch_Help) },
-			{ typeof(PluginsModel),
-					(m, s) => Step(s, new PluginsView { ViewModel = m as PluginsModel }, ViewResources.PluginsView_Elasticsearch_Help) },
-			{ typeof(ClosingModel),
-					(m, s) => Step(s, new ClosingView { ViewModel = m as ClosingModel }, null) },
+			{ typeof(NoticeModel), (m, s) =>  Step(s, new NoticeView { ViewModel = m as NoticeModel }, 
+				ViewResources.MainWindow_Help_Header, string.Format(ViewResources.MainWindow_Help, "Elasticsearch")) },
+			{ typeof(LocationsModel), (m, s) => Step(s, new LocationsView { ViewModel = m as LocationsModel }, 
+				ViewResources.LocationsView_Elasticsearch_Help_Header, ViewResources.LocationsView_Elasticsearch_Help)  },
+			{ typeof(ServiceModel), (m, s) => Step(s, new ServiceView { ViewModel = m as ServiceModel }, 
+				ViewResources.ServiceView_Elasticsearch_Help_Header, ViewResources.ServiceView_Elasticsearch_Help) },
+			{ typeof(ConfigurationModel), (m, s) => Step(s, new ConfigurationView { ViewModel = m as ConfigurationModel }, 
+				ViewResources.ConfigurationView_Elasticsearch_Help_Header, ViewResources.ConfigurationView_Elasticsearch_Help) },
+			{ typeof(PluginsModel), (m, s) => Step(s, new PluginsView { ViewModel = m as PluginsModel }, 
+				ViewResources.PluginsView_Elasticsearch_Help_Header, ViewResources.PluginsView_Elasticsearch_Help) },
+			{ typeof(ClosingModel), (m, s) => Step(s, new ClosingView { ViewModel = m as ClosingModel }, null, null) },
 		};
 
-		private static void Step(StepWithHelp step, UserControl view, string help)
+		private static void Step(StepWithHelp step, UserControl view, string helpHeaderText, string help)
 		{
 			step.Step = view;
 			step.HelpText = help;
+			step.HelpHeaderText = helpHeaderText;
 		}
 
 		private void TabNavigation()
@@ -206,7 +207,9 @@ namespace Elastic.Installer.UI.Elasticsearch
 
 						label.Foreground = defaultTabForeground;
 						if (i == selected)
+						{
 							label.Foreground = selectedTabForeground;
+						}
 						if (!this.ViewModel.Steps[i].IsValid)
 							label.Foreground = badTabForeground;
 						if (i > max)
@@ -235,7 +238,9 @@ namespace Elastic.Installer.UI.Elasticsearch
 				var tabItem = this.StepsTab.Items[this.ViewModel.TabSelectedIndex] as TabItem;
 				var stepWithHelp = tabItem?.Content as StepWithHelp;
 				if (stepWithHelp == null) return;
-				stepWithHelp.ToggleHelp();
+				this.HelpHtmlControl.Html = stepWithHelp.HelpText;
+				this.FlyoutControl.Header = stepWithHelp.HelpHeaderText;
+				this.FlyoutControl.IsOpen = !this.FlyoutControl.IsOpen;
 			});
 
 			this.ViewModel.ShowLicenseBlurb.Subscribe(async x =>

--- a/src/Installer/Elastic.Installer.UI/Kibana/MainWindow.xaml
+++ b/src/Installer/Elastic.Installer.UI/Kibana/MainWindow.xaml
@@ -6,6 +6,7 @@
                       xmlns:escontrols="clr-namespace:Elastic.Installer.UI.Controls"
                       
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:uc="http://www.quickzip.org/BaseControls"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       mc:Ignorable="d"
                       xmlns:resx="clr-namespace:Elastic.Installer.UI.Properties"
@@ -24,6 +25,16 @@
                       Style="{DynamicResource CleanWindowStyleKey}"
                       >
 
+  <controls:MetroWindow.Flyouts>
+        <controls:FlyoutsControl BorderBrush="Gray" BorderThickness="3" x:Name="FlyoutsControl">
+          <controls:Flyout Header="Help" Theme="Adapt" CloseButtonVisibility="Visible" x:Name="FlyoutControl" IsModal="true" Width="600" IsPinned="false" Position="Left">
+            <ScrollViewer>
+              <uc:HtmlTextBlock x:Name="HelpHtmlControl" Html="" TextWrapping="Wrap" Margin="3" Height="auto"></uc:HtmlTextBlock>
+            </ScrollViewer>
+            <!-- Your custom content here -->
+          </controls:Flyout>
+        </controls:FlyoutsControl>
+  </controls:MetroWindow.Flyouts>
   <controls:MetroWindow.Background>
     <SolidColorBrush Color="White"></SolidColorBrush>
   </controls:MetroWindow.Background>

--- a/src/Installer/Elastic.Installer.UI/Kibana/MainWindow.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Kibana/MainWindow.xaml.cs
@@ -235,7 +235,8 @@ namespace Elastic.Installer.UI.Kibana
 				var tabItem = this.StepsTab.Items[this.ViewModel.TabSelectedIndex] as TabItem;
 				var stepWithHelp = tabItem?.Content as StepWithHelp;
 				if (stepWithHelp == null) return;
-				stepWithHelp.ToggleHelp();
+				this.HelpHtmlControl.Html = stepWithHelp.HelpText;
+				this.FlyoutControl.IsOpen = !this.FlyoutControl.IsOpen;
 			});
 
 			this.ViewModel.ShowLicenseBlurb.Subscribe(async x =>

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -429,6 +429,11 @@ namespace Elastic.Installer.UI.Properties {
             }
         }
         
+        public static string ConfigurationView_Elasticsearch_Help_Header {
+            get {
+                return ResourceManager.GetString("ConfigurationView_Elasticsearch_Help_Header", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to This step allows you to specify some settings found in the [b]elasticsearch.yml[/b] and [b]jvm.options[/b] files located in the [b]config[/b] folder.  We&apos;re only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
         ///
@@ -1022,6 +1027,11 @@ namespace Elastic.Installer.UI.Properties {
             }
         }
         
+        public static string LocationsView_Elasticsearch_Help_Header {
+            get {
+                return ResourceManager.GetString("LocationsView_Elasticsearch_Help_Header", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Elasticsearch has several different folders that it needs to have read and/or write access to:
         ///
@@ -1118,6 +1128,11 @@ namespace Elastic.Installer.UI.Properties {
             }
         }
         
+        public static string MainWindow_Help_Header {
+            get {
+                return ResourceManager.GetString("MainWindow_Help_Header", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Heya! Welcome the {0} Windows intaller.
         ///
@@ -1329,6 +1344,11 @@ namespace Elastic.Installer.UI.Properties {
             }
         }
         
+        public static string PluginsView_Elasticsearch_Help_Header {
+            get {
+                return ResourceManager.GetString("PluginsView_Elasticsearch_Help_Header", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Plugins are a way to enhance the basic Elasticsearch functionality in a custom manner.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), native scripts, custom discovery and more.
         ///
@@ -1439,6 +1459,11 @@ namespace Elastic.Installer.UI.Properties {
             }
         }
         
+        public static string ServiceView_Elasticsearch_Help_Header {
+            get {
+                return ResourceManager.GetString("ServiceView_Elasticsearch_Help_Header", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to By default, Elasticsearch will be installed as a service.
         ///

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -275,19 +275,19 @@
     <value>Installing...</value>
   </data>
   <data name="MainWindow_TabItemConfiguration" xml:space="preserve">
-    <value>configuration</value>
+    <value>Configuration</value>
   </data>
   <data name="MainWindow_TabItemLocations" xml:space="preserve">
-    <value>locations</value>
+    <value>Locations</value>
   </data>
   <data name="MainWindow_TabItemPlugins" xml:space="preserve">
-    <value>plugins</value>
+    <value>Plugins</value>
   </data>
   <data name="MainWindow_TabItemService" xml:space="preserve">
-    <value>service</value>
+    <value>Service</value>
   </data>
   <data name="MainWindow_TabItemWelcome" xml:space="preserve">
-    <value>welcome</value>
+    <value>Welcome</value>
   </data>
   <data name="MainWindow_Title" xml:space="preserve">
     <value>Elasticsearch {0} Installation</value>
@@ -394,6 +394,9 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
   <data name="NoticeView_RunAsServiceHeaderLabel" xml:space="preserve">
     <value>Install as a service</value>
   </data>
+  <data name="ConfigurationView_Elasticsearch_Help_Header" xml:space="preserve">
+    <value>Configuration Help</value>
+  </data>
   <data name="ConfigurationView_Elasticsearch_Help" xml:space="preserve">
     <value>This step allows you to specify some settings found in the [b]elasticsearch.yml[/b] and [b]jvm.options[/b] files located in the [b]config[/b] folder.  We're only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
 
@@ -414,6 +417,9 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
 
 [b]Transport port[/b]: The port to use for node-to-node communication over the Elasticsearch transport protocol.</value>
   </data>
+  <data name="LocationsView_Elasticsearch_Help_Header" xml:space="preserve">
+    <value>Locations Help</value>
+  </data>
   <data name="LocationsView_Elasticsearch_Help" xml:space="preserve">
     <value>Elasticsearch has several different folders that it needs to have read and/or write access to:
 
@@ -427,16 +433,25 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
 
 It is best practice to keep your logs, config, and data directories separate from your home directory.  This keeps your data and configuration safe from overwriting when upgrading to newer versions of Elasticsearch.</value>
   </data>
+  <data name="MainWindow_Help_Header" xml:space="preserve">
+    <value>Installation Help</value>
+  </data>
   <data name="MainWindow_Help" xml:space="preserve">
     <value>Heya! Welcome the {0} Windows intaller.
 
 This installer will walk you through various steps to help you conifigure and install {0} on your system.  To make things easier, we've gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you'll definitely want to change.</value>
     <comment>{0} = Product name</comment>
   </data>
+  <data name="PluginsView_Elasticsearch_Help_Header" xml:space="preserve">
+    <value>Plugin Help</value>
+  </data>
   <data name="PluginsView_Elasticsearch_Help" xml:space="preserve">
     <value>Plugins are a way to enhance the basic Elasticsearch functionality in a custom manner.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), native scripts, custom discovery and more.
 
 We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually.</value>
+  </data>
+  <data name="ServiceView_Elasticsearch_Help_Header" xml:space="preserve">
+    <value>Service Help</value>
   </data>
   <data name="ServiceView_Elasticsearch_Help" xml:space="preserve">
     <value>By default, Elasticsearch will be installed as a service.


### PR DESCRIPTION
Noticed in the new documentation that i hated the blue help flyout:

![image](https://user-images.githubusercontent.com/245275/27336207-210a3ece-55cf-11e7-856a-1a650c853198.png)

Updated it to this now: 
![installer-help](https://user-images.githubusercontent.com/245275/27336230-31599662-55cf-11e7-939e-85b56fd23698.gif)
