### PR TITLE
Successfully upgrade when plugins are installed

### DIFF
--- a/src/Installer/Elastic.Installer.Msi/CustomActions/CommitCustomAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/CustomActions/CommitCustomAction.cs
@@ -1,0 +1,15 @@
+﻿using WixSharp;
+
+namespace Elastic.Installer.Msi.CustomActions
+{
+	public abstract class CommitCustomAction<TProduct> : CustomAction<TProduct>
+		where TProduct : Product, new()
+	{
+		public override Execute Execute => Execute.commit;
+		public override Condition Condition => null;
+		public override Return Return => Return.ignore;
+		public override Sequence Sequence => Sequence.InstallExecuteSequence;
+		public override When When => When.Before;
+		public override Step Step => Step.InstallFinalize;
+	}
+}

--- a/src/Installer/Elastic.Installer.Msi/CustomActions/CustomAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/CustomActions/CustomAction.cs
@@ -51,7 +51,7 @@ namespace Elastic.Installer.Msi.CustomActions
 				Sequence = this.Sequence,
 				Execute = this.Execute,
 				Impersonate = !this.NeedsElevatedPrivileges,
-				UsesProperties = string.Join(",", this.AllArguments.Concat(new string[] { "UILevel", "INSTALLDIRECTORY.bin", "VERSION", "REMOVE" }))
+				UsesProperties = string.Join(",", this.AllArguments.Concat(new[] { "UILevel", "INSTALLDIRECTORY.bin", "VERSION", "REMOVE", "ProductName" }))
 			};
 		}
 	}

--- a/src/Installer/Elastic.Installer.Msi/Elastic.Installer.Msi.csproj
+++ b/src/Installer/Elastic.Installer.Msi/Elastic.Installer.Msi.csproj
@@ -44,13 +44,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomActions\CommitCustomAction.cs" />
     <Compile Include="CustomActions\CustomAction.cs" />
+    <Compile Include="Elasticsearch\CustomActions\Commit\ElasticsearchCleanupAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\ElasticsearchCustomActionOrder.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchConfigurationAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchDirectoriesAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchEnvironmentAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchJvmOptionsAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchPluginsAction.cs" />
+    <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchPreserveInstallAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchServiceInstallAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchServiceStartAction.cs" />
     <Compile Include="CustomActions\RollbackCustomAction.cs" />

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Commit/ElasticsearchCleanupAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Commit/ElasticsearchCleanupAction.cs
@@ -1,0 +1,20 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Msi.CustomActions;
+using Elastic.Installer.Msi.Elasticsearch.CustomActions.Install;
+using Elastic.InstallerHosts;
+using Elastic.InstallerHosts.Elasticsearch.Tasks;
+using Microsoft.Deployment.WindowsInstaller;
+using WixSharp;
+
+namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Commit
+{
+	public class ElasticsearchCleanupAction : CommitCustomAction<Elasticsearch>
+	{
+		public override string Name => nameof(ElasticsearchCleanupAction);
+		public override int Order => (int)ElasticsearchCustomActionOrder.CleanupInstall;
+
+		[CustomAction]
+		public static ActionResult ElasticsearchCleanupInstall(Session session) =>
+			session.Handle(() => new CleanupInstallTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
+	}
+}

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Commit/ElasticsearchCleanupAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Commit/ElasticsearchCleanupAction.cs
@@ -14,7 +14,7 @@ namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Commit
 		public override int Order => (int)ElasticsearchCustomActionOrder.CleanupInstall;
 
 		[CustomAction]
-		public static ActionResult ElasticsearchCleanupInstall(Session session) =>
+		public static ActionResult ElasticsearchCleanup(Session session) =>
 			session.Handle(() => new CleanupInstallTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
 	}
 }

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/ElasticsearchCustomActionOrder.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/ElasticsearchCustomActionOrder.cs
@@ -7,6 +7,7 @@
 
 		// Deferred actions
 		SetPreconditions = 2,
+		InstallPreserveInstall = 3,
 		InstallStopServiceAction = 3,
 		InstallEnvironment = 4,
 		InstallDirectories = 5,
@@ -15,8 +16,6 @@
 		InstallPlugins = 8,
 		InstallService = 9,
 		InstallStartService = 10,
