### PR TITLE
Integration tests against releases and build candidates

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,4 +10,4 @@ IF EXIST paket.lock (
 	.paket\paket.exe install
 	IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 )
-"packages\build\FAKE\tools\Fake.exe" "build\\scripts\\Targets.fsx" "cmdline=%*"
+"packages\build\FAKE.x64\tools\FAKE.exe" "build\\scripts\\Targets.fsx" "cmdline=%*"

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -129,6 +129,12 @@ Whether to skip unit tests.
         let m = VersionRegex().Match version
         if m.Success |> not then failwithf "Could not parse version from %s" version
         let source = parseSource m.Source.Value
+
+        let rawValue =
+            match source with
+            | Compile -> m.Version.Value
+            | _ -> sprintf "%s:%s" m.Source.Value m.Version.Value
+
         { Product = m.Product.Value;
           FullVersion = m.Version.Value;
           Major = m.Major.Value |> int;
@@ -136,7 +142,7 @@ Whether to skip unit tests.
           Patch = m.Patch.Value |> int;
           Prerelease = m.Prerelease.Value; 
           Source = source;
-          RawValue = version; }
+          RawValue = rawValue; }
 
     let private lastFeedVersion (product : Product) =
         // TODO: disallow prereleases for moment. Make build parameter in future?

--- a/build/scripts/Products.fsx
+++ b/build/scripts/Products.fsx
@@ -2,11 +2,8 @@
 
 #r "FakeLib.dll"
 
-open System
 open System.Globalization
-open System.Text
 open System.IO
-open System.Text.RegularExpressions
 open Fake
 open Fake.FileHelper
 
@@ -82,7 +79,8 @@ module Products =
         Minor : int;
         Patch : int;
         Prerelease : string;
-        Source : Source
+        Source : Source;
+        RawValue: string;
     }
 
     type ProductVersions(product:Product, versions:Version list) =

--- a/build/scripts/Products.fsx
+++ b/build/scripts/Products.fsx
@@ -28,6 +28,10 @@ module Paths =
 
     let ArtifactDownloadsUrl = "https://artifacts.elastic.co/downloads"
 
+    let StagingDownloadsUrl product version hash = 
+        sprintf "https://staging.elastic.co/%s-%s/downloads/windows-installers/%s/%s-%s.msi" 
+            version hash product product version
+
 module Products =
     open Paths
 
@@ -60,6 +64,17 @@ module Products =
 
     let All = [Elasticsearch; Kibana]
 
+    type Source =
+        | Compile
+        | Released
+        | BuildCandidate of hash:string
+
+        member this.Description =
+            match this with
+            | Compile -> "compiled from source"
+            | Released -> "official release"
+            | BuildCandidate hash -> sprintf "build candidate %s" hash
+
     type Version = {
         Product : string;
         FullVersion : string;
@@ -67,6 +82,7 @@ module Products =
         Minor : int;
         Patch : int;
         Prerelease : string;
+        Source : Source
     }
 
     type ProductVersions(product:Product, versions:Version list) =
@@ -75,34 +91,30 @@ module Products =
         member this.Name = product.Name
         member this.Title = product.Title
 
-        member this.DownloadUrls =
-            this.Versions
-            |> List.map(fun v ->
+        member private this.DownloadUrl (version:Version) =
+            match version.Source with
+            | Compile ->
                 match product with
                 | Elasticsearch ->
-                    sprintf "%s/elasticsearch/elasticsearch-%s.zip" ArtifactDownloadsUrl v.FullVersion
+                    sprintf "%s/elasticsearch/elasticsearch-%s.zip" ArtifactDownloadsUrl version.FullVersion
                 | Kibana ->               
-                    sprintf "%s/kibana/kibana-%s-windows-x86.zip" ArtifactDownloadsUrl v.FullVersion                       
-            )
-        
-        member this.ZipFiles =
-            InDir |> CreateDir
-            let fullPathInDir = InDir |> Path.GetFullPath
-            this.Versions
-            |> List.map(fun v ->
-                Path.Combine(fullPathInDir, sprintf "%s-%s.zip" this.Name v.FullVersion)
-            )
+                    sprintf "%s/kibana/kibana-%s-windows-x86.zip" ArtifactDownloadsUrl version.FullVersion 
+            | Released ->
+                sprintf "%s/%s/%s-%s.msi" ArtifactDownloadsUrl this.Name this.Name version.FullVersion 
+            | BuildCandidate hash ->
+                StagingDownloadsUrl this.Name version.FullVersion hash
 
-        member this.ExtractedDirectories =
-            InDir |> CreateDir
+        member private this.ZipFile (version:Version) =
+            let fullPathInDir = InDir |> Path.GetFullPath
+            Path.Combine(fullPathInDir, sprintf "%s-%s.zip" this.Name version.FullVersion)
+
+        member private this.ExtractedDirectory (version:Version) =
             let fullPathInDir = InDir |> Path.GetFullPath            
-            this.Versions
-            |> List.map (fun v ->
-                Path.Combine(fullPathInDir, sprintf "%s-%s" this.Name v.FullVersion)
-            )
+            Path.Combine(fullPathInDir, sprintf "%s-%s" this.Name version.FullVersion)
 
         member this.BinDirs = 
             this.Versions
+            |> List.filter (fun v -> v.Source = Compile)
             |> List.map(fun v -> InDir @@ sprintf "%s-%s/bin/" this.Name v.FullVersion)
 
         member this.ServiceDir =
@@ -110,35 +122,47 @@ module Products =
 
         member this.ServiceBinDir = this.ServiceDir @@ "bin/AnyCPU/Release/"
 
-        member this.Unzip () =
-            List.zip3 this.ExtractedDirectories this.ZipFiles this.Versions
-            |> List.iter(fun (extractedDirectory, zipFile, version) ->
-                if directoryExists extractedDirectory |> not && fileExists zipFile
-                then
-                    tracefn "Unzipping %s %s" this.Name zipFile
-                    Unzip InDir zipFile
-                    match this.Product with
-                        | Kibana ->
-                            let original = sprintf "kibana-%s-windows-x86" version.FullVersion
-                            if directoryExists original |> not then
-                                Rename (InDir @@ (sprintf "kibana-%s" version.FullVersion)) (InDir @@ original)
-                        | _ -> ()
-                else tracefn "Extracted directory %s already exists" extractedDirectory                
-            )
+        member this.DownloadPath (version:Version) =
+            let fullPathInDir = InDir |> Path.GetFullPath 
+            let releaseFile version dir =
+                let downloadUrl = this.DownloadUrl version     
+                Path.Combine(fullPathInDir, dir, Path.GetFileName downloadUrl)
+            match version.Source with
+            | Compile ->  this.ZipFile version
+            | Released -> releaseFile version "releases"
+            | BuildCandidate hash -> releaseFile version hash
 
         member this.Download () =
-            let locations = List.zip this.DownloadUrls this.ZipFiles
-            locations
-            |> List.iter(fun location ->          
-                match location with
-                | (_, zip) when fileExists zip ->
-                    tracefn "Already downloaded %s to %s" this.Name zip
-                | (url, zip) ->
+            this.Versions
+            |> List.iter (fun version ->
+                match (this.DownloadUrl version, this.DownloadPath version) with
+                | (_, file) when fileExists file ->
+                    tracefn "Already downloaded %s to %s" this.Name file
+                | (url, file) ->
                     tracefn "Downloading %s from %s" this.Name url 
+                    let targetDirectory = file |> Path.GetDirectoryName
+                    if (directoryExists targetDirectory |> not) then CreateDir targetDirectory
                     use webClient = new System.Net.WebClient()
-                    location |> webClient.DownloadFile
-                    tracefn "Done downloading %s from %s to %s" this.Name url zip 
-            )  
+                    (url, file) |> webClient.DownloadFile
+                    tracefn "Done downloading %s from %s to %s" this.Name url file 
+
+                match version.Source with
+                | Compile -> 
+                    let extractedDirectory = this.ExtractedDirectory version
+                    let zipFile = this.DownloadPath version
+                    if directoryExists extractedDirectory |> not
+                    then
+                        tracefn "Unzipping %s %s" this.Name zipFile
+                        Unzip InDir zipFile
+                        match this.Product with
+                            | Kibana ->
+                                let original = sprintf "kibana-%s-windows-x86" version.FullVersion
+                                if directoryExists original |> not then
+                                    Rename (InDir @@ (sprintf "kibana-%s" version.FullVersion)) (InDir @@ original)
+                            | _ -> ()
+                    else tracefn "Extracted directory %s already exists" extractedDirectory   
+                | _ -> ()
+            )
 
         static member CreateFromProduct (productToVersion:Product -> Version list) (product: Product)  =
             ProductVersions(product, productToVersion product)

