### PR TITLE
Remove x-pack credentials from open Elasticsearch link

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
@@ -66,6 +66,6 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 			return sb.ToString();
 		}
 
-		protected virtual List<string> DefaultPlugins() => new List<string>();
+		public virtual List<string> DefaultPlugins() => new List<string>();
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Closing/ClosingModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Closing/ClosingModel.cs
@@ -9,15 +9,17 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Closing
 	public class ClosingModel : ClosingModelBase<ClosingModel, ClosingModelValidator>
 	{
 		public ClosingModel(
-			SemVersion currentVersion,
-			bool isUpgrade,
-			IObservable<string> hostName,
-			IObservable<string> wixLogFile,
-			IObservable<string> elasticsearchLog,
-			IObservable<bool> installXPack,
+			SemVersion currentVersion, 
+			bool isUpgrade, 
+			bool defaultInstallXPack, 
+			IObservable<string> hostName, 
+			IObservable<string> wixLogFile, 
+			IObservable<string> elasticsearchLog, 
+			IObservable<bool> installXPack, 
 			IServiceStateProvider serviceStateProvider) 
 			: base(currentVersion, isUpgrade, hostName, wixLogFile, elasticsearchLog, installXPack, serviceStateProvider)
 		{
+			this.DefaultInstallXPack = defaultInstallXPack;
 			this.OpenFindYourClient = ReactiveCommand.Create();
 			this.Refresh();
 		}
@@ -25,5 +27,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Closing
 		public sealed override void Refresh() { }
 
 		public ReactiveCommand<object> OpenFindYourClient { get; }
+
+		public bool DefaultInstallXPack { get; }
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -86,11 +86,13 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				(h, p) => $"http://{(string.IsNullOrWhiteSpace(h) ? "localhost" : h)}:{p}");
 			var observeInstallationLog = this.WhenAnyValue(vm => vm.MsiLogFileLocation);
 			var observeElasticsearchLog = this.WhenAnyValue(vm => vm.LocationsModel.ElasticsearchLog);
+
+			var installXPack = this.PluginsModel.DefaultPlugins().Contains("x-pack");
 			var observeInstallXPack = this.PluginsModel.AvailablePlugins.ItemChanged
 				.Where(x => x.PropertyName == nameof(Plugin.Selected) && x.Sender.PluginType == PluginType.XPack)
 				.Select(x => x.Sender.Selected);
 
-			this.ClosingModel = new ClosingModel(wixStateProvider.CurrentVersion, isUpgrade, observeHost, observeInstallationLog,
+			this.ClosingModel = new ClosingModel(wixStateProvider.CurrentVersion, isUpgrade, installXPack, observeHost, observeInstallationLog,
 				observeElasticsearchLog, observeInstallXPack, serviceStateProvider);
 			this.AllSteps = new ReactiveList<IStep>
 			{

--- a/src/Installer/Elastic.Installer.Domain/Model/Kibana/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Kibana/Plugins/PluginsModel.cs
@@ -31,6 +31,6 @@ namespace Elastic.Installer.Domain.Model.Kibana.Plugins
 			};
 		}
 
-		protected override List<string> DefaultPlugins() => new List<string> { "x-pack" };
+		public override List<string> DefaultPlugins() => new List<string> { "x-pack" };
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Kibana/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Kibana/Plugins/PluginsModel.cs
@@ -30,7 +30,5 @@ namespace Elastic.Installer.Domain.Model.Kibana.Plugins
 				Description = TextResources.PluginsModel_XPack,
 			};
 		}
-
-		public override List<string> DefaultPlugins() => new List<string> { "x-pack" };
 	}
 }

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ClosingView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ClosingView.xaml.cs
@@ -43,7 +43,11 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 
 			var majorMinor = $"{this.ViewModel.CurrentVersion.Major}.{this.ViewModel.CurrentVersion.Minor}";
 			this.OpenReference.Content = string.Format(ViewResources.ClosingView_ReadTheReference, majorMinor);
-		
+
+			this.OpenElasticsearch.Content = this.ViewModel.DefaultInstallXPack
+				? ViewResources.ClosingView_ElasticsearchRunningAtHeaderWithCredentials
+				: ViewResources.ClosingView_ElasticsearchRunningAtHeader;
+
 			this.ViewModel.InstallXPack.Subscribe(x =>
 			{
 				this.OpenElasticsearch.Content = x

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","d33303")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","44ab5e")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "d33303";
+        internal const System.String AssemblyMetadata_GitBuildHash = "44ab5e";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";


### PR DESCRIPTION
Only include credentials in the open Elasticsearch in the browser link when X-Pack is installed.

Closes #63