-
-
 
 		// Rollback actions are played in reverse order
 		RollbackEnvironment = 1,
@@ -28,6 +27,9 @@
 		UninstallService = 1,
 		UninstallPlugins = 2,
 		UninstallDirectories = 3,
-		UninstallEnvironment = 4
+		UninstallEnvironment = 4,
+
+		// Commit actons
+		CleanupInstall = 1,
 	}
 }

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchPreserveInstallAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchPreserveInstallAction.cs
@@ -1,0 +1,25 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Msi.CustomActions;
+using Elastic.InstallerHosts;
+using Elastic.InstallerHosts.Elasticsearch.Tasks;
+using Microsoft.Deployment.WindowsInstaller;
+using WixSharp;
+
+namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
+{
+	public class ElasticsearchPreserveInstallAction : CustomAction<Elasticsearch>
+	{
+		public override string Name => nameof(ElasticsearchPreserveInstallAction);
+		public override int Order => (int)ElasticsearchCustomActionOrder.InstallStopServiceAction;
+		public override Condition Condition => Condition.NOT_BeingRemoved;
+		public override Return Return => Return.check;
+		public override Sequence Sequence => Sequence.InstallExecuteSequence;
+		public override When When => When.After;
+		public override Step Step => Step.StopServices;
+		public override Execute Execute => Execute.deferred;
+
+		[CustomAction]
+		public static ActionResult ElasticsearchPreserveInstall(Session session) =>
+			session.Handle(() => new PreserveInstallTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
+	}
+}

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchServiceInstallAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchServiceInstallAction.cs
@@ -11,7 +11,7 @@ namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
 	{
 		public override string Name => nameof(ElasticsearchServiceInstallAction);
 		public override int Order => (int)ElasticsearchCustomActionOrder.InstallService;
-		public override Condition Condition => Condition.NOT_Installed;
+		public override Condition Condition => new Condition("(NOT Installed) AND INSTALLASSERVICE=\"true\"");
 		public override Return Return => Return.check;
 		public override Sequence Sequence => Sequence.InstallExecuteSequence;
 		public override When When => When.After;

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Rollback/ElasticsearchRollbackInstallServiceAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Rollback/ElasticsearchRollbackInstallServiceAction.cs
@@ -16,7 +16,7 @@ namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Rollback
 		public override Step Step => new Step(nameof(ElasticsearchServiceInstallAction));
 
 		[CustomAction]
-		public static ActionResult ElasticsearchRollbackService(Session session) =>
+		public static ActionResult ElasticsearchRollbackInstallService(Session session) =>
 			session.Handle(() => new UninstallServiceTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
 	}
 }

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -11,6 +11,10 @@
         <Directory Id="Elastic" Name="Elastic">
           <Directory Id="INSTALLDIR" Name="Elasticsearch">
 
+            <Component Id="Component.INSTALLDIR" Guid="daaa2cba-a1ed-4f29-afbf-5478671bebaa" Win64="yes">
+              <RemoveFile Id="INSTALLDIR" Name="*" On="both" />
+            </Component>
+
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
               <RemoveFile Id="LICENSE.txt" Name="LICENSE.txt" On="both" />
               <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\LICENSE.txt" />
@@ -27,6 +31,10 @@
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
+
+              <Component Id="Component.INSTALLDIR.bin" Guid="daaa2cba-a1ed-4f29-afbf-5478df768362" Win64="yes">
+                <RemoveFile Id="INSTALLDIR.bin" Name="*" On="both" />
+              </Component>
 
               <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
                 <RemoveFile Id="elasticsearch_env.bat" Name="elasticsearch-env.bat" On="both" />
@@ -59,6 +67,10 @@
 
             <Directory Id="INSTALLDIR.config" Name="config">
 
+              <Component Id="Component.INSTALLDIR.config" Guid="daaa2cba-a1ed-4f29-afbf-5478ab6080b0" Win64="yes">
+                <RemoveFile Id="INSTALLDIR.config" Name="*" On="both" />
+              </Component>
+
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
                 <RemoveFile Id="elasticsearch.yml" Name="elasticsearch.yml" On="both" />
                 <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\config\elasticsearch.yml" />
@@ -77,6 +89,10 @@
             </Directory>
 
             <Directory Id="INSTALLDIR.lib" Name="lib">
+
+              <Component Id="Component.INSTALLDIR.lib" Guid="daaa2cba-a1ed-4f29-afbf-547828bdf4cc" Win64="yes">
+                <RemoveFile Id="INSTALLDIR.lib" Name="*" On="both" />
+              </Component>
 
               <Component Id="Component.elasticsearch_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780af1fbea" Win64="yes">
                 <RemoveFile Id="elasticsearch_6.0.0_beta1.jar" Name="elasticsearch-6.0.0-beta1.jar" On="both" />
@@ -258,6 +274,10 @@
             <Directory Id="INSTALLDIR.modules" Name="modules">
               <Directory Id="INSTALLDIR.modules.aggs_matrix_stats" Name="aggs-matrix-stats">
 
+                <Component Id="Component.INSTALLDIR.modules.aggs_matrix_stats" Guid="daaa2cba-a1ed-4f29-afbf-5478eade9085" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.aggs_matrix_stats" Name="*" On="both" />
+                </Component>
+
                 <Component Id="Component._...s_matrix_stats_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785df02122" Win64="yes">
                   <RemoveFile Id="_...s_matrix_stats_6.0.0_beta1.jar" Name="aggs-matrix-stats-6.0.0-beta1.jar" On="both" />
                   <File Id="_...s_matrix_stats_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-beta1.jar" />
@@ -272,6 +292,10 @@
 
               <Directory Id="INSTALLDIR.modules.analysis_common" Name="analysis-common">
 
+                <Component Id="Component.INSTALLDIR.modules.analysis_common" Guid="daaa2cba-a1ed-4f29-afbf-5478e676d55e" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.analysis_common" Name="*" On="both" />
+                </Component>
+
                 <Component Id="Component._...nalysis_common_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478739e4d14" Win64="yes">
                   <RemoveFile Id="_...nalysis_common_6.0.0_beta1.jar" Name="analysis-common-6.0.0-beta1.jar" On="both" />
                   <File Id="_...nalysis_common_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\analysis-common\analysis-common-6.0.0-beta1.jar" />
@@ -285,6 +309,10 @@
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.ingest_common" Name="ingest-common">
+
+                <Component Id="Component.INSTALLDIR.modules.ingest_common" Guid="daaa2cba-a1ed-4f29-afbf-54787e7f0b5f" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.ingest_common" Name="*" On="both" />
+                </Component>
 
                 <Component Id="Component.ingest_common_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780774bf6d" Win64="yes">
                   <RemoveFile Id="ingest_common_6.0.0_beta1.jar" Name="ingest-common-6.0.0-beta1.jar" On="both" />
@@ -309,6 +337,10 @@
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.lang_expression" Name="lang-expression">
+
+                <Component Id="Component.INSTALLDIR.modules.lang_expression" Guid="daaa2cba-a1ed-4f29-afbf-547819d8cae4" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.lang_expression" Name="*" On="both" />
+                </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
                   <RemoveFile Id="antlr4_runtime_4.5.1_1.jar" Name="antlr4-runtime-4.5.1-1.jar" On="both" />
@@ -354,6 +386,10 @@
 
               <Directory Id="INSTALLDIR.modules.lang_mustache" Name="lang-mustache">
 
+                <Component Id="Component.INSTALLDIR.modules.lang_mustache" Guid="daaa2cba-a1ed-4f29-afbf-5478266128bd" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.lang_mustache" Name="*" On="both" />
+                </Component>
+
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
                   <RemoveFile Id="compiler_0.9.3.jar" Name="compiler-0.9.3.jar" On="both" />
                   <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-mustache\compiler-0.9.3.jar" />
@@ -377,6 +413,10 @@
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.lang_painless" Name="lang-painless">
+
+                <Component Id="Component.INSTALLDIR.modules.lang_painless" Guid="daaa2cba-a1ed-4f29-afbf-54786cd01ef8" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.lang_painless" Name="*" On="both" />
+                </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
                   <RemoveFile Id="antlr4_runtime_4.5.1_1.jar.1" Name="antlr4-runtime-4.5.1-1.jar" On="both" />
@@ -407,6 +447,10 @@
 
               <Directory Id="INSTALLDIR.modules.parent_join" Name="parent-join">
 
+                <Component Id="Component.INSTALLDIR.modules.parent_join" Guid="daaa2cba-a1ed-4f29-afbf-5478fb41d8fb" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.parent_join" Name="*" On="both" />
+                </Component>
+
                 <Component Id="Component.parent_join_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789363c240" Win64="yes">
                   <RemoveFile Id="parent_join_6.0.0_beta1.jar" Name="parent-join-6.0.0-beta1.jar" On="both" />
                   <File Id="parent_join_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\parent-join\parent-join-6.0.0-beta1.jar" />
@@ -421,6 +465,10 @@
 
               <Directory Id="INSTALLDIR.modules.percolator" Name="percolator">
 
+                <Component Id="Component.INSTALLDIR.modules.percolator" Guid="daaa2cba-a1ed-4f29-afbf-54780303c528" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.percolator" Name="*" On="both" />
+                </Component>
+
                 <Component Id="Component.percolator_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789a236dcb" Win64="yes">
                   <RemoveFile Id="percolator_6.0.0_beta1.jar" Name="percolator-6.0.0-beta1.jar" On="both" />
                   <File Id="percolator_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\percolator\percolator-6.0.0-beta1.jar" />
@@ -434,6 +482,10 @@
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.reindex" Name="reindex">
+
+                <Component Id="Component.INSTALLDIR.modules.reindex" Guid="daaa2cba-a1ed-4f29-afbf-54788078000c" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.reindex" Name="*" On="both" />
+                </Component>
 
                 <Component Id="Component._...ch_rest_client_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b2b14d61" Win64="yes">
                   <RemoveFile Id="_...ch_rest_client_6.0.0_beta1.jar" Name="elasticsearch-rest-client-6.0.0-beta1.jar" On="both" />
@@ -459,6 +511,10 @@
 
               <Directory Id="INSTALLDIR.modules.repository_url" Name="repository-url">
 
+                <Component Id="Component.INSTALLDIR.modules.repository_url" Guid="daaa2cba-a1ed-4f29-afbf-54784082cc52" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.repository_url" Name="*" On="both" />
+                </Component>
+
                 <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.9" Name="plugin-descriptor.properties" On="both" />
                   <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\repository-url\plugin-descriptor.properties" />
@@ -477,6 +533,10 @@
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.transport_netty4" Name="transport-netty4">
+
+                <Component Id="Component.INSTALLDIR.modules.transport_netty4" Guid="daaa2cba-a1ed-4f29-afbf-5478f1dfade6" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.transport_netty4" Name="*" On="both" />
+                </Component>
 
                 <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
                   <RemoveFile Id="netty_buffer_4.1.13.Final.jar" Name="netty-buffer-4.1.13.Final.jar" On="both" />
@@ -531,6 +591,10 @@
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.tribe" Name="tribe">
+
+                <Component Id="Component.INSTALLDIR.modules.tribe" Guid="daaa2cba-a1ed-4f29-afbf-547802b798a0" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.tribe" Name="*" On="both" />
+                </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.11" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae9" Win64="yes">
                   <RemoveFile Id="plugin_descriptor.properties.11" Name="plugin-descriptor.properties" On="both" />
@@ -718,6 +782,22 @@
       <ComponentRef Id="Component._...ansport_netty4_6.0.0_beta1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.11" />
       <ComponentRef Id="Component.tribe_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR" />
+      <ComponentRef Id="Component.INSTALLDIR.bin" />
+      <ComponentRef Id="Component.INSTALLDIR.config" />
+      <ComponentRef Id="Component.INSTALLDIR.lib" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.aggs_matrix_stats" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.analysis_common" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.ingest_common" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.lang_expression" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.lang_mustache" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.lang_painless" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.parent_join" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.percolator" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.reindex" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.repository_url" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.transport_netty4" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.tribe" />
     </Feature>
 
     <InstallExecuteSequence>
@@ -753,7 +833,7 @@
       <Custom Action="Set_ElasticsearchPluginsAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchPluginsAction" After="ElasticsearchJvmOptionsAction"> (NOT Installed) </Custom>
       <Custom Action="Set_ElasticsearchServiceInstallAction_Props" After="InstallInitialize" />
-      <Custom Action="ElasticsearchServiceInstallAction" After="ElasticsearchPluginsAction"> (NOT Installed) </Custom>
+      <Custom Action="ElasticsearchServiceInstallAction" After="ElasticsearchPluginsAction">(NOT Installed) AND INSTALLASSERVICE="true"</Custom>
       <Custom Action="Set_ElasticsearchServiceStartAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchServiceStartAction" After="ElasticsearchServiceInstallAction">(NOT Installed) AND INSTALLASSERVICE="true" AND STARTAFTERINSTALL="true"</Custom>
       <Custom Action="PreventDowngrading" After="FindRelatedProducts">NEWPRODUCTFOUND</Custom>

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elastic.InstallerHosts.csproj
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elastic.InstallerHosts.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Elasticsearch\Tasks\CleanupInstallTask.cs" />
     <Compile Include="Elasticsearch\Tasks\CreateDirectoriesTask.cs" />
     <Compile Include="Elasticsearch\Tasks\DeleteDirectoriesTask.cs" />
     <Compile Include="Elasticsearch\Tasks\EditElasticsearchYamlTask.cs" />
@@ -47,6 +48,7 @@
     <Compile Include="Elasticsearch\Tasks\ElasticsearchInstallationTask.cs" />
     <Compile Include="Elasticsearch\Tasks\InstallPluginsTask.cs" />
     <Compile Include="Elasticsearch\Tasks\InstallServiceTask.cs" />
+    <Compile Include="Elasticsearch\Tasks\PreserveInstallTask.cs" />
     <Compile Include="Elasticsearch\Tasks\RemoveEnvironmentVariablesTask.cs" />
     <Compile Include="Elasticsearch\Tasks\RemovePluginsTask.cs" />
     <Compile Include="Elasticsearch\Tasks\SetEnvironmentVariablesTask.cs" />

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/CleanupInstallTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/CleanupInstallTask.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Abstractions;
+﻿using System;
+using System.IO.Abstractions;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Elasticsearch;
 
@@ -14,7 +15,17 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 		protected override bool ExecuteTask()
 		{
 			if (this.FileSystem.Directory.Exists(this.TempDirectory))
-				this.FileSystem.Directory.Delete(this.TempDirectory, true);
+			{
+				try
+				{
+					this.FileSystem.Directory.Delete(this.TempDirectory, true);
+				}
+				catch (Exception e)
+				{
+					// log, but continue.
+					this.Session.Log($"Exception deleting {this.TempDirectory}: {e}");
+				}
+			}
 
 			return true;
 		}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/CleanupInstallTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/CleanupInstallTask.cs
@@ -1,0 +1,22 @@
+﻿using System.IO.Abstractions;
+using Elastic.Installer.Domain.Configuration.Wix.Session;
+using Elastic.Installer.Domain.Model.Elasticsearch;
+
+namespace Elastic.InstallerHosts.Elasticsearch.Tasks
+{
+	public class CleanupInstallTask : ElasticsearchInstallationTask
+	{
+		public CleanupInstallTask(string[] args, ISession session) : base(args, session) {}
+
+		public CleanupInstallTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
+			: base(model, session, fileSystem) {}
+
+		protected override bool ExecuteTask()
+		{
+			if (this.FileSystem.Directory.Exists(this.TempDirectory))
+				this.FileSystem.Directory.Delete(this.TempDirectory, true);
+
+			return true;
+		}
+	}
+}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/CreateDirectoriesTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/CreateDirectoriesTask.cs
@@ -2,6 +2,8 @@
 using System.IO.Abstractions;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Elasticsearch;
+using static System.Environment;
+using static System.Reflection.Assembly;
 
 namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 {
@@ -28,10 +30,13 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			return true;
 		}
 
+
+
 		private void CreatePluginsDirectory()
 		{
-			var installDirectory = this.InstallationModel.LocationsModel.InstallDir;
-			var pluginsDirectory = Path.Combine(installDirectory, "plugins");
+			var pluginsDirectoryName = "plugins";
+			var installDirectory = this.InstallationModel.LocationsModel.InstallDir;			
+			var pluginsDirectory = this.FileSystem.Path.Combine(installDirectory, pluginsDirectoryName);
 
 			if (!this.FileSystem.Directory.Exists(pluginsDirectory))
 			{
@@ -71,7 +76,8 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			//create new config directory if it does not already exist
 			var configDirectory = this.InstallationModel.LocationsModel.ConfigDirectory;
 			var installDirectory = this.InstallationModel.LocationsModel.InstallDir;
-			var installConfigDirectory = Path.Combine(installDirectory, "config");
+			var configDirectoryName = "config";
+			var installConfigDirectory = this.FileSystem.Path.Combine(installDirectory, configDirectoryName);
 
 			int actionsTaken = 0;
 			if (!this.FileSystem.Directory.Exists(configDirectory))
@@ -95,8 +101,8 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 
 				foreach (var file in this.FileSystem.Directory.EnumerateFiles(installConfigDirectory))
 				{
-					var fileName = Path.GetFileName(file);
-					var to = Path.Combine(configDirectory, fileName);
+					var fileName = this.FileSystem.Path.GetFileName(file);
+					var to = this.FileSystem.Path.Combine(configDirectory, fileName);
 					//do not overwrite existing files
 					if (this.FileSystem.File.Exists(to)) continue;
 
@@ -105,10 +111,10 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 				}
 				foreach (var dir in this.FileSystem.Directory.EnumerateDirectories(installConfigDirectory))
 				{
-					var dirName = Path.GetDirectoryName(dir);
-					var to = Path.Combine(configDirectory, dir);
+					var to = this.FileSystem.Path.Combine(configDirectory, dir);
 					//do not overwrite existing directories
 					if (this.FileSystem.Directory.Exists(to)) continue;
+
 					this.Session.Log($"moving directory: {dir} to {to}");
 					this.FileSystem.Directory.Move(dir, to);
 				}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/ElasticsearchInstallationTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/ElasticsearchInstallationTask.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO.Abstractions;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Elastic.Installer.Domain;
 using Elastic.Installer.Domain.Configuration.Wix;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
@@ -21,5 +23,11 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 		protected ElasticsearchInstallationTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem)
 			: base(model, session, fileSystem)
 		{ }
+
+		protected bool IsDirectoryEmpty(string path) =>
+			this.FileSystem.Directory.Exists(path) && !this.FileSystem.Directory.EnumerateFileSystemEntries(path).Any();
+
+		protected string TempDirectory =>
+			this.FileSystem.Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), this.Session.Get<string>("ProductName"));
 	}
 }

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/PreserveInstallTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/PreserveInstallTask.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO.Abstractions;
+using System.Reflection;
+using Elastic.Installer.Domain.Configuration.Wix.Session;
+using Elastic.Installer.Domain.Model.Elasticsearch;
+
+namespace Elastic.InstallerHosts.Elasticsearch.Tasks
+{
+	public class PreserveInstallTask : ElasticsearchInstallationTask
+	{
+		public PreserveInstallTask(string[] args, ISession session) : base(args, session) {}
+
+		public PreserveInstallTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
+			: base(model, session, fileSystem) {}
+
+		protected override bool ExecuteTask()
+		{
+			if (this.FileSystem.Directory.Exists(this.TempDirectory))
+				this.FileSystem.Directory.Delete(this.TempDirectory, true);
+
+			// move the current installed plugins, to restore in case of rollback.
+			// Current plugins could be removed and reinstalled in event of rollback,
+			// but that would mean redownloading again
+			MoveCurrentPlugins();
+
+			// copy the directory, to restore in case of rollback
+			CopyCurrentConfigDirectory();
+
+			return true;
+		}
+
+		private void CopyCurrentConfigDirectory()
+		{
+			var configDirectory = this.InstallationModel.LocationsModel.ConfigDirectory;
+			if (this.FileSystem.Directory.Exists(configDirectory))
+			{
+				var tempConfigDirectory = this.FileSystem.Path.Combine(this.TempDirectory, "config");
+				this.Session.Log($"Copying existing config directory from {configDirectory} to {tempConfigDirectory}");
+				this.CopyDirectory(configDirectory, tempConfigDirectory);
+			}
+		}
+
+		private void MoveCurrentPlugins()
+		{
+			var path = this.FileSystem.Path;
+			var pluginsDirectory = path.Combine(this.InstallationModel.LocationsModel.InstallDir, "plugins");
+			var tempPluginsDirectory = path.Combine(this.TempDirectory, "plugins");
+
+			if (this.FileSystem.Directory.Exists(pluginsDirectory))
+			{
+				this.Session.Log($"Moving existing plugin directory from {pluginsDirectory} to {tempPluginsDirectory}");
+				this.FileSystem.Directory.CreateDirectory(tempPluginsDirectory);
+				var source = this.FileSystem.DirectoryInfo.FromDirectoryName(pluginsDirectory);
+
+				foreach (var file in source.GetFiles())
+					file.MoveTo(path.Combine(tempPluginsDirectory, file.Name));
+				foreach (var dir in source.GetDirectories())
+					dir.MoveTo(path.Combine(tempPluginsDirectory, dir.Name));
+			}
+		}
+	}
+}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/RemovePluginsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/RemovePluginsTask.cs
@@ -34,7 +34,7 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			foreach (var plugin in plugins)
 			{
 				this.Session.SendProgress(ticksPerPlugin[0], $"removing {plugin}");
-				provider.Remove(ticksPerPlugin[1], installDirectory, configDirectory, plugin);
+				provider.Remove(ticksPerPlugin[1], installDirectory, configDirectory, plugin, "--purge");
 				this.Session.SendProgress(ticksPerPlugin[2], $"removed {plugin}");
 			}
 			return true;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StartServiceTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StartServiceTask.cs
