### PR TITLE
Change default settings to align with other package distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the repository for the Elastic stack MSI-based Windows installers.
 Simply clone the repository and run
 
 ```bat
-build
+build.bat
 ```
 
 This will download the latest version of the stack (currently only Elasticsearch) and create the MSIs.
@@ -17,7 +17,13 @@ This will download the latest version of the stack (currently only Elasticsearch
 You can also specify a specific version
 
 ```bat
-build 5.1.1
+build.bat 5.1.1
+```
+
+There are many other configuration options available, run the following to see them all
+
+```bat
+build.bat help
 ```
 
 **NOTE**: *Building from source should only be done for development purposes.  Only the officially distributed and signed Elastic installer should be used in production. Using an unofficial Elastic installer is not supported.*
@@ -27,29 +33,29 @@ build 5.1.1
 Instead of installing through the UI, it is also possible to perform an installation in "quiet" mode via the command-line using [msiexec](https://technet.microsoft.com/en-us/library/bb490936.aspx?f=255&MSPPError=-2147217396) and passing the `/qn` flag, which will invoke the installer without the UI.  This can be particularly useful for automating deployments.
 
 ```bat
-msiexec /i elasticsearch-5.1.1.msi /qn
+start /wait msiexec.exe /i elasticsearch-5.5.0.msi /qn
 ```
 
 You can also optionally specify a log file
 
 ```bat
-msiexec /i elasticsearch-5.1.1.msi /qn /l elastic-install.log
+start /wait msiexec.exe /i elasticsearch-5.5.0.msi /qn /l elastic-install.log
 ```
 
 All of the configurable options available in the UI are also exposed as command line arguments to `msiexec`:
 
 ```bat
-msiexec /i elasticsearch-5.1.1.msi /qn /l elastic-install.log NODENAME=my_node_name CLUSTERNAME=my_cluster_name
+start /wait msiexec.exe /i elasticsearch-5.5.0.msi /qn /l elastic-install.log NODENAME=my_node_name CLUSTERNAME=my_cluster_name
 ```
 
 ### Command-line options
 
 | Parameter name                   | Description                      | Default value                    |
 | -------------------------------- | -------------------------------- | -------------------------------- |
-| INSTALLDIR                       | Elasticsearch installation path  | C:\Program Files\Elastic\Elasticsearch |
-| DATADIRECTORY                    | Data directory path              | C:\ProgramData\Elastic\Elasticsearch\data |
-| CONFIGDIRECTORY                  | Config directory path            | C:\ProgramData\Elastic\Elasticsearch\config |
-| LOGSDIRECTORY                    | Logs directory path              | C:\ProgramData\Elastic\Elasticsearch\logs |
+| INSTALLDIR                       | Elasticsearch installation path  | `%ProgramW6432%`\Elastic\Elasticsearch |
+| DATADIRECTORY                    | Data directory path              | `%ALLUSERSPROFILE%`\Elastic\Elasticsearch\data |
+| CONFIGDIRECTORY                  | Config directory path            | `%ALLUSERSPROFILE%`\Elastic\Elasticsearch\config |
+| LOGSDIRECTORY                    | Logs directory path              | `%ALLUSERSPROFILE%`\Elastic\Elasticsearch\logs |
 | CLUSTERNAME                      | Cluster name                     | elasticsearch |
 | NODENAME                         | Node name                        | `%COMPUTERNAME%` |
 | UNICASTHOSTS                     | Comma-delimited list of unicast nodes ||
@@ -60,8 +66,8 @@ msiexec /i elasticsearch-5.1.1.msi /qn /l elastic-install.log NODENAME=my_node_n
 | DATANODE                         | Whether or not to make this a data node     | `true` |
 | INGESTNODE                       | Whether or not to make this an ingest node| | `true` |
 | NETWORKHOST                      | Hostname to bind to and advertise to other nodes | `true` |
-| SELECTEDMEMORY                   | Amount of memory to allocate to the JVM | 50% of available RAM capped at 32GB |
-| LOCKMEMORY                       | Whether or not to lock JVM memory           | `true` |
+| SELECTEDMEMORY                   | Amount of memory to allocate to the JVM | 2GB. If the target machine has less than 4GB RAM, then 50% RAM |
+| LOCKMEMORY                       | Whether or not to lock JVM memory           | `false` |
 | INSTALLASSERVICE                 | Install as a Windows service                | `true` |
 | STARTAFTERINSTALL                | Start the service after install is completed | `true` |
 | STARTWHENWINDOWSSTARTS           | Start the service when Windows starts (Automatic) | `true` |
@@ -70,7 +76,7 @@ msiexec /i elasticsearch-5.1.1.msi /qn /l elastic-install.log NODENAME=my_node_n
 | USEEXISTINGUSER                  | Run the service as the specified `USER` | `false` |
 | USER                             | Existing user to run the service as     ||
 | PASSWORD                         | Password for the existing user          ||
-| PLUGINS                          | Comma-delimited list of plugins to install | x-pack,ingest-attachment,ingest-geoip |
+| PLUGINS                          | Comma-delimited list of plugins to install | |
 
 ## Running as a service
 
@@ -97,7 +103,7 @@ In addition to installing and running Elasticsearch as a service, it can also be
 It also accepts the same command-line arguments as the original bat file.
 
 ```bat
-./elasticsearch.exe -Ecluster.name=my_cluster_name -Enode.name=my_node_name
+./elasticsearch.exe -E cluster.name=my_cluster_name -E node.name=my_node_name
 ```
 
 ## Reporting problems

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -330,6 +330,12 @@ Whether to skip unit tests.
                            products |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
                        | [IsTarget target] ->
                            All |> List.map (ProductVersions.CreateFromProduct lastFeedVersion)
+                       | [IsProductList products; IsVersionList versions] ->
+                           products |> List.map(ProductVersions.CreateFromProduct <| fun _ -> versions)
+                       | [IsVersionList versions] ->
+                           All |> List.map(ProductVersions.CreateFromProduct <| fun _ -> versions)
+                       | [IsProductList products] ->
+                           products |> List.map(ProductVersions.CreateFromProduct lastFeedVersion)
                        | [] ->
                            All |> List.map (ProductVersions.CreateFromProduct lastFeedVersion)
                        | ["help"]

--- a/build/scripts/config.yaml
+++ b/build/scripts/config.yaml
@@ -41,6 +41,10 @@ elasticsearch:
       guid: 8279eff6-3a85-4b37-ac5a-3c5136bb5465
     - version: 5.4.1
       guid: 127c0984-c0fe-4f6d-acf9-4c15101bd627
+    - version: 5.4.2
+      guid: 13ad87cd-18f3-481e-a278-545d873f7353
+    - version: 5.4.3
+      guid: 481906c0-70ca-4a4c-bb66-a6e25ed22b94
     - version: 5.5.0
       guid: 344f09a4-5bf8-4d44-8e86-2130c263b08f
 kibana:

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
@@ -21,7 +21,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Config
 		public const bool DefaultMasterNode = true;
 		public const bool DefaultDataNode = true;
 		public const bool DefaultIngestNode = true;
-		public const bool DefaultMemoryLock = true;
+		public const bool DefaultMemoryLock = false;
 		public static ulong DefaultTotalPhysicalMemory { get; } = GetTotalPhysicalMemory();
 		public const ulong DefaultHeapSizeThreshold = 4096;
 		public const ulong DefaultDistributionHeapSize = 2048;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
@@ -23,7 +23,11 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Config
 		public const bool DefaultIngestNode = true;
 		public const bool DefaultMemoryLock = true;
 		public static ulong DefaultTotalPhysicalMemory { get; } = GetTotalPhysicalMemory();
-		public static ulong DefaultHeapSize => DefaultTotalPhysicalMemory / 2;
+		public const ulong DefaultHeapSizeThreshold = 4096;
+		public const ulong DefaultDistributionHeapSize = 2048;
+		public static ulong DefaultHeapSize => DefaultTotalPhysicalMemory <= DefaultHeapSizeThreshold 
+			? DefaultTotalPhysicalMemory / 2 
+			: DefaultDistributionHeapSize;
 		public const ulong CompressedOrdinaryPointersThreshold = 30500;
 		public const int HttpPortMinimum = 80;
 		public const int TransportPortMinimum = 1024;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -75,7 +75,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			this.ConfigurationModel = new ConfigurationModel(yamlConfiguration, localJvmOptions);
 
 			var pluginDependencies = this.WhenAnyValue(
-				vm => vm.ConfigurationModel.IngestNode,
 				vm => vm.NoticeModel.AlreadyInstalled,
 				vm => vm.LocationsModel.InstallDir,
 				vm => vm.LocationsModel.ConfigDirectory

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -12,17 +12,14 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 {
 	public class PluginsModel : PluginsModelBase<PluginsModel, PluginsModelValidator>
 	{
-		private bool _includeSuggest;
-
-		public PluginsModel(IPluginStateProvider pluginStateProvider, IObservable<Tuple<bool, bool, string, string>> pluginDependencies)
+		public PluginsModel(IPluginStateProvider pluginStateProvider, IObservable<Tuple<bool, string, string>> pluginDependencies)
 			: base(pluginStateProvider)
 		{
 			pluginDependencies.Subscribe(t =>
 			{
-				this._includeSuggest = t.Item1;
-				this.AlreadyInstalled = t.Item2;
-				this.InstallDirectory = t.Item3;
-				this.ConfigDirectory = t.Item4;
+				this.AlreadyInstalled = t.Item1;
+				this.InstallDirectory = t.Item2;
+				this.ConfigDirectory = t.Item3;
 				this.Refresh();
 			});
 
@@ -208,14 +205,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				DisplayName = "Store SMB",
 				Description = TextResources.PluginsModel_StoreSmb
 			};
-		}
-		protected override List<string> DefaultPlugins()
-		{
-			var selectedPlugins = new List<string> { "x-pack" };
-			if (!this._includeSuggest) return selectedPlugins;
-			selectedPlugins.Add("ingest-attachment");
-			selectedPlugins.Add("ingest-geoip");
-			return selectedPlugins;
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/ProductGuids.cs
+++ b/src/Installer/Elastic.Installer.Domain/ProductGuids.cs
@@ -30,6 +30,8 @@ namespace Elastic.Installer.Domain
 			{ "5.3.2", new Guid("8bc18570-a189-4304-8c85-1f2d7db3d839") },
 			{ "5.4.0", new Guid("8279eff6-3a85-4b37-ac5a-3c5136bb5465") },
 			{ "5.4.1", new Guid("127c0984-c0fe-4f6d-acf9-4c15101bd627") },
+			{ "5.4.2", new Guid("13ad87cd-18f3-481e-a278-545d873f7353") },
+			{ "5.4.3", new Guid("481906c0-70ca-4a4c-bb66-a6e25ed22b94") },
 			{ "5.5.0", new Guid("344f09a4-5bf8-4d44-8e86-2130c263b08f") }
 		};
 

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -334,7 +334,7 @@ in this cluster are empty. To migrate this data back into the downgraded cluster
     <value>The Store SMB plugin works around for a bug in Windows SMB and Java on Windows.</value>
   </data>
   <data name="PluginsModel_XPack" xml:space="preserve">
-    <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. A 30 day fully featured trial license is provided upon first installation.</value>
+    <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation.</value>
   </data>
   <data name="PluginType_ApiExtensions" xml:space="preserve">
     <value>API Extensions</value>

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -615,7 +615,7 @@
     <Property Id="MASTERNODE" Value="true" />
     <Property Id="DATANODE" Value="true" />
     <Property Id="INGESTNODE" Value="true" />
-    <Property Id="LOCKMEMORY" Value="true" />
+    <Property Id="LOCKMEMORY" Value="false" />
     <Property Id="HTTPPORT" Value="9200" />
     <Property Id="TRANSPORTPORT" Value="9300" />
     <Property Id="PLUGINS" />

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -618,7 +618,7 @@
     <Property Id="LOCKMEMORY" Value="true" />
     <Property Id="HTTPPORT" Value="9200" />
     <Property Id="TRANSPORTPORT" Value="9300" />
-    <Property Id="PLUGINS" Value="x-pack, ingest-attachment, ingest-geoip" />
+    <Property Id="PLUGINS" />
     <Property Id="ARPHELPLINK" Value="https://discuss.elastic.co/c/elasticsearch" />
     <Property Id="ARPPRODUCTICON" Value="app_icon.ico" />
     <Property Id="ARPURLINFOABOUT" Value="https://www.elastic.co/products/elasticsearch" />

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
-  <Product Id="127c0984-c0fe-4f6d-acf9-4c15101bd627" Name="Elasticsearch 5.4.1" Language="1033" Codepage="Windows-1252" Version="5.4.1" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="481906c0-70ca-4a4c-bb66-a6e25ed22b94" Name="Elasticsearch 5.4.3" Language="1033" Codepage="Windows-1252" Version="5.4.3" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_5.4.1_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_5.4.3_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -13,39 +13,39 @@
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
               <RemoveFile Id="LICENSE.txt" Name="LICENSE.txt" On="both" />
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-5.4.1\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-5.4.3\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
               <RemoveFile Id="NOTICE.txt" Name="NOTICE.txt" On="both" />
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-5.4.1\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-5.4.3\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
               <RemoveFile Id="README.textile" Name="README.textile" On="both" />
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-5.4.1\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-5.4.3\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
 
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
                 <RemoveFile Id="elasticsearch_keystore.bat" Name="elasticsearch_keystore.bat" On="both" />
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-5.4.1\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-5.4.3\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
                 <RemoveFile Id="elasticsearch_plugin.bat" Name="elasticsearch_plugin.bat" On="both" />
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-5.4.1\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-5.4.3\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
                 <RemoveFile Id="elasticsearch_translog.bat" Name="elasticsearch_translog.bat" On="both" />
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-5.4.1\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-5.4.3\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
                 <RemoveFile Id="elasticsearch.exe" Name="elasticsearch.exe" On="both" />
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-5.4.1\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-5.4.3\bin\elasticsearch.exe" />
               </Component>
 
             </Directory>
@@ -54,191 +54,191 @@
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
                 <RemoveFile Id="elasticsearch.yml" Name="elasticsearch.yml" On="both" />
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-5.4.1\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-5.4.3\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
                 <RemoveFile Id="jvm.options" Name="jvm.options" On="both" />
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-5.4.1\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-5.4.3\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
                 <RemoveFile Id="log4j2.properties" Name="log4j2.properties" On="both" />
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-5.4.1\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-5.4.3\config\log4j2.properties" />
               </Component>
 
             </Directory>
 
             <Directory Id="INSTALLDIR.lib" Name="lib">
 
-              <Component Id="Component.elasticsearch_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783bf44646" Win64="yes">
-                <RemoveFile Id="elasticsearch_5.4.1.jar" Name="elasticsearch_5.4.1.jar" On="both" />
-                <File Id="elasticsearch_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\elasticsearch-5.4.1.jar" />
+              <Component Id="Component.elasticsearch_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783bf44580" Win64="yes">
+                <RemoveFile Id="elasticsearch_5.4.3.jar" Name="elasticsearch_5.4.3.jar" On="both" />
+                <File Id="elasticsearch_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\elasticsearch-5.4.3.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
                 <RemoveFile Id="HdrHistogram_2.1.9.jar" Name="HdrHistogram_2.1.9.jar" On="both" />
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
                 <RemoveFile Id="hppc_0.7.1.jar" Name="hppc_0.7.1.jar" On="both" />
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
                 <RemoveFile Id="jackson_core_2.8.6.jar" Name="jackson_core_2.8.6.jar" On="both" />
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
                 <RemoveFile Id="_...kson_dataformat_cbor_2.8.6.jar" Name="_...kson_dataformat_cbor_2.8.6.jar" On="both" />
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
                 <RemoveFile Id="_...son_dataformat_smile_2.8.6.jar" Name="_...son_dataformat_smile_2.8.6.jar" On="both" />
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
                 <RemoveFile Id="_...kson_dataformat_yaml_2.8.6.jar" Name="_...kson_dataformat_yaml_2.8.6.jar" On="both" />
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component.java_version_checker_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783d96c2cd" Win64="yes">
-                <RemoveFile Id="java_version_checker_5.4.1.jar" Name="java_version_checker_5.4.1.jar" On="both" />
-                <File Id="java_version_checker_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\java-version-checker-5.4.1.jar" />
+              <Component Id="Component.java_version_checker_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c8a0c2cd" Win64="yes">
+                <RemoveFile Id="java_version_checker_5.4.3.jar" Name="java_version_checker_5.4.3.jar" On="both" />
+                <File Id="java_version_checker_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\java-version-checker-5.4.3.jar" />
               </Component>
 
               <Component Id="Component.jna_4.4.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa115652" Win64="yes">
                 <RemoveFile Id="jna_4.4.0.jar" Name="jna_4.4.0.jar" On="both" />
-                <File Id="jna_4.4.0.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jna-4.4.0.jar" />
+                <File Id="jna_4.4.0.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jna-4.4.0.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
                 <RemoveFile Id="joda_time_2.9.5.jar" Name="joda_time_2.9.5.jar" On="both" />
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
                 <RemoveFile Id="jopt_simple_5.0.2.jar" Name="jopt_simple_5.0.2.jar" On="both" />
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
                 <RemoveFile Id="jts_1.13.jar" Name="jts_1.13.jar" On="both" />
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\jts-1.13.jar" />
               </Component>
 
               <Component Id="Component.log4j_1.2_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd896f3f" Win64="yes">
                 <RemoveFile Id="log4j_1.2_api_2.8.2.jar" Name="log4j_1.2_api_2.8.2.jar" On="both" />
-                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\log4j-1.2-api-2.8.2.jar" />
+                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\log4j-1.2-api-2.8.2.jar" />
               </Component>
 
               <Component Id="Component.log4j_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830b6218a" Win64="yes">
                 <RemoveFile Id="log4j_api_2.8.2.jar" Name="log4j_api_2.8.2.jar" On="both" />
-                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\log4j-api-2.8.2.jar" />
+                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\log4j-api-2.8.2.jar" />
               </Component>
 
               <Component Id="Component.log4j_core_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b3cb698" Win64="yes">
                 <RemoveFile Id="log4j_core_2.8.2.jar" Name="log4j_core_2.8.2.jar" On="both" />
-                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\log4j-core-2.8.2.jar" />
+                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\log4j-core-2.8.2.jar" />
               </Component>
 
               <Component Id="Component._...ene_analyzers_common_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478363d2dca" Win64="yes">
                 <RemoveFile Id="_...ene_analyzers_common_6.5.1.jar" Name="_...ene_analyzers_common_6.5.1.jar" On="both" />
-                <File Id="_...ene_analyzers_common_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-analyzers-common-6.5.1.jar" />
+                <File Id="_...ene_analyzers_common_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-analyzers-common-6.5.1.jar" />
               </Component>
 
               <Component Id="Component._...cene_backward_codecs_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780b037ac6" Win64="yes">
                 <RemoveFile Id="_...cene_backward_codecs_6.5.1.jar" Name="_...cene_backward_codecs_6.5.1.jar" On="both" />
-                <File Id="_...cene_backward_codecs_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-backward-codecs-6.5.1.jar" />
+                <File Id="_...cene_backward_codecs_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-backward-codecs-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_core_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f9874823" Win64="yes">
                 <RemoveFile Id="lucene_core_6.5.1.jar" Name="lucene_core_6.5.1.jar" On="both" />
-                <File Id="lucene_core_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-core-6.5.1.jar" />
+                <File Id="lucene_core_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-core-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_grouping_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547848b16eb8" Win64="yes">
                 <RemoveFile Id="lucene_grouping_6.5.1.jar" Name="lucene_grouping_6.5.1.jar" On="both" />
-                <File Id="lucene_grouping_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-grouping-6.5.1.jar" />
+                <File Id="lucene_grouping_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-grouping-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_highlighter_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547863280fdb" Win64="yes">
                 <RemoveFile Id="lucene_highlighter_6.5.1.jar" Name="lucene_highlighter_6.5.1.jar" On="both" />
-                <File Id="lucene_highlighter_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-highlighter-6.5.1.jar" />
+                <File Id="lucene_highlighter_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-highlighter-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_join_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784ef8141c" Win64="yes">
                 <RemoveFile Id="lucene_join_6.5.1.jar" Name="lucene_join_6.5.1.jar" On="both" />
-                <File Id="lucene_join_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-join-6.5.1.jar" />
+                <File Id="lucene_join_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-join-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_memory_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547816daa6a3" Win64="yes">
                 <RemoveFile Id="lucene_memory_6.5.1.jar" Name="lucene_memory_6.5.1.jar" On="both" />
-                <File Id="lucene_memory_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-memory-6.5.1.jar" />
+                <File Id="lucene_memory_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-memory-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_misc_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b699e473" Win64="yes">
                 <RemoveFile Id="lucene_misc_6.5.1.jar" Name="lucene_misc_6.5.1.jar" On="both" />
-                <File Id="lucene_misc_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-misc-6.5.1.jar" />
+                <File Id="lucene_misc_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-misc-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_queries_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb94136d" Win64="yes">
                 <RemoveFile Id="lucene_queries_6.5.1.jar" Name="lucene_queries_6.5.1.jar" On="both" />
-                <File Id="lucene_queries_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-queries-6.5.1.jar" />
+                <File Id="lucene_queries_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-queries-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_queryparser_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783d7fe130" Win64="yes">
                 <RemoveFile Id="lucene_queryparser_6.5.1.jar" Name="lucene_queryparser_6.5.1.jar" On="both" />
-                <File Id="lucene_queryparser_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-queryparser-6.5.1.jar" />
+                <File Id="lucene_queryparser_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-queryparser-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_sandbox_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e1dca387" Win64="yes">
                 <RemoveFile Id="lucene_sandbox_6.5.1.jar" Name="lucene_sandbox_6.5.1.jar" On="both" />
-                <File Id="lucene_sandbox_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-sandbox-6.5.1.jar" />
+                <File Id="lucene_sandbox_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-sandbox-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_spatial_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d819eaf2" Win64="yes">
                 <RemoveFile Id="lucene_spatial_6.5.1.jar" Name="lucene_spatial_6.5.1.jar" On="both" />
-                <File Id="lucene_spatial_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-spatial-6.5.1.jar" />
+                <File Id="lucene_spatial_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-spatial-6.5.1.jar" />
               </Component>
 
               <Component Id="Component._...ucene_spatial_extras_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547801331172" Win64="yes">
                 <RemoveFile Id="_...ucene_spatial_extras_6.5.1.jar" Name="_...ucene_spatial_extras_6.5.1.jar" On="both" />
-                <File Id="_...ucene_spatial_extras_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-spatial-extras-6.5.1.jar" />
+                <File Id="_...ucene_spatial_extras_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-spatial-extras-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_spatial3d_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780d831cc7" Win64="yes">
                 <RemoveFile Id="lucene_spatial3d_6.5.1.jar" Name="lucene_spatial3d_6.5.1.jar" On="both" />
-                <File Id="lucene_spatial3d_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-spatial3d-6.5.1.jar" />
+                <File Id="lucene_spatial3d_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-spatial3d-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.lucene_suggest_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783d9ec821" Win64="yes">
                 <RemoveFile Id="lucene_suggest_6.5.1.jar" Name="lucene_suggest_6.5.1.jar" On="both" />
-                <File Id="lucene_suggest_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\lucene-suggest-6.5.1.jar" />
+                <File Id="lucene_suggest_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\lucene-suggest-6.5.1.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
                 <RemoveFile Id="securesm_1.1.jar" Name="securesm_1.1.jar" On="both" />
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
                 <RemoveFile Id="snakeyaml_1.15.jar" Name="snakeyaml_1.15.jar" On="both" />
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
                 <RemoveFile Id="spatial4j_0.6.jar" Name="spatial4j_0.6.jar" On="both" />
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
                 <RemoveFile Id="t_digest_3.0.jar" Name="t_digest_3.0.jar" On="both" />
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -246,38 +246,38 @@
             <Directory Id="INSTALLDIR.modules" Name="modules">
               <Directory Id="INSTALLDIR.modules.aggs_matrix_stats" Name="aggs-matrix-stats">
 
-                <Component Id="Component.aggs_matrix_stats_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d1c03d3d" Win64="yes">
-                  <RemoveFile Id="aggs_matrix_stats_5.4.1.jar" Name="aggs_matrix_stats_5.4.1.jar" On="both" />
-                  <File Id="aggs_matrix_stats_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\aggs-matrix-stats\aggs-matrix-stats-5.4.1.jar" />
+                <Component Id="Component.aggs_matrix_stats_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d1c03de3" Win64="yes">
+                  <RemoveFile Id="aggs_matrix_stats_5.4.3.jar" Name="aggs_matrix_stats_5.4.3.jar" On="both" />
+                  <File Id="aggs_matrix_stats_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\aggs-matrix-stats\aggs-matrix-stats-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties" Name="plugin_descriptor.properties" On="both" />
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.ingest_common" Name="ingest-common">
 
-                <Component Id="Component.ingest_common_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478208b7c32" Win64="yes">
-                  <RemoveFile Id="ingest_common_5.4.1.jar" Name="ingest_common_5.4.1.jar" On="both" />
-                  <File Id="ingest_common_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\ingest-common\ingest-common-5.4.1.jar" />
+                <Component Id="Component.ingest_common_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478208b7bf0" Win64="yes">
+                  <RemoveFile Id="ingest_common_5.4.3.jar" Name="ingest_common_5.4.3.jar" On="both" />
+                  <File Id="ingest_common_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\ingest-common\ingest-common-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
                   <RemoveFile Id="jcodings_1.0.12.jar" Name="jcodings_1.0.12.jar" On="both" />
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
                   <RemoveFile Id="joni_2.1.6.jar" Name="joni_2.1.6.jar" On="both" />
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.1" Name="plugin_descriptor.properties.1" On="both" />
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\ingest-common\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\ingest-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -286,42 +286,42 @@
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
                   <RemoveFile Id="antlr4_runtime_4.5.1_1.jar" Name="antlr4_runtime_4.5.1_1.jar" On="both" />
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
                   <RemoveFile Id="asm_5.0.4.jar" Name="asm_5.0.4.jar" On="both" />
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
                   <RemoveFile Id="asm_commons_5.0.4.jar" Name="asm_commons_5.0.4.jar" On="both" />
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
                   <RemoveFile Id="asm_tree_5.0.4.jar" Name="asm_tree_5.0.4.jar" On="both" />
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component.lang_expression_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547858bd450c" Win64="yes">
-                  <RemoveFile Id="lang_expression_5.4.1.jar" Name="lang_expression_5.4.1.jar" On="both" />
-                  <File Id="lang_expression_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\lang-expression-5.4.1.jar" />
+                <Component Id="Component.lang_expression_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547869913516" Win64="yes">
+                  <RemoveFile Id="lang_expression_5.4.3.jar" Name="lang_expression_5.4.3.jar" On="both" />
+                  <File Id="lang_expression_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\lang-expression-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_expressions_6.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547829d926c8" Win64="yes">
                   <RemoveFile Id="lucene_expressions_6.5.1.jar" Name="lucene_expressions_6.5.1.jar" On="both" />
-                  <File Id="lucene_expressions_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\lucene-expressions-6.5.1.jar" />
+                  <File Id="lucene_expressions_6.5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\lucene-expressions-6.5.1.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.2" Name="plugin_descriptor.properties.2" On="both" />
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
                   <RemoveFile Id="plugin_security.policy" Name="plugin_security.policy" On="both" />
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-expression\plugin-security.policy" />
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-expression\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -330,22 +330,22 @@
 
                 <Component Id="Component.groovy_2.4.6_indy.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c4b086e8" Win64="yes">
                   <RemoveFile Id="groovy_2.4.6_indy.jar" Name="groovy_2.4.6_indy.jar" On="both" />
-                  <File Id="groovy_2.4.6_indy.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-groovy\groovy-2.4.6-indy.jar" />
+                  <File Id="groovy_2.4.6_indy.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-groovy\groovy-2.4.6-indy.jar" />
                 </Component>
 
-                <Component Id="Component.lang_groovy_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783d78a5c0" Win64="yes">
-                  <RemoveFile Id="lang_groovy_5.4.1.jar" Name="lang_groovy_5.4.1.jar" On="both" />
-                  <File Id="lang_groovy_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-groovy\lang-groovy-5.4.1.jar" />
+                <Component Id="Component.lang_groovy_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782da4b5b6" Win64="yes">
+                  <RemoveFile Id="lang_groovy_5.4.3.jar" Name="lang_groovy_5.4.3.jar" On="both" />
+                  <File Id="lang_groovy_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-groovy\lang-groovy-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.3" Name="plugin_descriptor.properties.3" On="both" />
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-groovy\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-groovy\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
                   <RemoveFile Id="plugin_security.policy.1" Name="plugin_security.policy.1" On="both" />
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-groovy\plugin-security.policy" />
+                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-groovy\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -354,22 +354,22 @@
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
                   <RemoveFile Id="compiler_0.9.3.jar" Name="compiler_0.9.3.jar" On="both" />
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f660c497" Win64="yes">
-                  <RemoveFile Id="lang_mustache_5.4.1.jar" Name="lang_mustache_5.4.1.jar" On="both" />
-                  <File Id="lang_mustache_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-mustache\lang-mustache-5.4.1.jar" />
+                <Component Id="Component.lang_mustache_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f660c55d" Win64="yes">
+                  <RemoveFile Id="lang_mustache_5.4.3.jar" Name="lang_mustache_5.4.3.jar" On="both" />
+                  <File Id="lang_mustache_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-mustache\lang-mustache-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.4" Name="plugin_descriptor.properties.4" On="both" />
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-mustache\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-mustache\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
                   <RemoveFile Id="plugin_security.policy.2" Name="plugin_security.policy.2" On="both" />
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-mustache\plugin-security.policy" />
+                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-mustache\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -378,41 +378,41 @@
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
                   <RemoveFile Id="antlr4_runtime_4.5.1_1.jar.1" Name="antlr4_runtime_4.5.1_1.jar.1" On="both" />
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
                   <RemoveFile Id="asm_debug_all_5.1.jar" Name="asm_debug_all_5.1.jar" On="both" />
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f210c081" Win64="yes">
-                  <RemoveFile Id="lang_painless_5.4.1.jar" Name="lang_painless_5.4.1.jar" On="both" />
-                  <File Id="lang_painless_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-painless\lang-painless-5.4.1.jar" />
+                <Component Id="Component.lang_painless_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f210bfc3" Win64="yes">
+                  <RemoveFile Id="lang_painless_5.4.3.jar" Name="lang_painless_5.4.3.jar" On="both" />
+                  <File Id="lang_painless_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-painless\lang-painless-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.5" Name="plugin_descriptor.properties.5" On="both" />
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-painless\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-painless\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
                   <RemoveFile Id="plugin_security.policy.3" Name="plugin_security.policy.3" On="both" />
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\lang-painless\plugin-security.policy" />
+                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\lang-painless\plugin-security.policy" />
                 </Component>
 
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.percolator" Name="percolator">
 
-                <Component Id="Component.percolator_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d5a9ddf2" Win64="yes">
-                  <RemoveFile Id="percolator_5.4.1.jar" Name="percolator_5.4.1.jar" On="both" />
-                  <File Id="percolator_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\percolator\percolator-5.4.1.jar" />
+                <Component Id="Component.percolator_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d5ebddf2" Win64="yes">
+                  <RemoveFile Id="percolator_5.4.3.jar" Name="percolator_5.4.3.jar" On="both" />
+                  <File Id="percolator_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\percolator\percolator-5.4.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.6" Name="plugin_descriptor.properties.6" On="both" />
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\percolator\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\percolator\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -421,47 +421,47 @@
 
                 <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
                   <RemoveFile Id="commons_codec_1.10.jar" Name="commons_codec_1.10.jar" On="both" />
-                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\commons-codec-1.10.jar" />
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\commons-codec-1.10.jar" />
                 </Component>
 
                 <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
                   <RemoveFile Id="commons_logging_1.1.3.jar" Name="commons_logging_1.1.3.jar" On="both" />
-                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\commons-logging-1.1.3.jar" />
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\commons-logging-1.1.3.jar" />
                 </Component>
 
                 <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
                   <RemoveFile Id="httpasyncclient_4.1.2.jar" Name="httpasyncclient_4.1.2.jar" On="both" />
-                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\httpasyncclient-4.1.2.jar" />
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\httpasyncclient-4.1.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
                   <RemoveFile Id="httpclient_4.5.2.jar" Name="httpclient_4.5.2.jar" On="both" />
-                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\httpclient-4.5.2.jar" />
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\httpclient-4.5.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
                   <RemoveFile Id="httpcore_4.4.5.jar" Name="httpcore_4.4.5.jar" On="both" />
-                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\httpcore-4.4.5.jar" />
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\httpcore-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
                   <RemoveFile Id="httpcore_nio_4.4.5.jar" Name="httpcore_nio_4.4.5.jar" On="both" />
-                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\httpcore-nio-4.4.5.jar" />
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.7" Name="plugin_descriptor.properties.7" On="both" />
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.reindex_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785eaa762d" Win64="yes">
-                  <RemoveFile Id="reindex_5.4.1.jar" Name="reindex_5.4.1.jar" On="both" />
-                  <File Id="reindex_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\reindex-5.4.1.jar" />
+                <Component Id="Component.reindex_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547884ba0b0f" Win64="yes">
+                  <RemoveFile Id="reindex_5.4.3.jar" Name="reindex_5.4.3.jar" On="both" />
+                  <File Id="reindex_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\reindex-5.4.3.jar" />
                 </Component>
 
-                <Component Id="Component.rest_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547858933a5b" Win64="yes">
-                  <RemoveFile Id="rest_5.4.1.jar" Name="rest_5.4.1.jar" On="both" />
-                  <File Id="rest_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\reindex\rest-5.4.1.jar" />
+                <Component Id="Component.rest_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb113a5b" Win64="yes">
+                  <RemoveFile Id="rest_5.4.3.jar" Name="rest_5.4.3.jar" On="both" />
+                  <File Id="rest_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\reindex\rest-5.4.3.jar" />
                 </Component>
 
               </Directory>
@@ -470,22 +470,22 @@
 
                 <Component Id="Component.netty_3.10.6.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786aa11ed2" Win64="yes">
                   <RemoveFile Id="netty_3.10.6.Final.jar" Name="netty_3.10.6.Final.jar" On="both" />
-                  <File Id="netty_3.10.6.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty3\netty-3.10.6.Final.jar" />
+                  <File Id="netty_3.10.6.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty3\netty-3.10.6.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.8" Name="plugin_descriptor.properties.8" On="both" />
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty3\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty3\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
                   <RemoveFile Id="plugin_security.policy.4" Name="plugin_security.policy.4" On="both" />
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty3\plugin-security.policy" />
+                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty3\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty3_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785dc31d4e" Win64="yes">
-                  <RemoveFile Id="transport_netty3_5.4.1.jar" Name="transport_netty3_5.4.1.jar" On="both" />
-                  <File Id="transport_netty3_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty3\transport-netty3-5.4.1.jar" />
+                <Component Id="Component.transport_netty3_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785e451d4e" Win64="yes">
+                  <RemoveFile Id="transport_netty3_5.4.3.jar" Name="transport_netty3_5.4.3.jar" On="both" />
+                  <File Id="transport_netty3_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty3\transport-netty3-5.4.3.jar" />
                 </Component>
 
               </Directory>
@@ -494,52 +494,52 @@
 
                 <Component Id="Component.netty_buffer_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881351e3b" Win64="yes">
                   <RemoveFile Id="netty_buffer_4.1.11.Final.jar" Name="netty_buffer_4.1.11.Final.jar" On="both" />
-                  <File Id="netty_buffer_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-buffer-4.1.11.Final.jar" />
+                  <File Id="netty_buffer_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-buffer-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_codec_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547885592eca" Win64="yes">
                   <RemoveFile Id="netty_codec_4.1.11.Final.jar" Name="netty_codec_4.1.11.Final.jar" On="both" />
-                  <File Id="netty_codec_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-codec-4.1.11.Final.jar" />
+                  <File Id="netty_codec_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-codec-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...ty_codec_http_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d644a9fe" Win64="yes">
                   <RemoveFile Id="_...ty_codec_http_4.1.11.Final.jar" Name="_...ty_codec_http_4.1.11.Final.jar" On="both" />
-                  <File Id="_...ty_codec_http_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-codec-http-4.1.11.Final.jar" />
+                  <File Id="_...ty_codec_http_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-codec-http-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_common_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7fe90e" Win64="yes">
                   <RemoveFile Id="netty_common_4.1.11.Final.jar" Name="netty_common_4.1.11.Final.jar" On="both" />
-                  <File Id="netty_common_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-common-4.1.11.Final.jar" />
+                  <File Id="netty_common_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-common-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_handler_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780908ab4a" Win64="yes">
                   <RemoveFile Id="netty_handler_4.1.11.Final.jar" Name="netty_handler_4.1.11.Final.jar" On="both" />
-                  <File Id="netty_handler_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-handler-4.1.11.Final.jar" />
+                  <File Id="netty_handler_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-handler-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...etty_resolver_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785ae2d95f" Win64="yes">
                   <RemoveFile Id="_...etty_resolver_4.1.11.Final.jar" Name="_...etty_resolver_4.1.11.Final.jar" On="both" />
-                  <File Id="_...etty_resolver_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-resolver-4.1.11.Final.jar" />
+                  <File Id="_...etty_resolver_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-resolver-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...tty_transport_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b258d01b" Win64="yes">
                   <RemoveFile Id="_...tty_transport_4.1.11.Final.jar" Name="_...tty_transport_4.1.11.Final.jar" On="both" />
-                  <File Id="_...tty_transport_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\netty-transport-4.1.11.Final.jar" />
+                  <File Id="_...tty_transport_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\netty-transport-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.9" Name="plugin_descriptor.properties.9" On="both" />
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
                   <RemoveFile Id="plugin_security.policy.5" Name="plugin_security.policy.5" On="both" />
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\plugin-security.policy" />
+                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty4_5.4.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786ee21d4e" Win64="yes">
-                  <RemoveFile Id="transport_netty4_5.4.1.jar" Name="transport_netty4_5.4.1.jar" On="both" />
-                  <File Id="transport_netty4_5.4.1.jar" Source="..\..\..\build\in\elasticsearch-5.4.1\modules\transport-netty4\transport-netty4-5.4.1.jar" />
+                <Component Id="Component.transport_netty4_5.4.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786f641d4e" Win64="yes">
+                  <RemoveFile Id="transport_netty4_5.4.3.jar" Name="transport_netty4_5.4.3.jar" On="both" />
+                  <File Id="transport_netty4_5.4.3.jar" Source="..\..\..\build\in\elasticsearch-5.4.3\modules\transport-netty4\transport-netty4-5.4.3.jar" />
                 </Component>
 
               </Directory>
@@ -556,8 +556,8 @@
     </UI>
 
     <Upgrade Id="daaa2cba-a1ed-4f29-afbf-5478617b00f6">
-      <UpgradeVersion Minimum="0.0.0.0" Maximum="5.4.1" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
-      <UpgradeVersion Minimum="5.4.1" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
+      <UpgradeVersion Minimum="0.0.0.0" Maximum="5.4.3" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
+      <UpgradeVersion Minimum="5.4.3" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
     </Upgrade>
 
     <Icon Id="app_icon.ico" SourceFile="Resources\elasticsearch.ico" />
@@ -602,7 +602,7 @@
     <Binary Id="ElasticsearchValidateArgumentsAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="5.4.1" />
+    <Property Id="CurrentVersion" Value="5.4.3" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -634,14 +634,14 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_5.4.1.jar" />
+      <ComponentRef Id="Component.elasticsearch_5.4.3.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component.java_version_checker_5.4.1.jar" />
+      <ComponentRef Id="Component.java_version_checker_5.4.3.jar" />
       <ComponentRef Id="Component.jna_4.4.0.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
@@ -668,9 +668,9 @@
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component.aggs_matrix_stats_5.4.1.jar" />
+      <ComponentRef Id="Component.aggs_matrix_stats_5.4.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.ingest_common_5.4.1.jar" />
+      <ComponentRef Id="Component.ingest_common_5.4.3.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.1" />
@@ -678,24 +678,24 @@
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component.lang_expression_5.4.1.jar" />
+      <ComponentRef Id="Component.lang_expression_5.4.3.jar" />
       <ComponentRef Id="Component.lucene_expressions_6.5.1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.2" />
       <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.groovy_2.4.6_indy.jar" />
-      <ComponentRef Id="Component.lang_groovy_5.4.1.jar" />
+      <ComponentRef Id="Component.lang_groovy_5.4.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.3" />
       <ComponentRef Id="Component.plugin_security.policy.1" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_5.4.1.jar" />
+      <ComponentRef Id="Component.lang_mustache_5.4.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.4" />
       <ComponentRef Id="Component.plugin_security.policy.2" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_5.4.1.jar" />
+      <ComponentRef Id="Component.lang_painless_5.4.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.5" />
       <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.percolator_5.4.1.jar" />
+      <ComponentRef Id="Component.percolator_5.4.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.6" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
@@ -704,12 +704,12 @@
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.7" />
-      <ComponentRef Id="Component.reindex_5.4.1.jar" />
-      <ComponentRef Id="Component.rest_5.4.1.jar" />
+      <ComponentRef Id="Component.reindex_5.4.3.jar" />
+      <ComponentRef Id="Component.rest_5.4.3.jar" />
       <ComponentRef Id="Component.netty_3.10.6.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.8" />
       <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.transport_netty3_5.4.1.jar" />
+      <ComponentRef Id="Component.transport_netty3_5.4.3.jar" />
       <ComponentRef Id="Component.netty_buffer_4.1.11.Final.jar" />
       <ComponentRef Id="Component.netty_codec_4.1.11.Final.jar" />
       <ComponentRef Id="Component._...ty_codec_http_4.1.11.Final.jar" />
@@ -719,7 +719,7 @@
       <ComponentRef Id="Component._...tty_transport_4.1.11.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.9" />
       <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component.transport_netty4_5.4.1.jar" />
+      <ComponentRef Id="Component.transport_netty4_5.4.3.jar" />
     </Feature>
 
     <InstallExecuteSequence>

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -405,13 +405,13 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
 
 [b]Node name[/b]: The unique name given to this particular Elasticsearch node.
 
-[b]Node role[/b]: The type of role(s) this node should have.  If no roles are assigned, then it will act as a client node any only route requests to other nodes in your cluster.
+[b]Node role[/b]: The type of role(s) this node should have.  If no roles are assigned, then it will act as a client node, and only route requests to other nodes in your cluster.
 
 [b]Memory[/b]: The amount of memory to allocate to the JVM heap for Elasticsearch.  The standard rule of thumb is to allocate 50% of available memory to the heap, but never exceed 30.5 GB, leaving the remaining 50% free to ensure there is enough for kernel file system caches.  The 30.5 GB limit is recommended in order to prevent the JVM from entering 64-bit address space, which will result in a performance degradation.
 
-[b]Lock memory[/b]: Windows will try to use as much memory as possible for file system caches and eagerly swap out unused application memory, possibly resulting in the Elasticsearch process being swapped, which is very bad for performance and node stability. By choosing to lock memory, Elasticsearch will leverage the native VirtualLock function in Windows, in effort to keep the JVM in physical memory at all times.
+[b]Lock memory[/b]: Windows will try to use as much memory as possible for file system caches and eagerly swap out unused application memory, possibly resulting in the Elasticsearch process being swapped, which is very bad for performance and node stability. By choosing to lock memory, Elasticsearch will leverage the native VirtualLock function in Windows, in an effort to keep the JVM in physical memory at all times.
 
-[b]Network host[/b]: By default, Elasticsearch binds to loopback addresses only (e.g. [b]127.0.0.1[/b]).  This is sufficient to run a single development node on a server.  However, in order to communicate to form a cluster on other servers, your node will need to bind to a non-loopback address.
+[b]Network host[/b]: By default, Elasticsearch binds to loopback addresses only (e.g. [b]127.0.0.1[/b]).  This is sufficient to run a single development node on a server. However, in order to communicate to form a cluster on other servers, your node will need to bind to a non-loopback address.
 
 [b]HTTP port[/b]: The port to communicate with Elasticsearch REST API over HTTP.
 

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,23 +6,23 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","2b7e0b")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","61ebc1")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
-[assembly: AssemblyVersionAttribute("5.4.1")]
-[assembly: AssemblyFileVersionAttribute("5.4.1")]
+[assembly: AssemblyVersionAttribute("5.4.3")]
+[assembly: AssemblyFileVersionAttribute("5.4.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "2b7e0b";
+        internal const System.String AssemblyMetadata_GitBuildHash = "61ebc1";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
-        internal const System.String AssemblyVersion = "5.4.1";
-        internal const System.String AssemblyFileVersion = "5.4.1";
+        internal const System.String AssemblyVersion = "5.4.3";
+        internal const System.String AssemblyFileVersion = "5.4.3";
     }
 }

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","61ebc1")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","3c5f41")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "61ebc1";
+        internal const System.String AssemblyMetadata_GitBuildHash = "3c5f41";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","3c5f41")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","764ecb")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "3c5f41";
+        internal const System.String AssemblyMetadata_GitBuildHash = "764ecb";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/JavaConfigurationTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/JavaConfigurationTests.cs
@@ -45,7 +45,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration
 			.JavaHomeUserVariable(_userVariable)
 		);
 
