### PR TITLE
Always run DownloadProducts target

### DIFF
--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -137,7 +137,7 @@ Target "Help" (fun () -> trace Commandline.usage)
 
 "Clean"
   ==> "PatchGuids"
-  =?> ("DownloadProducts", (not ((getBuildParam "release") = "1")))
+  ==> "DownloadProducts"
   ==> "PruneFiles"
   =?> ("UnitTest", (not ((getBuildParam "skiptests") = "1")))
   ==> "BuildServices"


### PR DESCRIPTION
DownloadProducts both downloads, if not downloaded and unzips, if not unzipped.