@@ -23,12 +23,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 
 		protected override bool ExecuteTask()
 		{
-			if (this.InstallationModel.NoticeModel.ExistingVersionInstalled)
-			{
-				this.Session.Log($"Skipping {nameof(StartServiceTask)}. Existing version already installed, service will need to be manually started after installation");
-				return true;
-			}
-
 			this.Session.Log("Executing start service");
 			if (!this.InstallationModel.ServiceModel.StartAfterInstall)
 				return true;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StopServiceTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StopServiceTask.cs
@@ -23,14 +23,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 
 		protected override bool ExecuteTask()
 		{
-			if (this.InstallationModel.NoticeModel.ExistingVersionInstalled &&
-			    this.InstallationModel.NoticeModel.CurrentVersion < this.InstallationModel.NoticeModel.ExistingVersion && 
-				this.Session.IsUninstalling)
-			{
-				this.Session.Log($"Skipping {nameof(StopServiceTask)}: Newer version installed and uninstalling older version");
-				return true;
-			}
-
 			var seesService = this.ServiceStateProvider.SeesService;
 			this.Session.Log($"Trying to execute StopServiceTask seeing service: " + seesService);
 			if (!seesService) return true;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/UninstallServiceTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/UninstallServiceTask.cs
@@ -23,13 +23,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 
 		protected override bool ExecuteTask()
 		{
-			if (this.Session.IsRollback && this.InstallationModel.NoticeModel.ExistingVersionInstalled)
-			{
-				// handle rolling back to a version that uses the old config environment variable
-				this.Session.Log($"Skipping {nameof(UninstallServiceTask)}: Already installed and rolling back");
-				return true;
-			}
-
 			if (this.InstallationModel.NoticeModel.ExistingVersionInstalled && !this.Session.IsUninstalling)
 			{
 				this.Session.Log($"Skipping {nameof(UninstallServiceTask)}: Already installed and not currently uninstalling");

--- a/src/InstallerHosts/Elastic.InstallerHosts/Tasks/InstallationTaskBase.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Tasks/InstallationTaskBase.cs
@@ -56,6 +56,27 @@ namespace Elastic.InstallerHosts.Tasks
 			!string.IsNullOrEmpty(pathA) && 
 			!string.IsNullOrEmpty(pathB) && 
 			0 == string.Compare(Path.GetFullPath(pathA), Path.GetFullPath(pathB), true);
+
+		protected void CopyDirectory(string sourceDirectory, string destinationDirectory)
+		{
+			var source = new DirectoryInfo(sourceDirectory);
+			var destination = new DirectoryInfo(destinationDirectory);
+			CopyDirectory(source, destination);
+		}
+
+		protected void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
+		{
+			this.FileSystem.Directory.CreateDirectory(target.FullName);
+
+			foreach (var file in source.GetFiles())
+				file.CopyTo(Path.Combine(target.FullName, file.Name), true);
+
+			foreach (var directory in source.GetDirectories())
+			{
+				var nextTargetSubDir = target.CreateSubdirectory(directory.Name);
+				CopyDirectory(directory, nextTargetSubDir);
+			}
+		}
 	}
 
 

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","e14e31")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","acf4b1")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "e14e31";
+        internal const System.String AssemblyMetadata_GitBuildHash = "acf4b1";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","b21a2e")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","585a72")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -19,7 +19,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "b21a2e";
+        internal const System.String AssemblyMetadata_GitBuildHash = "585a72";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","acf4b1")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","12ff96")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "acf4b1";
+        internal const System.String AssemblyMetadata_GitBuildHash = "12ff96";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,23 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","585a72")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","e14e31")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
-[assembly: AssemblyVersionAttribute("6.0.0")]
-[assembly: AssemblyFileVersionAttribute("6.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("6.0.0-beta1")]
+[assembly: AssemblyVersionAttribute("5.5.2")]
+[assembly: AssemblyFileVersionAttribute("5.5.2")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "585a72";
+        internal const System.String AssemblyMetadata_GitBuildHash = "e14e31";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
-        internal const System.String AssemblyVersion = "6.0.0";
-        internal const System.String AssemblyFileVersion = "6.0.0";
-        internal const System.String AssemblyInformationalVersion = "6.0.0-beta1";
+        internal const System.String AssemblyVersion = "5.5.2";
+        internal const System.String AssemblyFileVersion = "5.5.2";
     }
 }

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Upgrade/SilentInstall-Upgrade.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Upgrade/SilentInstall-Upgrade.Tests.ps1
@@ -55,31 +55,6 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade - Upgrade to new version
 
     Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment") -Version $version
 
-	# BUG: Service is not started *after* upgrade, start manually for now
-	Context "Elasticsearch service" {	
-		$service = Get-ElasticsearchService
-
-		It "Service is not null" {
-            $Service | Should Not Be $null
-        }
-
-		if ($service.Status -ne "Running") {
-			$service.Start()
-			$service.Refresh()
-			$startTime = Get-Date
-			$timeout = New-TimeSpan -Seconds 30
-
-			while ($service.Status -ne "Running") {
-				if ($(Get-Date) - $startTime -gt $timeout) {
-					throw "Attempted to start the service in $timeout, but did not start"
-				}
-
-				Start-Sleep -m 250
-				$service.Refresh()
-			}
-		}
-	}
-
     Context-ElasticsearchService
 
     Context-PingNode -XPackSecurityInstalled $true


### PR DESCRIPTION
- Wildcard remove all files in MSI registered directories

  Using wildcard removal mitigates the issue where different versions of Elasticsearch depend on different versions of dependent jars.

- Only install as a Windows Service if not installed and `INSTALLASSERVICE=true`
- Windows Service can be started on successful upgrade
- Successfully update when plugins installed

  When performing an upgrade, Move the current plugins directory and config directory to `%TEMP%\<Product Name>` to restore in the event of rollback. Existing plugins could be uninstalled but the primary reason for moving as opposed to uninstalling is that the latter would mean re-installing plugins again in the event of rollback, meaning that they would need to be re-downloaded. Specific plugin configuration may also be lost.

  Ideally, the removal of plugin files and folders would be handled by the MSI, using the RemoveFile table. The table is limited however in that it needs to know ahead of time the directories from which files should be removed, and in addition, the remove operation is not recursive, making it tricky to use in a simple way for this purpose.

- Remove individual `RemoveFile` elements for each `File` element as files will be removed by wildcard `RemoveFile` elements applied at the Directory level
- Add `Component` to remove the bin/x-pack directory as part of install and uninstall. This must be removed for upgrading X-Pack plugin to succeed

Closes #91
Closes #92