-		[Fact] void UserBeathsMachine() => AssertJavaHome(_userVariable, m => m
+		[Fact] void UserBeatsMachine() => AssertJavaHome(_userVariable, m => m
 			.JavaHomeUserVariable(_userVariable)
 			.JavaHomeMachineVariable(_machineVariable)
 		);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/RolesArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/RolesArgumentsTests.cs
@@ -19,13 +19,13 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 		[Fact] void IngestNodeFalse() => Argument(nameof(ConfigurationModel.IngestNode), false, (m, v) =>
 		{
 			m.ConfigurationModel.IngestNode.Should().BeFalse();
-			m.PluginsModel.Plugins.Should().HaveCount(1).And.Contain("x-pack");
+			m.PluginsModel.Plugins.Should().BeEmpty();
 		});
 
 		[Fact] void IngestNodeTrue() => Argument(nameof(ConfigurationModel.IngestNode), true, (m, v) =>
 		{
 			m.ConfigurationModel.IngestNode.Should().BeTrue();
-			m.PluginsModel.Plugins.Count().Should().BeGreaterThan(1);
+			m.PluginsModel.Plugins.Should().BeEmpty();
 		});
 
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -16,26 +16,15 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 				.IsValidOnStep(m => m.PluginsModel);
 		}
 