--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -97,7 +97,7 @@ Target "Release" (fun () ->
 Target "Integrate" (fun () ->
     // TODO: Get the version for each different project
     let versions = productsToBuild.Head.Versions 
-                  |> List.map(fun v -> v.FullVersion)
+                  |> List.map(fun v -> v.RawValue)
     
     // last version in the list is the _target_ version    
     let version = versions |> List.last                

--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -29,7 +29,8 @@ let productsToBuild = Commandline.parse()
 
 let productDescriptions = productsToBuild
                           |> List.map(fun p ->
-                                 p.Versions |> List.map(fun v -> sprintf "%s %s" p.Title v.FullVersion)
+                                 p.Versions 
+                                 |> List.map(fun v -> sprintf "%s %s (%s)" p.Title v.FullVersion v.Source.Description)
                              )
                           |> List.concat
                           |> String.concat Environment.NewLine
@@ -46,10 +47,6 @@ Target "Clean" (fun _ ->
 Target "DownloadProducts" (fun () ->
     productsToBuild
     |> List.iter (fun p -> p.Download())
-)
-
-Target "UnzipProducts" (fun () ->
-    productsToBuild |> List.iter (fun p -> p.Unzip())
 )
 
 Target "PatchGuids" (fun () ->
@@ -142,7 +139,6 @@ Target "Help" (fun () -> trace Commandline.usage)
 "Clean"
   ==> "PatchGuids"
   =?> ("DownloadProducts", (not ((getBuildParam "release") = "1")))
-  ==> "UnzipProducts"
   ==> "PruneFiles"
   =?> ("UnitTest", (not ((getBuildParam "skiptests") = "1")))
   ==> "BuildServices"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -39,7 +39,7 @@ group tests
 group build
     source https://www.nuget.org/api/v2
 
-    nuget FAKE
+	nuget FAKE.x64
     nuget FSharp.Data
 	nuget FSharp.Text.RegexProvider
     nuget FSharp.Configuration

--- a/paket.lock
+++ b/paket.lock
@@ -549,7 +549,7 @@ NUGET
 GROUP build
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.63)
+    FAKE.x64 (4.63.2)
     FSharp.Configuration (1.3)
       FSharp.Core (>= 4.0.0.1)
     FSharp.Core (4.2.3)

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="f234f31d-f25c-4e64-8d3e-868f7b7ece97" Name="Elasticsearch 6.0.0-beta1" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="1f75dce6-5c9e-43c4-ad23-72d94bfec22d" Name="Elasticsearch 5.5.3" Language="1033" Codepage="Windows-1252" Version="5.5.3" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_6.0.0_beta1_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_5.5.3_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -17,15 +17,15 @@
             </Component>
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-5.5.3\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-5.5.3\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-5.5.3\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -43,24 +43,20 @@
                 <RemoveFolder Id="INSTALLDIR.bin.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
-                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\bin\elasticsearch-env.bat" />
-              </Component>
-
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch.exe" />
 
                 <ServiceControl Id="elasticsearch.exe" Name="Elasticsearch" Stop="both" Wait="yes" />
               </Component>
@@ -75,15 +71,15 @@
               </Component>
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-5.5.3\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-5.5.3\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-5.5.3\config\log4j2.properties" />
               </Component>
 
             </Directory>
@@ -95,144 +91,144 @@
                 <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780af1fbea" Win64="yes">
-                <File Id="elasticsearch_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\elasticsearch-6.0.0-beta1.jar" />
+              <Component Id="Component.elasticsearch_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478134af927" Win64="yes">
+                <File Id="elasticsearch_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\elasticsearch-5.5.3.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component._...ersion_checker_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547814935a68" Win64="yes">
-                <File Id="_...ersion_checker_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\java-version-checker-6.0.0-beta1.jar" />
+              <Component Id="Component.java_version_checker_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c981c2cd" Win64="yes">
+                <File Id="java_version_checker_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\java-version-checker-5.5.3.jar" />
               </Component>
 
-              <Component Id="Component.jna_4.4.0_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838772020" Win64="yes">
-                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jna-4.4.0-1.jar" />
+              <Component Id="Component.jna_4.4.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa115652" Win64="yes">
+                <File Id="jna_4.4.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jna-4.4.0.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jts-1.13.jar" />
               </Component>
 
               <Component Id="Component.log4j_1.2_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd896f3f" Win64="yes">
-                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\log4j-1.2-api-2.8.2.jar" />
+                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\log4j-1.2-api-2.8.2.jar" />
               </Component>
 
               <Component Id="Component.log4j_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830b6218a" Win64="yes">
-                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\log4j-api-2.8.2.jar" />
+                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\log4j-api-2.8.2.jar" />
               </Component>
 
               <Component Id="Component.log4j_core_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b3cb698" Win64="yes">
-                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\log4j-core-2.8.2.jar" />
+                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\log4j-core-2.8.2.jar" />
               </Component>
 
-              <Component Id="Component._...mon_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786e24ebfa" Win64="yes">
-                <File Id="_...mon_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-analyzers-common-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component._...ene_analyzers_common_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818972dca" Win64="yes">
+                <File Id="_...ene_analyzers_common_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-analyzers-common-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ecs_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b87ae09" Win64="yes">
-                <File Id="_...ecs_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-backward-codecs-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component._...cene_backward_codecs_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478587b7ac6" Win64="yes">
+                <File Id="_...cene_backward_codecs_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-backward-codecs-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ore_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b53cca9d" Win64="yes">
-                <File Id="_...ore_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-core-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_core_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820309523" Win64="yes">
+                <File Id="lucene_core_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-core-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ing_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780e80ab0f" Win64="yes">
-                <File Id="_...ing_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-grouping-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_grouping_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478200823f6" Win64="yes">
+                <File Id="lucene_grouping_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-grouping-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ter_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cfbfe19c" Win64="yes">
-                <File Id="_...ter_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-highlighter-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_highlighter_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cf520fdb" Win64="yes">
+                <File Id="lucene_highlighter_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-highlighter-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...oin_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc255d97" Win64="yes">
-                <File Id="_...oin_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-join-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_join_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788bdd052a" Win64="yes">
+                <File Id="lucene_join_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-join-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ory_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7c26e83" Win64="yes">
-                <File Id="_...ory_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-memory-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_memory_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547821ad2a45" Win64="yes">
+                <File Id="lucene_memory_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-memory-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...isc_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478419dc977" Win64="yes">
-                <File Id="_...isc_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-misc-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_misc_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868e10357" Win64="yes">
+                <File Id="lucene_misc_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-misc-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ies_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f5eb9ecc" Win64="yes">
-                <File Id="_...ies_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-queries-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_queries_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478acaa136d" Win64="yes">
+                <File Id="lucene_queries_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-queries-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ser_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-547836d55139" Win64="yes">
-                <File Id="_...ser_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-queryparser-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_queryparser_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785a63e130" Win64="yes">
+                <File Id="lucene_queryparser_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-queryparser-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...box_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478929bbc54" Win64="yes">
-                <File Id="_...box_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-sandbox-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_sandbox_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547865c0a387" Win64="yes">
+                <File Id="lucene_sandbox_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-sandbox-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ial_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a65afda1" Win64="yes">
-                <File Id="_...ial_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-spatial-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_spatial_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785099eaf2" Win64="yes">
+                <File Id="lucene_spatial_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-spatial-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...ras_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-547854e48778" Win64="yes">
-                <File Id="_...ras_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-spatial-extras-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component._...ucene_spatial_extras_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478101d1172" Win64="yes">
+                <File Id="_...ucene_spatial_extras_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-spatial-extras-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...l3d_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782c1bb554" Win64="yes">
-                <File Id="_...l3d_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-spatial3d-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_spatial3d_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fe531cc7" Win64="yes">
+                <File Id="lucene_spatial3d_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-spatial3d-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component._...est_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478031719da" Win64="yes">
-                <File Id="_...est_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\lucene-suggest-7.0.0-snapshot-00142c9.jar" />
+              <Component Id="Component.lucene_suggest_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c90c821" Win64="yes">
+                <File Id="lucene_suggest_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-suggest-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component.plugin_cli_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830801542" Win64="yes">
-                <File Id="plugin_cli_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\plugin-cli-6.0.0-beta1.jar" />
+              <Component Id="Component.plugin_cli_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ae9f650f" Win64="yes">
+                <File Id="plugin_cli_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\plugin-cli-5.5.3.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -245,95 +241,103 @@
                   <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...s_matrix_stats_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785df02122" Win64="yes">
-                  <File Id="_...s_matrix_stats_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-beta1.jar" />
+                <Component Id="Component.aggs_matrix_stats_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478261442da" Win64="yes">
+                  <File Id="aggs_matrix_stats_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\aggs-matrix-stats\aggs-matrix-stats-5.5.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\aggs-matrix-stats\plugin-descriptor.properties" />
-                </Component>
-
-              </Directory>
-
-              <Directory Id="INSTALLDIR.modules.analysis_common" Name="analysis-common">
-
-                <Component Id="Component.INSTALLDIR.modules.analysis_common" Guid="daaa2cba-a1ed-4f29-afbf-54787e7f0b5f" Win64="yes">
-                  <RemoveFile Id="INSTALLDIR.modules.analysis_common" Name="*" On="both" />
-                  <RemoveFolder Id="INSTALLDIR.modules.analysis_common.dir" On="both" />
-                </Component>
-
-                <Component Id="Component._...nalysis_common_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478739e4d14" Win64="yes">
-                  <File Id="_...nalysis_common_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\analysis-common\analysis-common-6.0.0-beta1.jar" />
-                </Component>
-
-                <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\analysis-common\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.ingest_common" Name="ingest-common">
 
-                <Component Id="Component.INSTALLDIR.modules.ingest_common" Guid="daaa2cba-a1ed-4f29-afbf-547819d8cae4" Win64="yes">
+                <Component Id="Component.INSTALLDIR.modules.ingest_common" Guid="daaa2cba-a1ed-4f29-afbf-54787e7f0b5f" Win64="yes">
                   <RemoveFile Id="INSTALLDIR.modules.ingest_common" Name="*" On="both" />
                   <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.ingest_common_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780774bf6d" Win64="yes">
-                  <File Id="ingest_common_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\ingest-common\ingest-common-6.0.0-beta1.jar" />
+                <Component Id="Component.ingest_common_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547872ac12f9" Win64="yes">
+                  <File Id="ingest_common_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\ingest-common-5.5.3.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\ingest-common\plugin-descriptor.properties" />
+                <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
+                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.lang_expression" Name="lang-expression">
 
-                <Component Id="Component.INSTALLDIR.modules.lang_expression" Guid="daaa2cba-a1ed-4f29-afbf-5478266128bd" Win64="yes">
+                <Component Id="Component.INSTALLDIR.modules.lang_expression" Guid="daaa2cba-a1ed-4f29-afbf-547819d8cae4" Win64="yes">
                   <RemoveFile Id="INSTALLDIR.modules.lang_expression" Name="*" On="both" />
                   <RemoveFolder Id="INSTALLDIR.modules.lang_expression.dir" On="both" />
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component._...ang_expression_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478253a9e5a" Win64="yes">
-                  <File Id="_...ang_expression_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\lang-expression-6.0.0-beta1.jar" />
+                <Component Id="Component.lang_expression_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547869913535" Win64="yes">
+                  <File Id="lang_expression_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\lang-expression-5.5.3.jar" />
                 </Component>
 
-                <Component Id="Component._...ons_7.0.0_snapshot_00142c9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b45ed1db" Win64="yes">
-                  <File Id="_...ons_7.0.0_snapshot_00142c9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\lucene-expressions-7.0.0-snapshot-00142c9.jar" />
+                <Component Id="Component.lucene_expressions_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bdb326c8" Win64="yes">
+                  <File Id="lucene_expressions_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\lucene-expressions-6.6.0.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\plugin-descriptor.properties" />
+                <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
+                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-expression\plugin-security.policy" />
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\plugin-security.policy" />
+                </Component>
+
+              </Directory>
+
+              <Directory Id="INSTALLDIR.modules.lang_groovy" Name="lang-groovy">
+
+                <Component Id="Component.INSTALLDIR.modules.lang_groovy" Guid="daaa2cba-a1ed-4f29-afbf-5478266128bd" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.lang_groovy" Name="*" On="both" />
+                  <RemoveFolder Id="INSTALLDIR.modules.lang_groovy.dir" On="both" />
+                </Component>
+
+                <Component Id="Component.groovy_2.4.6_indy.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c4b086e8" Win64="yes">
+                  <File Id="groovy_2.4.6_indy.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\groovy-2.4.6-indy.jar" />
+                </Component>
+
+                <Component Id="Component.lang_groovy_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782da4b593" Win64="yes">
+                  <File Id="lang_groovy_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\lang-groovy-5.5.3.jar" />
+                </Component>
+
+                <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
+                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\plugin-descriptor.properties" />
+                </Component>
+
+                <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
+                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -346,19 +350,19 @@
                 </Component>
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d90e3a8b" Win64="yes">
-                  <File Id="lang_mustache_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-mustache\lang-mustache-6.0.0-beta1.jar" />
+                <Component Id="Component.lang_mustache_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784419a698" Win64="yes">
+                  <File Id="lang_mustache_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\lang-mustache-5.5.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-mustache\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-mustache\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
+                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -371,23 +375,23 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c95ef840" Win64="yes">
-                  <File Id="lang_painless_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-painless\lang-painless-6.0.0-beta1.jar" />
+                <Component Id="Component.lang_painless_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547840c9a1fe" Win64="yes">
+                  <File Id="lang_painless_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\lang-painless-5.5.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-painless\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\lang-painless\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
+                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -399,12 +403,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.parent_join_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789363c240" Win64="yes">
-                  <File Id="parent_join_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\parent-join\parent-join-6.0.0-beta1.jar" />
+                <Component Id="Component.parent_join_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478aba0a9e7" Win64="yes">
+                  <File Id="parent_join_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\parent-join\parent-join-5.5.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\parent-join\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\parent-join\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -416,12 +420,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.percolator_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789a236dcb" Win64="yes">
-                  <File Id="percolator_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\percolator\percolator-6.0.0-beta1.jar" />
+                <Component Id="Component.percolator_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d894ddf2" Win64="yes">
+                  <File Id="percolator_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\percolator\percolator-5.5.3.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\percolator\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\percolator\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -433,41 +437,65 @@
                   <RemoveFolder Id="INSTALLDIR.modules.reindex.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...ch_rest_client_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b2b14d61" Win64="yes">
-                  <File Id="_...ch_rest_client_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\reindex\elasticsearch-rest-client-6.0.0-beta1.jar" />
+                <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\commons-codec-1.10.jar" />
+                </Component>
+
+                <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\commons-logging-1.1.3.jar" />
+                </Component>
+
+                <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpasyncclient-4.1.2.jar" />
+                </Component>
+
+                <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpclient-4.5.2.jar" />
+                </Component>
+
+                <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpcore-4.4.5.jar" />
+                </Component>
+
+                <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\reindex\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\reindex\plugin-security.policy" />
+                <Component Id="Component.reindex_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547884ba0af4" Win64="yes">
+                  <File Id="reindex_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\reindex-5.5.3.jar" />
                 </Component>
 
-                <Component Id="Component.reindex_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783a09d5c9" Win64="yes">
-                  <File Id="reindex_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\reindex\reindex-6.0.0-beta1.jar" />
+                <Component Id="Component.rest_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbf23a5b" Win64="yes">
+                  <File Id="rest_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\rest-5.5.3.jar" />
                 </Component>
 
               </Directory>
 
-              <Directory Id="INSTALLDIR.modules.repository_url" Name="repository-url">
+              <Directory Id="INSTALLDIR.modules.transport_netty3" Name="transport-netty3">
 
-                <Component Id="Component.INSTALLDIR.modules.repository_url" Guid="daaa2cba-a1ed-4f29-afbf-5478f1dfade6" Win64="yes">
-                  <RemoveFile Id="INSTALLDIR.modules.repository_url" Name="*" On="both" />
-                  <RemoveFolder Id="INSTALLDIR.modules.repository_url.dir" On="both" />
+                <Component Id="Component.INSTALLDIR.modules.transport_netty3" Guid="daaa2cba-a1ed-4f29-afbf-5478f1dfade6" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.transport_netty3" Name="*" On="both" />
+                  <RemoveFolder Id="INSTALLDIR.modules.transport_netty3.dir" On="both" />
+                </Component>
+
+                <Component Id="Component.netty_3.10.6.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786aa11ed2" Win64="yes">
+                  <File Id="netty_3.10.6.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\netty-3.10.6.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\repository-url\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\repository-url\plugin-security.policy" />
+                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.repository_url_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a0e24525" Win64="yes">
-                  <File Id="repository_url_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\repository-url\repository-url-6.0.0-beta1.jar" />
+                <Component Id="Component.transport_netty3_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785d681d4e" Win64="yes">
+                  <File Id="transport_netty3_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\transport-netty3-5.5.3.jar" />
                 </Component>
 
               </Directory>
@@ -479,61 +507,44 @@
                   <RemoveFolder Id="INSTALLDIR.modules.transport_netty4.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
-                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
+                <Component Id="Component.netty_buffer_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881351e3b" Win64="yes">
+                  <File Id="netty_buffer_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-buffer-4.1.11.Final.jar" />
                 </Component>
 
-                <Component Id="Component.netty_codec_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478677b2eca" Win64="yes">
-                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
+                <Component Id="Component.netty_codec_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547885592eca" Win64="yes">
+                  <File Id="netty_codec_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-codec-4.1.11.Final.jar" />
                 </Component>
 
-                <Component Id="Component._...ty_codec_http_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bebaa9fe" Win64="yes">
-                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
+                <Component Id="Component._...ty_codec_http_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d644a9fe" Win64="yes">
+                  <File Id="_...ty_codec_http_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-codec-http-4.1.11.Final.jar" />
                 </Component>
 
-                <Component Id="Component.netty_common_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7df66c" Win64="yes">
-                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
+                <Component Id="Component.netty_common_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7fe90e" Win64="yes">
+                  <File Id="netty_common_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-common-4.1.11.Final.jar" />
                 </Component>
 
-                <Component Id="Component.netty_handler_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fda2ab4a" Win64="yes">
-                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
+                <Component Id="Component.netty_handler_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780908ab4a" Win64="yes">
+                  <File Id="netty_handler_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-handler-4.1.11.Final.jar" />
                 </Component>
 
-                <Component Id="Component._...etty_resolver_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785164d95f" Win64="yes">
-                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
+                <Component Id="Component._...etty_resolver_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785ae2d95f" Win64="yes">
+                  <File Id="_...etty_resolver_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-resolver-4.1.11.Final.jar" />
                 </Component>
 
-                <Component Id="Component._...tty_transport_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbded01b" Win64="yes">
-                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
+                <Component Id="Component._...tty_transport_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b258d01b" Win64="yes">
+                  <File Id="_...tty_transport_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-transport-4.1.11.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.10" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae8" Win64="yes">
-                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\plugin-security.policy" />
+                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component._...ansport_netty4_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784490642c" Win64="yes">
-                  <File Id="_...ansport_netty4_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\transport-netty4\transport-netty4-6.0.0-beta1.jar" />
-                </Component>
-
-              </Directory>
-
-              <Directory Id="INSTALLDIR.modules.tribe" Name="tribe">
-
-                <Component Id="Component.INSTALLDIR.modules.tribe" Guid="daaa2cba-a1ed-4f29-afbf-5478d0798b49" Win64="yes">
-                  <RemoveFile Id="INSTALLDIR.modules.tribe" Name="*" On="both" />
-                  <RemoveFolder Id="INSTALLDIR.modules.tribe.dir" On="both" />
-                </Component>
-
-                <Component Id="Component.plugin_descriptor.properties.11" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae9" Win64="yes">
-                  <File Id="plugin_descriptor.properties.11" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\tribe\plugin-descriptor.properties" />
-                </Component>
-
-                <Component Id="Component.tribe_6.0.0_beta1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786c82c61e" Win64="yes">
-                  <File Id="tribe_6.0.0_beta1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta1\modules\tribe\tribe-6.0.0-beta1.jar" />
+                <Component Id="Component.transport_netty4_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547870411d4e" Win64="yes">
+                  <File Id="transport_netty4_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\transport-netty4-5.5.3.jar" />
                 </Component>
 
               </Directory>
@@ -553,8 +564,8 @@
     </UI>
 
     <Upgrade Id="daaa2cba-a1ed-4f29-afbf-5478617b00f6">
-      <UpgradeVersion Minimum="0.0.0.0" Maximum="6.0.0" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
-      <UpgradeVersion Minimum="6.0.0" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
+      <UpgradeVersion Minimum="0.0.0.0" Maximum="5.5.3" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
+      <UpgradeVersion Minimum="5.5.3" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
     </Upgrade>
 
     <Icon Id="app_icon.ico" SourceFile="Resources\elasticsearch.ico" />
@@ -603,7 +614,7 @@
     <Binary Id="ElasticsearchValidateArgumentsAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="6.0.0-beta1" />
+    <Property Id="CurrentVersion" Value="5.5.3" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -629,7 +640,6 @@
       <ComponentRef Id="Component.LICENSE.txt" />
       <ComponentRef Id="Component.NOTICE.txt" />
       <ComponentRef Id="Component.README.textile" />
-      <ComponentRef Id="Component.elasticsearch_env.bat" />
       <ComponentRef Id="Component.elasticsearch_keystore.bat" />
       <ComponentRef Id="Component.elasticsearch_plugin.bat" />
       <ComponentRef Id="Component.elasticsearch_translog.bat" />
@@ -637,106 +647,111 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.elasticsearch_5.5.3.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component._...ersion_checker_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.jna_4.4.0_1.jar" />
+      <ComponentRef Id="Component.java_version_checker_5.5.3.jar" />
+      <ComponentRef Id="Component.jna_4.4.0.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
       <ComponentRef Id="Component.jts_1.13.jar" />
       <ComponentRef Id="Component.log4j_1.2_api_2.8.2.jar" />
       <ComponentRef Id="Component.log4j_api_2.8.2.jar" />
       <ComponentRef Id="Component.log4j_core_2.8.2.jar" />
-      <ComponentRef Id="Component._...mon_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ecs_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ore_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ing_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ter_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...oin_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ory_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...isc_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ies_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ser_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...box_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ial_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...ras_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...l3d_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component._...est_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component.plugin_cli_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component._...ene_analyzers_common_6.6.0.jar" />
+      <ComponentRef Id="Component._...cene_backward_codecs_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_core_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_grouping_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_highlighter_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_join_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_memory_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_misc_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_queries_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_queryparser_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_sandbox_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_spatial_6.6.0.jar" />
+      <ComponentRef Id="Component._...ucene_spatial_extras_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_spatial3d_6.6.0.jar" />
+      <ComponentRef Id="Component.lucene_suggest_6.6.0.jar" />
+      <ComponentRef Id="Component.plugin_cli_5.5.3.jar" />
       <ComponentRef Id="Component.securesm_1.1.jar" />
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component._...s_matrix_stats_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.aggs_matrix_stats_5.5.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component._...nalysis_common_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.1" />
-      <ComponentRef Id="Component.ingest_common_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.ingest_common_5.5.3.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.2" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.1" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar" />
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component._...ang_expression_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component._...ons_7.0.0_snapshot_00142c9.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.3" />
+      <ComponentRef Id="Component.lang_expression_5.5.3.jar" />
+      <ComponentRef Id="Component.lucene_expressions_6.6.0.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.2" />
       <ComponentRef Id="Component.plugin_security.policy" />
-      <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.4" />
+      <ComponentRef Id="Component.groovy_2.4.6_indy.jar" />
+      <ComponentRef Id="Component.lang_groovy_5.5.3.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.3" />
       <ComponentRef Id="Component.plugin_security.policy.1" />
+      <ComponentRef Id="Component.compiler_0.9.3.jar" />
+      <ComponentRef Id="Component.lang_mustache_5.5.3.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.4" />
+      <ComponentRef Id="Component.plugin_security.policy.2" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.lang_painless_5.5.3.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.5" />
-      <ComponentRef Id="Component.plugin_security.policy.2" />
-      <ComponentRef Id="Component.parent_join_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.6" />
-      <ComponentRef Id="Component.percolator_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.7" />
-      <ComponentRef Id="Component._...ch_rest_client_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.8" />
       <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.reindex_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.parent_join_5.5.3.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.6" />
+      <ComponentRef Id="Component.percolator_5.5.3.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.7" />
+      <ComponentRef Id="Component.commons_codec_1.10.jar" />
+      <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
+      <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
+      <ComponentRef Id="Component.httpclient_4.5.2.jar" />
+      <ComponentRef Id="Component.httpcore_4.4.5.jar" />
+      <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.8" />
+      <ComponentRef Id="Component.reindex_5.5.3.jar" />
+      <ComponentRef Id="Component.rest_5.5.3.jar" />
+      <ComponentRef Id="Component.netty_3.10.6.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.9" />
       <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.repository_url_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.netty_buffer_4.1.13.Final.jar" />
-      <ComponentRef Id="Component.netty_codec_4.1.13.Final.jar" />
-      <ComponentRef Id="Component._...ty_codec_http_4.1.13.Final.jar" />
-      <ComponentRef Id="Component.netty_common_4.1.13.Final.jar" />
-      <ComponentRef Id="Component.netty_handler_4.1.13.Final.jar" />
-      <ComponentRef Id="Component._...etty_resolver_4.1.13.Final.jar" />
-      <ComponentRef Id="Component._...tty_transport_4.1.13.Final.jar" />
+      <ComponentRef Id="Component.transport_netty3_5.5.3.jar" />
+      <ComponentRef Id="Component.netty_buffer_4.1.11.Final.jar" />
+      <ComponentRef Id="Component.netty_codec_4.1.11.Final.jar" />
+      <ComponentRef Id="Component._...ty_codec_http_4.1.11.Final.jar" />
+      <ComponentRef Id="Component.netty_common_4.1.11.Final.jar" />
+      <ComponentRef Id="Component.netty_handler_4.1.11.Final.jar" />
+      <ComponentRef Id="Component._...etty_resolver_4.1.11.Final.jar" />
+      <ComponentRef Id="Component._...tty_transport_4.1.11.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.10" />
       <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component._...ansport_netty4_6.0.0_beta1.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.11" />
-      <ComponentRef Id="Component.tribe_6.0.0_beta1.jar" />
+      <ComponentRef Id="Component.transport_netty4_5.5.3.jar" />
       <ComponentRef Id="Component.INSTALLDIR" />
       <ComponentRef Id="Component.INSTALLDIR.bin.xpack" />
       <ComponentRef Id="Component.INSTALLDIR.bin" />
       <ComponentRef Id="Component.INSTALLDIR.config" />
       <ComponentRef Id="Component.INSTALLDIR.lib" />
       <ComponentRef Id="Component.INSTALLDIR.modules.aggs_matrix_stats" />
-      <ComponentRef Id="Component.INSTALLDIR.modules.analysis_common" />
       <ComponentRef Id="Component.INSTALLDIR.modules.ingest_common" />
       <ComponentRef Id="Component.INSTALLDIR.modules.lang_expression" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.lang_groovy" />
       <ComponentRef Id="Component.INSTALLDIR.modules.lang_mustache" />
       <ComponentRef Id="Component.INSTALLDIR.modules.lang_painless" />
       <ComponentRef Id="Component.INSTALLDIR.modules.parent_join" />
       <ComponentRef Id="Component.INSTALLDIR.modules.percolator" />
       <ComponentRef Id="Component.INSTALLDIR.modules.reindex" />
-      <ComponentRef Id="Component.INSTALLDIR.modules.repository_url" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.transport_netty3" />
       <ComponentRef Id="Component.INSTALLDIR.modules.transport_netty4" />
-      <ComponentRef Id="Component.INSTALLDIR.modules.tribe" />
     </Feature>
 
     <InstallExecuteSequence>

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","216afa")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","d87c96")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
-[assembly: AssemblyVersionAttribute("6.0.0")]
-[assembly: AssemblyFileVersionAttribute("6.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("6.0.0-beta1")]
+[assembly: AssemblyVersionAttribute("5.5.3")]
+[assembly: AssemblyFileVersionAttribute("5.5.3")]
+[assembly: AssemblyInformationalVersionAttribute("5.5.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "216afa";
+        internal const System.String AssemblyMetadata_GitBuildHash = "d87c96";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
-        internal const System.String AssemblyVersion = "6.0.0";
-        internal const System.String AssemblyFileVersion = "6.0.0";
-        internal const System.String AssemblyInformationalVersion = "6.0.0-beta1";
+        internal const System.String AssemblyVersion = "5.5.3";
+        internal const System.String AssemblyFileVersion = "5.5.3";
+        internal const System.String AssemblyInformationalVersion = "5.5.3";
     }
 }

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","d87c96")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","8d8f53")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -19,7 +19,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "d87c96";
+        internal const System.String AssemblyMetadata_GitBuildHash = "8d8f53";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -134,7 +134,7 @@ function Context-EsHomeEnvironmentVariable($Expected) {
 
 function Context-EsConfigEnvironmentVariable($Expected) {
 	$Expected = Merge-Hashtables @{
-        Version = $Global:Version.FullVersion
+        Version = $Global:Version
         Path = Join-Path -Path $($env:ALLUSERSPROFILE) -ChildPath "Elastic\Elasticsearch\config"
     } $Expected
 
@@ -154,11 +154,13 @@ function Context-EsConfigEnvironmentVariable($Expected) {
 }
 
 function Context-MsiRegistered($Expected) {
+	$version = $Global:Version
+
     $Expected = Merge-Hashtables @{
-            Name = "Elasticsearch $Global:Version.FullVersion"
-            Caption = "Elasticsearch $Global:Version.FullVersion"
+            Name = "Elasticsearch $($version.FullVersion)"
+            Caption = "Elasticsearch $($version.FullVersion)"
             # Product Version is always without any prerelease suffix
-            Version = "$($Global:Version.Major).$($Global:Version.Minor).$($Global:Version.Patch)"
+            Version = "$($version.Major).$($version.Minor).$($version.Patch)"
         } $Expected
 
 
@@ -272,7 +274,7 @@ function Context-ElasticsearchConfiguration ([HashTable]$Expected) {
         NodeIngest = $true
         NodeMaster = $true
         NodeMaxLocalStorageNodes = 1
-		Version = $Global:Version.FullVersion
+		Version = $Global:Version
     } $Expected
 
     $esConfigEnvVar = Get-ConfigEnvironmentVariableForVersion -Version $Expected.Version
@@ -294,31 +296,31 @@ function Context-ElasticsearchConfiguration ([HashTable]$Expected) {
         }
 
 		It "bootstrap.memory_lock set to $($Expected.BootstrapMemoryLock)" {
-			$ConfigLines | Should Contain "bootstrap.memory_lock: $($Expected.BootstrapMemoryLock.ToString().ToLowerInvariant())"
+			$ConfigLines | Should FileContentMatchExactly "bootstrap.memory_lock: $($Expected.BootstrapMemoryLock.ToString().ToLowerInvariant())"
 		}         
            
 		It "node.data set to to $($Expected.NodeData)" {
-			$ConfigLines | Should Contain "node.data: $($Expected.NodeData.ToString().ToLowerInvariant())"
+			$ConfigLines | Should FileContentMatchExactly "node.data: $($Expected.NodeData.ToString().ToLowerInvariant())"
 		}    
 
 		It "node.ingest set to $($Expected.NodeIngest)" {
-			$ConfigLines | Should Contain "node.ingest: $($Expected.NodeIngest.ToString().ToLowerInvariant())"
+			$ConfigLines | Should FileContentMatchExactly "node.ingest: $($Expected.NodeIngest.ToString().ToLowerInvariant())"
 		}
 
 		It "node.master set to $($Expected.NodeMaster)" {
-			$ConfigLines | Should Contain "node.master: $($Expected.NodeMaster.ToString().ToLowerInvariant())"
+			$ConfigLines | Should FileContentMatchExactly "node.master: $($Expected.NodeMaster.ToString().ToLowerInvariant())"
 		}
 
         It "node.max_local_storage_nodes set to $($Expected.NodeMaxLocalStorageNodes)" {
-            $ConfigLines | Should Contain "node.max_local_storage_nodes: $($Expected.NodeMaxLocalStorageNodes)"
+            $ConfigLines | Should FileContentMatchExactly "node.max_local_storage_nodes: $($Expected.NodeMaxLocalStorageNodes)"
         }
 
         It "path.data set to $($Expected.Data)" {
-            $ConfigLines | Should Contain ([regex]::Escape("path.data: $($Expected.Data)"))
+            $ConfigLines | Should FileContentMatchExactly ([regex]::Escape("path.data: $($Expected.Data)"))
         }
 
         It "path.logs set to $($Expected.Logs)" {
-            $ConfigLines | Should Contain ([regex]::Escape("path.logs: $($Expected.Logs)"))
+            $ConfigLines | Should FileContentMatchExactly ([regex]::Escape("path.logs: $($Expected.Logs)"))
         }
     }
 }
@@ -333,7 +335,7 @@ function Context-JvmOptions ($Expected) {
     }
 	
 	$Expected = Merge-Hashtables @{
-		Version = $Global:Version.FullVersion
+		Version = $Global:Version
 		Memory = $defaultMemory
     } $Expected
 
@@ -347,11 +349,11 @@ function Context-JvmOptions ($Expected) {
         }
 
         It "Min Heap size should be set to $($Expected.Memory)m" {
-            $ConfigLines | Should Contain ([regex]::Escape("-Xmx$($Expected.Memory)m"))
+            $ConfigLines | Should FileContentMatchExactly ([regex]::Escape("-Xmx$($Expected.Memory)m"))
         }
 
         It "Max Heap size should be set to $($Expected.Memory)m" {
-            $ConfigLines | Should Contain ([regex]::Escape("-Xms$($Expected.Memory)m"))
+            $ConfigLines | Should FileContentMatchExactly ([regex]::Escape("-Xms$($Expected.Memory)m"))
         }
     }
 }
@@ -481,7 +483,7 @@ function Context-EmptyInstallDirectory($Path) {
 
 function Context-EsConfigEnvironmentVariableNull($Version) {
 	if (!($Version)) {
-		$Version = $Global:Version.FullVersion
+		$Version = $Global:Version
 	}
 
 	$Name = Get-ConfigEnvironmentVariableForVersion -Version $Version

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -19,7 +19,8 @@ function Context-ElasticsearchService($Expected) {
             StartType="Automatic"
             Name="Elasticsearch"
             DisplayName="Elasticsearch"
-        } $Expected
+			StartIfNotRunning = $true
+		} $Expected
 
     Context "Elasticsearch service" {
         $Service = Get-ElasticsearchService
@@ -30,6 +31,18 @@ function Context-ElasticsearchService($Expected) {
 
         It "Service status is $($Expected.Status)" {
             $Service.Status | Should Be $($Expected.Status)
+
+			# BUG: Upgrading from Elasticsearch 5.5.0-2, to 5.5.3+, the service is not started after upgrading.
+			# Start the service if commanded to do so
+			if ($Expected.StartIfNotRunning -and ($Expected.Status -eq "StopPending" -or $Expected.Status -eq "Stopped")) {
+				Write-Output "Service is currently $($Service.Status). Attempting to start"
+				$timeSpan = New-TimeSpan -Seconds 10
+				if ($Service.Status -eq "StopPending") {
+					$Service.WaitForStatus("Stopped", $timeSpan)
+				}
+
+				$Service | Start-Service
+			}
         }
 
         It "Service can be stopped" {
@@ -120,25 +133,32 @@ function Context-EsHomeEnvironmentVariable($Expected) {
 }
 
 function Context-EsConfigEnvironmentVariable($Expected) {
-    Context "CONF_DIR Environment Variable" {
-        $EsConfig = Get-MachineEnvironmentVariable "CONF_DIR"
+	$Expected = Merge-Hashtables @{
+        Version = $Global:Version.FullVersion
+        Path = Join-Path -Path $($env:ALLUSERSPROFILE) -ChildPath "Elastic\Elasticsearch\config"
+    } $Expected
 
-        It "CONF_DIR is not null" {
+	$esConfigEnvVar = Get-ConfigEnvironmentVariableForVersion -Version $Expected.Version
+
+    Context "$esConfigEnvVar Environment Variable" {
+        $EsConfig = Get-MachineEnvironmentVariable $esConfigEnvVar
+
+        It "$esConfigEnvVar is not null" {
             $EsConfig | Should Not Be $null
         }
 
-        It "CONF_DIR Environment variable set to $Expected" {
-            $EsConfig | Should Be $Expected
+        It "$esConfigEnvVar Environment variable set to $($Expected.Path)" {
+            $EsConfig | Should Be $Expected.Path
         }
     }
 }
 
 function Context-MsiRegistered($Expected) {
     $Expected = Merge-Hashtables @{
-            Name = "Elasticsearch $env:EsVersion"
-            Caption = "Elasticsearch $env:EsVersion"
-            # version is always without any prerelease suffix
-            Version = $($env:EsVersion).Split("-")[0]
+            Name = "Elasticsearch $Global:Version.FullVersion"
+            Caption = "Elasticsearch $Global:Version.FullVersion"
+            # Product Version is always without any prerelease suffix
+            Version = "$($Global:Version.Major).$($Global:Version.Minor).$($Global:Version.Patch)"
         } $Expected
 
 
@@ -246,20 +266,24 @@ function Context-ClusterNameAndNodeName($Expected) {
 }
 
 function Context-ElasticsearchConfiguration ([HashTable]$Expected) {
+	$Expected = Merge-Hashtables @{
+        BootstrapMemoryLock = $false
+        NodeData = $true
+        NodeIngest = $true
+        NodeMaster = $true
+        NodeMaxLocalStorageNodes = 1
+		Version = $Global:Version.FullVersion
+    } $Expected
 
-    $EsConfig = Get-MachineEnvironmentVariable "CONF_DIR"
+    $esConfigEnvVar = Get-ConfigEnvironmentVariableForVersion -Version $Expected.Version
+	$EsConfig = Get-MachineEnvironmentVariable $esConfigEnvVar
     $EsData = Split-Path $EsConfig -Parent | Join-Path -ChildPath "data"
     $EsLogs = Split-Path $EsConfig -Parent | Join-Path -ChildPath "logs"
 
-    $Expected = Merge-Hashtables @{
-            BootstrapMemoryLock = $false
-            NodeData = $true
-            NodeIngest = $true
-            NodeMaster = $true
-            NodeMaxLocalStorageNodes = 1
-            Data = $EsData
-            Logs = $EsLogs
-    } $Expected
+	$Expected = Merge-Hashtables @{
+		Data = $EsData
+        Logs = $EsLogs
+	} $Expected
 
     Context "Elasticsearch Yaml Configuration" {
 
@@ -300,31 +324,34 @@ function Context-ElasticsearchConfiguration ([HashTable]$Expected) {
 }
 
 function Context-JvmOptions ($Expected) {
-    if (!($Expected)) {
-    	$totalPhysicalMemory = Get-TotalPhysicalMemory
-    	
-    	if ($totalPhysicalMemory -le 4096) {
-    		$Expected = $totalPhysicalMemory / 2
-    	}
-    	else {
-    		$Expected = 2048
-    	}
+	$totalPhysicalMemory = Get-TotalPhysicalMemory  	
+    if ($totalPhysicalMemory -le 4096) {
+    	$defaultMemory = $totalPhysicalMemory / 2
     }
+    else {
+    	$defaultMemory = 2048
+    }
+	
+	$Expected = Merge-Hashtables @{
+		Version = $Global:Version.FullVersion
+		Memory = $defaultMemory
+    } $Expected
 
     Context "JVM Configuration" {
-        $EsConfig = Get-MachineEnvironmentVariable "CONF_DIR"
+        $esConfigEnvVar = Get-ConfigEnvironmentVariableForVersion -Version $Expected.Version
+		$EsConfig = Get-MachineEnvironmentVariable $esConfigEnvVar
         $ConfigLines = "$EsConfig\jvm.options"
 
         It "jvm.options should exist in $EsConfig" {
             $ConfigLines | Should Exist
         }
 
-        It "Min Heap size should be set to $($Expected)m" {
-            $ConfigLines | Should Contain ([regex]::Escape("-Xmx$($Expected)m"))
+        It "Min Heap size should be set to $($Expected.Memory)m" {
+            $ConfigLines | Should Contain ([regex]::Escape("-Xmx$($Expected.Memory)m"))
         }
 
-        It "Max Heap size should be set to $($Expected)m" {
-            $ConfigLines | Should Contain ([regex]::Escape("-Xms$($Expected)m"))
+        It "Max Heap size should be set to $($Expected.Memory)m" {
+            $ConfigLines | Should Contain ([regex]::Escape("-Xms$($Expected.Memory)m"))
         }
     }
 }
@@ -452,11 +479,27 @@ function Context-EmptyInstallDirectory($Path) {
     }
 }
 
-function Context-EnvironmentVariableNull($Name) {
+function Context-EsConfigEnvironmentVariableNull($Version) {
+	if (!($Version)) {
+		$Version = $Global:Version.FullVersion
+	}
+
+	$Name = Get-ConfigEnvironmentVariableForVersion -Version $Version
+
 	Context "$Name Environment Variable" {
         $envVar = Get-MachineEnvironmentVariable $Name
         It "$Name Environment variable should be null" {
             $envVar | Should Be $null
+        }
+    }
+}
+
+function Context-EsHomeEnvironmentVariableNull() {
+	$EsHome = Get-MachineEnvironmentVariable "ES_HOME"
+
+	Context "ES_HOME Environment Variable" {
+        It "ES_HOME Environment variable should be null" {
+            $EsHome | Should Be $null
         }
     }
 }

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
@@ -27,8 +27,8 @@ Param(
 )
 
 # Used in tests
-$Global:Version = ConvertTo-SemanticVersion $Version
-$Global:PreviousVersions = $PreviousVersions | ForEach-Object { ConvertTo-SemanticVersion $_ }
+$env:Version = $Version
+$env:PreviousVersions = $PreviousVersions -join ","
 
 $currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
 cd $currentDir

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
@@ -4,13 +4,13 @@
 .Example
 	.\PesterBootstrap.ps1 -Version "5.4.0" -TestDirName "Silent-Install"
 .Example
-	.\PesterBootstrap.ps1 -Version "5.4.0" -PreviousVersion "5.3.2" -TestDirName "Silent-Install"
+	.\PesterBootstrap.ps1 -Version "5.4.0" -PreviousVersions @("5.3.2") -TestDirName "Silent-Install"
 .Parameter TestDirName
     The name of the test directory containing the tests
 .Parameter Version
 	The product version under test
-.Parameter PreviousVersion
-	The previous product version used to test upgrades and downgrades
+.Parameter PreviousVersions
+	The previous product versions used to test upgrades and downgrades
 #>
 [CmdletBinding()]
 Param(
@@ -18,20 +18,17 @@ Param(
     [string] $TestDirName,
 
     [Parameter(Mandatory=$true)]
-	[ValidatePattern("\d+\.\d+\.\d+((?:\-[\w\-]+))?")]
-    [string] $Version,
-
-	[Parameter(Mandatory=$false)]
-	[ValidatePattern("^$|\d+\.\d+\.\d+((?:\-[\w\-]+))?")]
-    [string] $PreviousVersion
+	[ValidatePattern("^((\w*)\:)?((\d+)\.(\d+)\.(\d+)(?:\-([\w\-]+))?)$")]
+    [string] $Version,    
+    
+    [Parameter(Mandatory=$false)]
+	[ValidateScript({ $_ | ForEach-Object { $_ -match "^((\w*)\:)?((\d+)\.(\d+)\.(\d+)(?:\-([\w\-]+))?)$" } })]
+    [string[]] $PreviousVersions=@()
 )
 
 # Used in tests
-$env:EsVersion = $Version
-
-if ($PreviousVersion) {
-	$env:PreviousEsVersion = $PreviousVersion
-}
+$Global:Version = ConvertTo-SemanticVersion $Version
+$Global:PreviousVersions = $PreviousVersions | ForEach-Object { ConvertTo-SemanticVersion $_ }
 
 $currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
 cd $currentDir
@@ -41,8 +38,7 @@ $pester = "Pester"
 $date = Get-Date -format "yyyy-MM-ddT-HHmmssfff"
 $path = "$($drive)out\results-$TestDirName-$Version-$date.xml"
 
-if(-not(Get-Module -Name $pester)) 
-{ 
+if(-not(Get-Module -Name $pester)) { 
 	# Load the Pester module into the current session. Install if not available
 	Write-Output "import $pester"
 	if(Get-Module -Name $pester -ListAvailable) { 
@@ -54,9 +50,9 @@ if(-not(Get-Module -Name $pester))
 	}
 }
 
-if ($PreviousVersion) {
+if ($PreviousVersions) {
 	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile $path -OutputFormat "NUnitXml" -PassThru | Out-Null
 }
 else {
-	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile $path -OutputFormat "NUnitXml" -ExcludeTag "PreviousVersion" -PassThru | Out-Null
+	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile $path -OutputFormat "NUnitXml" -ExcludeTag "PreviousVersions" -PassThru | Out-Null
 }

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/SemVer.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/SemVer.ps1
@@ -1,0 +1,145 @@
+﻿<#
+Powershell script port of SemVer from https://gist.github.com/jageall/c5119d5ba26fa33602d1
+of https://github.com/maxhauser/semver
+
+Copyright (c) 2013 Max Hauser 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+#>
+
+Add-Type -TypeDefinition @"
+   public enum Source {
+      Compile,
+	  Released,
+	  BuildCandidate
+   }
+"@
+
+function ConvertTo-SemanticVersion($version){
+	$version -match "^((?<Source>\w*)\:)?(?<Version>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+)(?:\-(?<Prerelease>[\w\-]+))?(\+(?<Build>[0-9A-Za-z\-\.]+))?)$" | Out-Null
+    $major = [int]$matches['Major']
+    $minor = [int]$matches['Minor']
+    $patch = [int]$matches['Patch']
+    
+    if($matches['Prerelease'] -eq $null) {
+		$pre = @()
+	}
+    else {
+		$pre = $matches['Prerelease'].Split(".")
+	}
+
+	$build = $matches['Build']
+	$source = $matches['Source']
+	$fullVersion = $matches['Version']
+
+	if (!($source)) {
+		$sourceType = [Source]::Compile
+		$description = "$fullVersion (compiled from source)"
+	} 
+	elseif ($source -eq "r") {
+		$sourceType = [Source]::Released
+		$description = "$fullVersion (official release)"
+
+	}
+	else {
+		$sourceType = [Source]::BuildCandidate
+		$description = "$fullVersion (build candidate $source)"
+	}
+
+    New-Object PSObject -Property @{ 
+        Major = $major
+        Minor = $minor
+        Patch = $patch
+        Prerelease = $pre
+		Build = $build
+		Source = $source
+		SourceType = $sourceType
+        FullVersion = $fullVersion
+		Description = $description
+    }
+}
+
+function Compare-SemanticVersion($a, $b){
+    $result = 0
+    $result =  $a.Major.CompareTo($b.Major)
+    if($result -ne 0){return $result}
+
+    $result = $a.Minor.CompareTo($b.Minor)
+    if($result -ne 0){return $result}
+
+    $result = $a.Patch.CompareTo($b.Patch)
+    if($result -ne 0){return $result}
+    $ap = $a.Pre
+    $bp = $b.Pre
+    if($ap.Length  -eq 0 -and $bp.Length -eq 0) {return 0}
+    if($ap.Length  -eq 0){return 1}
+    if($bp.Length  -eq 0){return -1}
+    
+    $minLength = [Math]::Min($ap.Length, $bp.Length)
+    for($i = 0; $i -lt $minLength; $i++){
+        $ac = $ap[$i]
+        $bc = $bp[$i]
+
+        $anum = 0 
+        $bnum = 0
+        $aIsNum = [Int]::TryParse($ac, [ref] $anum)
+        $bIsNum = [Int]::TryParse($bc, [ref] $bnum)
+
+        if($aIsNum -and $bIsNum) { 
+            # Write-Host "2" $a.FullVersion $b.FullVersion $anum $bnum $anum.CompareTo($bnum)
+            $result = $anum.CompareTo($bnum) 
+            if($result -ne 0)
+            {
+                return $result
+            }
+        }
+        if($aIsNum) {
+            # Write-Host "3" $a.FullVersion $b.FullVersion
+            return -1
+        }
+        if($bIsNum) {
+           # Write-Host "4" $a.FullVersion $b.FullVersion $bIsNum $aIsNum $ac $bc $ap.Length $bp.Length $i
+        return 1}
+        
+        $result = [string]::CompareOrdinal($ac, $bc)
+        if($result -ne 0) {
+        
+        return $result
+        }
+    }
+    # Write-Host "comparing lengths" $ap.Length $bp.Length $ap.Length.CompareTo($bp.Length) $a.FullVersion $b.FullVersion
+    return $ap.Length.CompareTo($bp.Length)
+}
+
+function Add-RankToSemanticVersion($versions){
+    for($i = 0; $i -lt $versions.Length; $i++){
+        $rank = 0
+        for($j = 0; $j -lt $versions.Length; $j++){
+            $diff = 0
+            $diff = Compare-SemanticVersion $versions[$i] $versions[$j]
+            if($diff -gt 0) {
+                # Write-Host $versions[$i].FullVersion "is greater than " $versions[$j].FullVersion " got diff " $diff
+                $rank++
+            }
+        }
+        $current = [PsObject]$versions[$i]
+        Add-Member -InputObject $current -MemberType NoteProperty -Name Rank -Value $rank
+    }
+    return $versions
+}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
@@ -1,3 +1,5 @@
+.\SemVer.ps1
+
 function Write-Log {
     [CmdletBinding()]
     Param
@@ -165,6 +167,7 @@ function Add-VagrantAzureProvider() {
 
 	vagrant plugin install $vagrantAzurePlugin --plugin-version $pluginVersion
 
+	# don't log the Azure SubscriptionId and Admin Username. https://github.com/Azure/vagrant-azure/issues/191
     $vagrantAzureRunInstanceFile = [Environment]::ExpandEnvironmentVariables("%USERPROFILE%\.vagrant.d\gems\2.2.5\gems\vagrant-azure-$pluginVersion\lib\vagrant-azure\action\run_instance.rb")
     $replacements = @{
         'env[:ui].info(" -- Subscription Id: #{config.subscription_id}")' = 'env[:ui].info(" -- Subscription Id: <redacted>")'
@@ -218,7 +221,7 @@ function Invoke-IntegrationTestsOnLocal($Location, $Version, $PreviousVersion, $
 
 	try {
 		vagrant up local    
-		vagrant powershell local -c "C:\common\PesterBootstrap.ps1 -Version '$Version' -PreviousVersion '$PreviousVersion' -TestDirName '$testDirName'"
+		vagrant powershell local -c "C:\common\PesterBootstrap.ps1 -Version '$Version' -PreviousVersions @($($($PreviousVersions | ForEach-Object { "'$_'" }) -join ",")) -TestDirName '$testDirName'"
 	}
 	finally {
 		vagrant destroy local -f
@@ -283,7 +286,7 @@ function Invoke-IntegrationTestsOnAzure($Location, $Version, $PreviousVersion) {
 		$session = [System.Management.Automation.Runspaces.PSSession](Get-WinRmSession -DnsName $dnsName)
 		Copy-SyncedFoldersToRemote -Session $session
 		log "Run Pester bootstrap"	
-		vagrant powershell azure -c "C:\common\PesterBootstrap.ps1 -Version '$Version' -PreviousVersion '$PreviousVersion' -TestDirName '$testDirName'"
+		vagrant powershell azure -c "C:\common\PesterBootstrap.ps1 -Version '$Version' -PreviousVersions @($($($PreviousVersions | ForEach-Object { "'$_'" }) -join ",")) -TestDirName '$testDirName'"
 		Copy-SyncedFoldersFromRemote -Session $session -TestDirName $testDirName
 		Remove-PSSession $session
 	}
@@ -299,7 +302,7 @@ function Invoke-IntegrationTestsOnAzure($Location, $Version, $PreviousVersion) {
     }
 }
 
-function Invoke-IntegrationTestsOnQuickAzure($Location, $Version, $PreviousVersion, $Session) {
+function Invoke-IntegrationTestsOnQuickAzure($Location, $Version, $PreviousVersions, $Session) {
 	$currentLocation = Get-Location   
 	$testDirName = Split-Path $Location -Leaf
 	try {
@@ -311,7 +314,8 @@ function Invoke-IntegrationTestsOnQuickAzure($Location, $Version, $PreviousVersi
 		Copy-SyncedFoldersToRemote -Session $Session -SyncFolders $SyncFolders
 		log "Run Pester bootstrap"	
 		cd $currentLocation
-		vagrant powershell azure -c "C:\common\PesterBootstrap.ps1 -Version '$Version' -PreviousVersion '$PreviousVersion' -TestDirName '$testDirName'"
+
+		vagrant powershell azure -c "C:\common\PesterBootstrap.ps1 -Version '$Version' -PreviousVersions @($($($PreviousVersions | ForEach-Object { "'$_'" }) -join ",")) -TestDirName '$testDirName'"
 		cd $Location
 		Copy-SyncedFoldersFromRemote -Session $Session -TestDirName $testDirName	
 		cd $currentLocation
@@ -322,7 +326,7 @@ function Invoke-IntegrationTestsOnQuickAzure($Location, $Version, $PreviousVersi
 	}
 }
 
-function Invoke-IntegrationTests($CurrentDir, $TestDirs, $VagrantProvider, $Version, $PreviousVersion) {
+function Invoke-IntegrationTests($CurrentDir, $TestDirs, $VagrantProvider, $Version, $PreviousVersions) {
 
 	# run all tests on one vagrant box
 	if ($VagrantProvider -eq "quick-azure") {
@@ -349,7 +353,7 @@ function Invoke-IntegrationTests($CurrentDir, $TestDirs, $VagrantProvider, $Vers
 			Copy-SyncedFoldersToRemote -Session $session -SyncFolders $syncFolders
 			foreach ($dir in $TestDirs) {  
 				log "running tests in $dir"
-				Invoke-IntegrationTestsOnQuickAzure -Location $dir -Version "$Version" -PreviousVersion "$PreviousVersion" -Session $session
+				Invoke-IntegrationTestsOnQuickAzure -Location $dir -Version "$Version" -PreviousVersions $PreviousVersions -Session $session
 			}
 
 			Remove-PSSession $session
@@ -372,10 +376,10 @@ function Invoke-IntegrationTests($CurrentDir, $TestDirs, $VagrantProvider, $Vers
 			Copy-Item "$CurrentDir\common\Vagrantfile" -Destination $dir -Force
 
 			if ($VagrantProvider -eq "local") {
-				Invoke-IntegrationTestsOnLocal -Location $dir -Version $Version -PreviousVersion $PreviousVersion
+				Invoke-IntegrationTestsOnLocal -Location $dir -Version $Version -PreviousVersions $PreviousVersions 
 			} 
 			else {
-				Invoke-IntegrationTestsOnAzure -Location $dir -Version $Version -PreviousVersion $PreviousVersion
+				Invoke-IntegrationTestsOnAzure -Location $dir -Version $Version -PreviousVersions $PreviousVersions 
 			}
 		}
 	}
@@ -445,7 +449,7 @@ function Invoke-SilentInstall {
     $QuotedArgs = Add-Quotes $Exeargs
     $Exe = Get-Installer -Version $Version
     log "running installer: msiexec.exe /i $Exe /qn /l install.log $QuotedArgs"
-    $ExitCode = (Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i $Exe /qn /l install.log $QuotedArgs" -Wait -PassThru).ExitCode
+    $ExitCode = (Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i $Exe /qn /l*v install.log $QuotedArgs" -Wait -PassThru).ExitCode
 
     if ($ExitCode) {
         log "last exit code not zero: $ExitCode" -l Error
@@ -468,13 +472,26 @@ function Invoke-SilentUninstall {
     $QuotedArgs = Add-Quotes $Exeargs
     $Exe = Get-Installer -Version $Version
     log "running installer: msiexec.exe /x $Exe /qn /l uninstall.log $QuotedArgs"
-    $ExitCode = (Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/x $Exe /qn /l uninstall.log $QuotedArgs" -Wait -PassThru).ExitCode
+    $ExitCode = (Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/x $Exe /qn /l*v uninstall.log $QuotedArgs" -Wait -PassThru).ExitCode
 
     if ($ExitCode) {
         log "last exit code not zero: $ExitCode" -l Error
     }
 
     return $ExitCode
+}
+
+function Get-ConfigEnvironmentVariableForVersion($Version) {
+	if (!($Version)) {
+		$Version = $env:EsVersion
+	}
+
+	if ($Version.StartsWith("5")) {
+		return "ES_CONFIG"
+	}
+	else {
+		return "CONF_DIR"
+	}
 }
 
 function Ping-Node([System.Timespan]$Timeout, $Domain, $Port) {
@@ -546,22 +563,24 @@ function Get-TotalPhysicalMemory() {
     return (Get-WmiObject Win32_PhysicalMemory | Measure-Object -Property Capacity -Sum).Sum / 1mb
 }
 
-function Get-ElasticsearchYamlConfiguration() {
-	$EsConfig = Get-MachineEnvironmentVariable "CONF_DIR"
+function Get-ElasticsearchYamlConfiguration($Version) {
+	$esConfigEnvVar = Get-ConfigEnvironmentVariableForVersion -Version $Version
+	$EsConfig = Get-MachineEnvironmentVariable $esConfigEnvVar
     $EsData = Split-Path $EsConfig -Parent | Join-Path -ChildPath "data"
 	return Get-Content "$EsData\elasticsearch.yml"
 }
 
-function Add-XPackSecurityCredentials($Username, $Password, $Roles) {
+function Add-XPackSecurityCredentials($Username, $Password, $Roles, $Version) {
     if (!$Roles) {
         $Roles = @("superuser")
     }
 
+	$esConfigEnvVar = Get-ConfigEnvironmentVariableForVersion -Version $Version
     $Service = Get-ElasticsearchService
     $Service | Stop-Service
 
     $EsHome = Get-MachineEnvironmentVariable "ES_HOME"
-    $EsConfig = Get-MachineEnvironmentVariable "CONF_DIR"
+    $EsConfig = Get-MachineEnvironmentVariable $esConfigEnvVar
     $EsUsersBat = Join-Path -Path $EsHome -ChildPath "bin\x-pack\users.bat"
     $ConcatRoles = [string]::Join(",", $Roles)
 
@@ -586,4 +605,18 @@ function Merge-Hashtables {
         }
     }
     return $Output
+}
+
+function Get-ExpectedServiceStatus($Version, $PreviousVersion) {	
+	$expectedStatus = "Running"
+
+	if ($PreviousVersion.Major -eq 5 -and $PreviousVersion.Minor -eq 5 `
+		-and $PreviousVersion.Patch -le 2 -and $PreviousVersion.SourceType -eq "Released" `
+	    -and $Version.Major -eq 5 -and $Version.Minor -eq 5 -and $Version.Patch -ge 3) {
+
+		Write-Output "Previous version is $($PreviousVersion.Description) and version is $($Version.Description). Expected status is Stopped."
+		$expectedStatus = "Stopped"
+	}
+
+	return $expectedStatus
 }

--- a/src/Tests/Elastic.Installer.Integration.Tests/Elastic.Installer.Integration.Tests.csproj
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Elastic.Installer.Integration.Tests.csproj
@@ -2,7 +2,4 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <Folder Include="Tests\SilentInstall-Upgrade" />
-  </ItemGroup>
 </Project>

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Default/SilentInstall-Default.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Default/SilentInstall-Default.Tests.ps1
@@ -6,7 +6,10 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
-Describe "Silent Install with default arguments" {
+Get-Version
+Get-PreviousVersions
+
+Describe "Silent Install with default arguments $(($Global:Version).FullVersion)" {
 
     Invoke-SilentInstall
 
@@ -22,10 +25,7 @@ Describe "Silent Install with default arguments" {
     $ProfileFolder = $env:ALLUSERSPROFILE
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
-    Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $version 
-		Path = $ExpectedConfigFolder
-	}
+    Context-EsConfigEnvironmentVariable
 
     Context-PluginsInstalled
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Default/SilentInstall-Default.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Default/SilentInstall-Default.Tests.ps1
@@ -4,6 +4,7 @@ Set-Location $currentDir
 # mapped sync folder for common scripts
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
 
 Describe "Silent Install with default arguments" {
 
@@ -21,7 +22,10 @@ Describe "Silent Install with default arguments" {
     $ProfileFolder = $env:ALLUSERSPROFILE
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
-    Context-EsConfigEnvironmentVariable -Expected $ExpectedConfigFolder
+    Context-EsConfigEnvironmentVariable -Expected @{ 
+		Version = $version 
+		Path = $ExpectedConfigFolder
+	}
 
     Context-PluginsInstalled
 
@@ -44,9 +48,9 @@ Describe "Silent Uninstall" {
 
 	Context-NodeNotRunning
 
-	Context-EnvironmentVariableNull -Name "CONF_DIR"
+	Context-EsConfigEnvironmentVariableNull
 
-	Context-EnvironmentVariableNull -Name "ES_HOME"
+	Context-EsHomeEnvironmentVariableNull
 
 	Context-MsiNotRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-DifferentLocations/SilentInstall-DifferentLocations.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-DifferentLocations/SilentInstall-DifferentLocations.Tests.ps1
@@ -4,6 +4,7 @@ Set-Location $currentDir
 # mapped sync folder for common scripts
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
 
 $InstallDir = "C:\temp dir\Elasticsearch\"
 $DataDir = "C:\foo\data"
@@ -22,7 +23,9 @@ Describe "Silent Install with different install locations" {
 
     Context-EsHomeEnvironmentVariable -Expected $InstallDir
 
-    Context-EsConfigEnvironmentVariable -Expected $ConfigDir
+    Context-EsConfigEnvironmentVariable -Expected @{  
+		Path = $ConfigDir
+	}
 
     Context-PluginsInstalled
 
@@ -34,7 +37,10 @@ Describe "Silent Install with different install locations" {
   
     Context-ClusterNameAndNodeName
 
-    Context-ElasticsearchConfiguration -Expected @{Data = $DataDir; Logs = $LogsDir }
+    Context-ElasticsearchConfiguration -Expected @{
+		Data = $DataDir 
+		Logs = $LogsDir 
+	}
 
     Context-JvmOptions
 }
@@ -45,9 +51,9 @@ Describe "Silent Uninstall with different install locations" {
 
 	Context-NodeNotRunning
 
-	Context-EnvironmentVariableNull -Name "CONF_DIR"
+	Context-EsConfigEnvironmentVariableNull
 
-	Context-EnvironmentVariableNull -Name "ES_HOME"
+	Context-EsHomeEnvironmentVariableNull
 
 	Context-MsiNotRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-DifferentLocations/SilentInstall-DifferentLocations.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-DifferentLocations/SilentInstall-DifferentLocations.Tests.ps1
@@ -11,6 +11,9 @@ $DataDir = "C:\foo\data"
 $ConfigDir = "C:\bar\config"
 $LogsDir = "C:\baz\logs"
 
+Get-Version
+Get-PreviousVersions
+
 Describe "Silent Install with different install locations" {
 
     $InstallLocations = "INSTALLDIR=$InstallDir","DATADIRECTORY=$DataDir","CONFIGDIRECTORY=$ConfigDir","LOGSDIRECTORY=$LogsDir"

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailDefault/SilentInstall-FailDefault.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailDefault/SilentInstall-FailDefault.Tests.ps1
@@ -4,11 +4,12 @@ Set-Location $currentDir
 # mapped sync folder for common scripts
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
 
 Describe "Silent Failed Install with default arguments" {
 
 	$startDate = Get-Date
-	$version = $env:EsVersion
+	$version = $Global:Version
 
 	Context "Failed installation" {
 		$exitCode = Invoke-SilentInstall -Exeargs @("WIXFAILWHENDEFERRED=1")
@@ -22,9 +23,9 @@ Describe "Silent Failed Install with default arguments" {
 
 	Context-NodeNotRunning
 
-	Context-EnvironmentVariableNull -Name "CONF_DIR"
+	Context-EsConfigEnvironmentVariableNull
 
-	Context-EnvironmentVariableNull -Name "ES_HOME"
+	Context-EsHomeEnvironmentVariableNull
 
 	Context-MsiNotRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailDefault/SilentInstall-FailDefault.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailDefault/SilentInstall-FailDefault.Tests.ps1
@@ -6,10 +6,13 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
+Get-Version
+Get-PreviousVersions
+
 Describe "Silent Failed Install with default arguments" {
 
 	$startDate = Get-Date
-	$version = $Global:Version
+	$version = $Global:Version.FullVersion
 
 	Context "Failed installation" {
 		$exitCode = Invoke-SilentInstall -Exeargs @("WIXFAILWHENDEFERRED=1")

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailUpgrade/SilentInstall-FailUpgrade.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailUpgrade/SilentInstall-FailUpgrade.Tests.ps1
@@ -7,6 +7,10 @@ Set-Location $currentDir
 . $currentDir\..\common\SemVer.ps1
 
 $credentials = "elastic:changeme"
+
+Get-Version
+Get-PreviousVersions
+
 $version = $Global:Version
 $previousVersion = $Global:PreviousVersions[0]
 
@@ -29,7 +33,7 @@ Describe -Tag 'PreviousVersions' "Silent Install fail upgrade - Install previous
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
     Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $v 
+		Version = $previousVersion
 		Path = $ExpectedConfigFolder
 	}
 
@@ -48,11 +52,11 @@ Describe -Tag 'PreviousVersions' "Silent Install fail upgrade - Install previous
 	Context-ClusterNameAndNodeName
 
     Context-ElasticsearchConfiguration -Expected @{
-		Version = $v
+		Version = $previousVersion
 	}
 
     Context-JvmOptions -Expected @{
-		Version = $v
+		Version = $previousVersion
 	}
 
 	Context-InsertData
@@ -112,7 +116,7 @@ Describe -Tag 'PreviousVersions' "Silent Install fail upgrade - Fail when upgrad
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
     Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $pv 
+		Version = $previousVersion
 		Path = $ExpectedConfigFolder
 	}
 
@@ -130,11 +134,11 @@ Describe -Tag 'PreviousVersions' "Silent Install fail upgrade - Fail when upgrad
 	Context-ClusterNameAndNodeName
 
     Context-ElasticsearchConfiguration -Expected @{
-		Version = $pv
+		Version = $previousVersion
 	}
 
     Context-JvmOptions -Expected @{
-		Version = $pv
+		Version = $previousVersion
 	}
 
 	# Check inserted data still exists

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-HeapSize/SilentInstall-HeapSize.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-HeapSize/SilentInstall-HeapSize.Tests.ps1
@@ -6,6 +6,9 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
+Get-Version
+Get-PreviousVersions
+
 Describe "Silent Install with 1024mb heap size" {
     $HeapSize = 1024
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-HeapSize/SilentInstall-HeapSize.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-HeapSize/SilentInstall-HeapSize.Tests.ps1
@@ -4,6 +4,7 @@ Set-Location $currentDir
 # mapped sync folder for common scripts
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
 
 Describe "Silent Install with 1024mb heap size" {
     $HeapSize = 1024
@@ -11,7 +12,9 @@ Describe "Silent Install with 1024mb heap size" {
     Invoke-SilentInstall @(,"SELECTEDMEMORY=$HeapSize")
 
     Context-PingNode -XPackSecurityInstalled $false
-    Context-JvmOptions -Expected 1024
+    Context-JvmOptions -Expected @{
+		Memory = $HeapSize
+	}
 
     Invoke-SilentUninstall
 }
@@ -22,9 +25,9 @@ Describe "Silent Uninstall with 1024mb heap size" {
 
 	Context-NodeNotRunning
 
-	Context-EnvironmentVariableNull -Name "CONF_DIR"
+	Context-EsConfigEnvironmentVariableNull
 
-	Context-EnvironmentVariableNull -Name "ES_HOME"
+	Context-EsHomeEnvironmentVariableNull
 
 	Context-MsiNotRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-NoPlugins/SilentInstall-NoPlugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-NoPlugins/SilentInstall-NoPlugins.Tests.ps1
@@ -4,6 +4,7 @@ Set-Location $currentDir
 # mapped sync folder for common scripts
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
 
 Describe "Silent Install with no plugins" {
 
@@ -22,9 +23,9 @@ Describe "Silent Uninstall with no plugins" {
 
 	Context-NodeNotRunning
 
-	Context-EnvironmentVariableNull -Name "CONF_DIR"
+	Context-EsConfigEnvironmentVariableNull
 
-	Context-EnvironmentVariableNull -Name "ES_HOME"
+	Context-EsHomeEnvironmentVariableNull
 
 	Context-MsiNotRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-NoPlugins/SilentInstall-NoPlugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-NoPlugins/SilentInstall-NoPlugins.Tests.ps1
@@ -6,6 +6,9 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
+Get-Version
+Get-PreviousVersions
+
 Describe "Silent Install with no plugins" {
 
     Invoke-SilentInstall -Exeargs @("PLUGINS=")

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
@@ -6,6 +6,9 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
+Get-Version
+Get-PreviousVersions
+
 Describe "Silent Install with x-pack, ingest-geoip and ingest-attachment plugins" {
 
     Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment")

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
@@ -4,6 +4,7 @@ Set-Location $currentDir
 # mapped sync folder for common scripts
 . $currentDir\..\common\Utils.ps1
 . $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
 
 Describe "Silent Install with x-pack, ingest-geoip and ingest-attachment plugins" {
 
@@ -22,9 +23,9 @@ Describe "Silent Uninstall with x-pack, ingest-geoip and ingest-attachment plugi
 
 	Context-NodeNotRunning
 
-	Context-EnvironmentVariableNull -Name "CONF_DIR"
+	Context-EsConfigEnvironmentVariableNull
 
-	Context-EnvironmentVariableNull -Name "ES_HOME"
+	Context-EsHomeEnvironmentVariableNull
 
 	Context-MsiNotRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradeDefault/SilentInstall-UpgradeDefault.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradeDefault/SilentInstall-UpgradeDefault.Tests.ps1
@@ -6,10 +6,13 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
+Get-Version
+Get-PreviousVersions
+
 $version = $Global:Version
 $previousVersion = $Global:PreviousVersions[0]
 
-Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous version $($previousVersion.Description)" {
+Describe -Tag 'PreviousVersions' "Silent Install upgrade - Install previous version $($previousVersion.Description)" {
 
 	$v = $previousVersion.FullVersion
 
@@ -28,7 +31,7 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous versi
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
     Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $v 
+		Version = $previousVersion
 		Path = $ExpectedConfigFolder
 	}
 
@@ -47,11 +50,11 @@ Describe -Tag 'PreviousVersion' "Silent Install upgrade - Install previous versi
 	Context-ClusterNameAndNodeName
 
     Context-ElasticsearchConfiguration -Expected @{
-		Version = $v
+		Version = $previousVersion
 	}
 
     Context-JvmOptions -Expected @{
-		Version = $v
+		Version = $previousVersion
 	}
 
 	# Insert some data
@@ -73,7 +76,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade - Upgrade from $($previ
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
     Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $v 
+		Version = $version 
 		Path = $ExpectedConfigFolder
 	}
 
@@ -96,18 +99,18 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade - Upgrade from $($previ
 	Context-ClusterNameAndNodeName
 
     Context-ElasticsearchConfiguration -Expected @{
-		Version = $v
+		Version = $version
 	}
 
     Context-JvmOptions -Expected @{
-		Version = $v
+		Version = $version
 	}
 
 	# Check inserted data still exists
 	Context-ReadData
 }
 
-Describe -Tag 'PreviousVersion' "Silent Uninstall upgrade - Uninstall new version $($version.Description)" {
+Describe -Tag 'PreviousVersions' "Silent Uninstall upgrade - Uninstall new version $($version.Description)" {
 
 	$v = $version.FullVersion
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradePlugins/SilentInstall-UpgradePlugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradePlugins/SilentInstall-UpgradePlugins.Tests.ps1
@@ -6,6 +6,9 @@ Set-Location $currentDir
 . $currentDir\..\common\CommonTests.ps1
 . $currentDir\..\common\SemVer.ps1
 
+Get-Version
+Get-PreviousVersions
+
 $credentials = "elastic:changeme"
 $version = $Global:Version
 $previousVersion = $Global:PreviousVersions[0]
@@ -29,7 +32,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade with plugins - Install 
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
     Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $v
+		Version = $previousVersion
 		Path = $ExpectedConfigFolder
 	}
 
@@ -48,11 +51,11 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade with plugins - Install 
 	Context-ClusterNameAndNodeName -Expected @{ Credentials = $credentials }
 
     Context-ElasticsearchConfiguration -Expected @{
-		Version = $v
+		Version = $previousVersion
 	}
 
     Context-JvmOptions -Expected @{
-		Version = $v
+		Version = $previousVersion
 	}
 
 	# Insert some data
@@ -74,7 +77,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade with plugins - Upgrade 
     $ExpectedConfigFolder = Join-Path -Path $ProfileFolder -ChildPath "Elastic\Elasticsearch\config"
 
     Context-EsConfigEnvironmentVariable -Expected @{ 
-		Version = $v 
+		Version = $version 
 		Path = $ExpectedConfigFolder
 	}
 
@@ -97,11 +100,11 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade with plugins - Upgrade 
 	Context-ClusterNameAndNodeName -Expected @{ Credentials = $credentials }
 
     Context-ElasticsearchConfiguration -Expected @{
-		Version = $v
+		Version = $version
 	}
 
     Context-JvmOptions -Expected @{
-		Version = $v
+		Version = $version
 	}
 
 	# Check inserted data still exists


### PR DESCRIPTION
Provide ability to run integration tests against official releases and build candidates. For example,

```bat
build.bat integrate es r:5.5.1,5.5.2 local * skiptests
```

Runs integration tests against a VirtualBox vagrant image locally, with upgrade scenarios testing upgrades from the official release of 5.5.1 against a newly compiled version of 5.5.2.

```bat
build.bat integrate es r:5.5.3,e824d65e:5.6.0 quick-azure * skiptests
```

Runs all integration tests against one Azure VM vagrant image, with upgrade scenarios testing upgrades from the official release of 5.5.3 against the build candidate e824d65e of 5.6.0.
