### PR TITLE
Allow passing version with the FAKE target

### DIFF
--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -34,7 +34,8 @@ let productDescriptions = productsToBuild
                           |> List.concat
                           |> String.concat Environment.NewLine
 
-traceHeader (sprintf "Products:%s%s%s" Environment.NewLine Environment.NewLine productDescriptions)
+if (getBuildParam "target" |> toLower <> "help") then 
+    traceHeader (sprintf "Products:%s%s%s" Environment.NewLine Environment.NewLine productDescriptions)
 
 Target "Clean" (fun _ ->
     CleanDirs [MsiBuildDir; OutDir; ResultsDir]
@@ -134,6 +135,8 @@ Target "Integrate" (fun () ->
               |> Async.AwaitIAsyncResult
               |> Async.Ignore
     Async.RunSynchronously async)
+
+Target "Help" (fun () -> trace Commandline.usage)
 
 "Clean"
   ==> "PatchGuids"


### PR DESCRIPTION
The CommandLine parser always assumed that the first argument is the target. Now check if it's a valid target or default to buildinstallers. This supports passing only version as an argument
Move usage to being a FAKE target - a change in FAKE has meant that the exit from the CommandLine parser is no longer honoured by FAKE.