### PR TITLE
Better progress messages

### DIFF
--- a/src/Installer/Elastic.Installer.Msi/Program.cs
+++ b/src/Installer/Elastic.Installer.Msi/Program.cs
@@ -254,6 +254,19 @@ namespace Elastic.Installer.Msi
 					)
 				);
 			}
+
+			// Update in-built progress templates 
+			// See http://web.mit.edu/ops/services/afs/openafs-1.4.1/src/src/WINNT/install/wix/lang/en_US/ActionText.wxi
+			var ui = document.Root.Descendants(ns + "UI").Single();
+			ui.Add(new XElement(ns + "ProgressText",
+				new XAttribute("Action", "InstallFiles"),
+				new XAttribute("Template", "Copying new files: [9][1]"),
+				new XText("Copying new files")
+			), new XElement(ns + "ProgressText",
+				new XAttribute("Action", "StopServices"),
+				new XAttribute("Template", $"Stopping {_productTitle} service"),
+				new XText($"Stopping {_productTitle} service") // TODO: default template doesn't receive service name. Might be because it's not installed with ServiceInstall table?
+			));
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -617,6 +617,9 @@
 
     <UI>
       <EmbeddedUI Id="Elastic.Installer.UI.dll" SourceFile="Elastic.Installer.UI.CA.dll" />
+
+      <ProgressText Action="InstallFiles" Template="Copying new files: [9][1]">Copying new files</ProgressText>
+      <ProgressText Action="StopServices" Template="Stopping Elasticsearch service">Stopping Elasticsearch service</ProgressText>
     </UI>
 
     <Upgrade Id="daaa2cba-a1ed-4f29-afbf-5478617b00f6">

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StartServiceTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StartServiceTask.cs
@@ -30,7 +30,7 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			this.Session.Log($"Trying to execute StartServiceTask seeing service: " + seesService);
 			if (!seesService) return true;
 			var totalTicks = 1000;
-			this.Session.SendActionStart(totalTicks, ActionName, "Starting Elasticsearch service");
+			this.Session.SendActionStart(totalTicks, ActionName, "Elasticsearch service", "Elasticsearch service: [1]");
 			this.ServiceStateProvider.StartAndWaitForRunning(TimeSpan.FromSeconds(60), 2000);
 			this.Session.SendProgress(1000, "Elasticsearch service started");
 			return true;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StopServiceTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/StopServiceTask.cs
@@ -27,9 +27,9 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			this.Session.Log($"Trying to execute StopServiceTask seeing service: " + seesService);
 			if (!seesService) return true;
 			var totalTicks = 1000;
-			this.Session.SendActionStart(totalTicks, ActionName, "Stopping existing Elasticsearch service");
+			this.Session.SendActionStart(totalTicks, ActionName, "Stopping existing Elasticsearch service", "Elasticsearch service: [1]");
 			this.ServiceStateProvider.StopIfRunning(TimeSpan.FromSeconds(60));
-			this.Session.SendProgress(1000, "Elasticsearch service stopped");
+			this.Session.SendProgress(1000, "stopped");
 			return true;
 		}
 	}

--- a/src/InstallerHosts/Elastic.InstallerHosts/SessionExtensions.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/SessionExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Elastic.Configuration.Extensions;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Microsoft.Deployment.WindowsInstaller;
+using ReactiveUI;
 
 namespace Elastic.InstallerHosts
 {
@@ -25,8 +26,7 @@ namespace Elastic.InstallerHosts
 				var arguments = new List<string>();
 				foreach (var p in allArguments)
 				{
-					string v;
-					if (session.TryGetValue(p, out v))
+					if (session.TryGetValue(p, out var v))
 						arguments.Add($"{p}={v}");
 				}
 				_cachedSetupArguments = arguments.ToArray();
@@ -93,14 +93,14 @@ namespace Elastic.InstallerHosts
 		/// <summary>
 		/// Send an action start message. This only works with deferred custom actions
 		/// </summary>
-		public static MessageResult SendActionStart(this Microsoft.Deployment.WindowsInstaller.Session session, int totalTicks, string actionName, string message, string actionDataTemplate = null)
+		public static MessageResult SendActionStart(this Session session, int totalTicks, string actionName, string message, string actionDataTemplate = null)
 		{
 			// http://www.indigorose.com/webhelp/msifact/Program_Reference/LuaScript/Actions/MSI.ProcessMessage.htm
 			// [1] action name (must match the name in the MSI Tables), 
 			// [2] description, 
 			// [3] template for InstallMessage.ActionData messages e.g. [1], [2], 
 			//     etc. relate to the index of values sent in a proceeding ActionData
-			using (var record = new Record(actionName, message, actionDataTemplate ?? message))
+			using (var record = new Record(actionName, message, actionDataTemplate ?? string.Empty))
 			{
 				session.Message(InstallMessage.ActionStart, record);
 			}
@@ -126,7 +126,7 @@ namespace Elastic.InstallerHosts
 		/// <summary>
 		/// Send a progress message. This only works with deferred custom actions
 		/// </summary>
-		public static MessageResult SendProgress(this Microsoft.Deployment.WindowsInstaller.Session session, int tickIncrement, params object[] actionDataTemplateParameters)
+		public static MessageResult SendProgress(this Session session, int tickIncrement, params object[] actionDataTemplateParameters)
 		{
 			if (actionDataTemplateParameters.Any())
 			{

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","03f5e6")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","b21a2e")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "03f5e6";
+        internal const System.String AssemblyMetadata_GitBuildHash = "b21a2e";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts/Kibana/Process/KibanaMessage.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Kibana/Process/KibanaMessage.cs
@@ -27,20 +27,20 @@ namespace Elastic.ProcessHosts.Kibana.Process
 			if (string.IsNullOrEmpty(consoleLine)) return;
 			throw new NotImplementedException("Parking this for now");
 
-			try
-			{
-//				//var message = JsonConvert.DeserializeObject<KibanaLogMessage>(consoleLine);
-//				Type = message.Type;
-//				Date = message.Timestamp;
-//				Tags = message.Tags;
-//				ProcessId = message.ProcessId;
-//				State = message.State;
-//				Message = message.Message;
-			}
-			catch (Exception)
-			{
-				throw new Exception($"Cannot deserialize ${consoleLine}");
-			}
+//			try
+//			{
+////				//var message = JsonConvert.DeserializeObject<KibanaLogMessage>(consoleLine);
+////				Type = message.Type;
+////				Date = message.Timestamp;
+////				Tags = message.Tags;
+////				ProcessId = message.ProcessId;
+////				State = message.State;
+////				Message = message.Message;
+//			}
+//			catch (Exception)
+//			{
+//				throw new Exception($"Cannot deserialize ${consoleLine}");
+//			}
 		}
 
 		public bool TryGetStartedConfirmation(out string host, out int? port)


### PR DESCRIPTION
- Do not show ActionStart progress messages that contain placeholders in them.
- Use the last ActionStart template received to format ActionData messages
- Update inbuilt ProgressText templates for StopServices and InstallFiles