-		[Fact] void XPackSelectedByDefault() => this._model
+		[Fact] void XPackNotSelectedByDefault() => this._model
 			.OnStep(m => m.PluginsModel, step => 
 			{
-				step.AvailablePlugins.Should().Contain(a=>a.Url == "x-pack" && a.Selected);
+				step.AvailablePlugins.Should().NotContain(a => a.Url == "x-pack" && a.Selected);
 			})
 			.CanClickNext();
 
 
-		[Fact] void IngestPluginsAreSelectedAndReactiveToIngestNode() => this._model
-			.OnStep(m => m.PluginsModel, step =>
-			{
-				step.AvailablePlugins.Should().Contain(a => a.Url == "ingest-attachment" && a.Selected);
-				step.AvailablePlugins.Should().Contain(a => a.Url == "ingest-geoip" && a.Selected);
-			})
-			.ClickBack()
-			.OnStep(m => m.ConfigurationModel, step =>
-			{
-				step.IngestNode = false;
-			})
-			.ClickNext()
+		[Fact] void IngestPluginsNotSelectedByDefault() => this._model
 			.OnStep(m => m.PluginsModel, step =>
 			{
 				step.AvailablePlugins.Should().NotContain(a => a.Url == "ingest-attachment" && a.Selected);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/InstallPluginsTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/InstallPluginsTaskTests.cs
@@ -13,8 +13,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks
 				(m, s, fs) => new InstallPluginsTask(m, s, fs),
 				(m, t) =>
 				{
-					var installedPlugins = t.PluginState.InstalledAfter;
-					installedPlugins.Should().NotBeEmpty().And.Contain("x-pack").And.HaveCount(3);
+					t.PluginState.InstalledAfter.Should().BeEmpty();
 				}
 			);
 		}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -83,7 +83,7 @@ function Context-PluginsInstalled($Expected) {
 
     $Expected = Merge-Hashtables @{
         EsPluginBat = $DefaultPluginBat
-        Plugins = @("ingest-attachment", "ingest-geoip", "x-pack")
+        Plugins = @()
     } $Expected
 
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -286,7 +286,14 @@ function Context-ElasticsearchConfiguration ([HashTable]$Expected) {
 
 function Context-JvmOptions ($Expected) {
     if (!($Expected)) {
-        $Expected = (Get-TotalPhysicalMemory) / 2
+    	$totalPhysicalMemory = Get-TotalPhysicalMemory
+    	
+    	if ($totalPhysicalMemory -le 4096) {
+    		$Expected = $totalPhysicalMemory / 2
+    	}
+    	else {
+    		$Expected = 2048
+    	}
     }
 
     Context "JVM Configuration" {

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -237,7 +237,7 @@ function Context-ElasticsearchConfiguration ([HashTable]$Expected) {
     $EsLogs = Split-Path $EsConfig -Parent | Join-Path -ChildPath "logs"
 
     $Expected = Merge-Hashtables @{
-            BootstrapMemoryLock = $true
+            BootstrapMemoryLock = $false
             NodeData = $true
             NodeIngest = $true
             NodeMaster = $true

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Default/SilentInstall-Default.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Default/SilentInstall-Default.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Silent Install with default arguments" {
 
     Context-ElasticsearchService
 
-    Context-PingNode -XPackSecurityInstalled $true
+    Context-PingNode -XPackSecurityInstalled $false
 
     $ProgramFiles = Get-ProgramFilesFolder
     $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
@@ -31,7 +31,7 @@ Describe "Silent Install with default arguments" {
 
     Context-EmptyEventLog
 
-	Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:changeme" }
+	Context-ClusterNameAndNodeName
 
     Context-ElasticsearchConfiguration
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-DifferentLocations/SilentInstall-DifferentLocations.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-DifferentLocations/SilentInstall-DifferentLocations.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Silent Install with different install locations" {
 
     Context-ElasticsearchService
 
-    Context-PingNode -XPackSecurityInstalled $true
+    Context-PingNode -XPackSecurityInstalled $false
 
     Context-EsHomeEnvironmentVariable -Expected $InstallDir
 
@@ -32,7 +32,7 @@ Describe "Silent Install with different install locations" {
 
     Context-EmptyEventLog
   
-    Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:changeme" }
+    Context-ClusterNameAndNodeName
 
     Context-ElasticsearchConfiguration -Expected @{Data = $DataDir; Logs = $LogsDir }
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
@@ -5,18 +5,18 @@ Set-Location $currentDir
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
 
-Describe "Silent Install with 1024mb heap size" {
-    $HeapSize = 1024
+Describe "Silent Install with x-pack, ingest-geoip and ingest-attachment plugins" {
 
-    Invoke-SilentInstall @(,"SELECTEDMEMORY=$HeapSize")
+    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment")
 
-    Context-PingNode -XPackSecurityInstalled $false
-    Context-JvmOptions -Expected 1024
+    Context-PingNode -XPackSecurityInstalled $true
 
-    Invoke-SilentUninstall
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack","ingest-geoip","ingest-attachment") }
+
+    Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:changeme" }
 }
 
-Describe "Silent Uninstall with 1024mb heap size" {
+Describe "Silent Uninstall with x-pack, ingest-geoip and ingest-attachment plugins" {
 
     Invoke-SilentUninstall
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Upgrade/SilentInstall-Upgrade.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Upgrade/SilentInstall-Upgrade.Tests.ps1
@@ -5,12 +5,13 @@ Set-Location $currentDir
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
 
+$credentials = "elastic:changeme"
+
 Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous version" {
 
 	$previousVersion = $env:PreviousEsVersion
-	$credentials = "elastic:changeme"
-
-    Invoke-SilentInstall -Version $previousVersion
+	
+    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment") -Version $previousVersion
 
     Context-ElasticsearchService
 
@@ -26,7 +27,7 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous versi
 
     Context-EsConfigEnvironmentVariable -Expected $ExpectedConfigFolder
 
-    Context-PluginsInstalled
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack","ingest-geoip","ingest-attachment") }
 
     Context-MsiRegistered -Expected @{
 		Name = "Elasticsearch $previousVersion"
@@ -51,7 +52,6 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous versi
 Describe -Tag 'PreviousVersion' "Silent Install upgrade -Upgrade to new version" {
 
 	$version = $env:EsVersion
-	$credentials = "elastic:changeme"
 
     Invoke-SilentInstall -Version $version
 
@@ -69,7 +69,7 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade -Upgrade to new version"
 
     Context-EsConfigEnvironmentVariable -Expected $ExpectedConfigFolder
 
-    Context-PluginsInstalled
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack","ingest-geoip","ingest-attachment") }
 
     Context-MsiRegistered
 
@@ -77,7 +77,7 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade -Upgrade to new version"
 
     Context-EmptyEventLog
 
-	Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:changeme" }
+	Context-ClusterNameAndNodeName -Expected @{ Credentials = $credentials }
 
     Context-ElasticsearchConfiguration
 


### PR DESCRIPTION
Change

- Set JVM Heap size to 2GB. If the target machine has less than or equal to 4GB of total memory, default to half of RAM.
- Do not install any plugins by default
- Do not set `bootstrap.memory_lock` by default