### PR TITLE
Ability to specify HTTP and HTTPS proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ start /wait msiexec.exe /i elasticsearch-5.5.0.msi /qn /l elastic-install.log NO
 | USEEXISTINGUSER                  | Run the service as the specified `USER` | `false` |
 | USER                             | Existing user to run the service as     ||
 | PASSWORD                         | Password for the existing user          ||
-| PLUGINS                          | Comma-delimited list of plugins to install | |
+| HTTPPROXYHOST                    | Hostname of the HTTP proxy to use when downloading plugins. If specified, this will be the proxy used to download plugins from any HTTP scheme resource ||
+| HTTPPROXYPORT                    | Port of the HTTP proxy to use when downloading plugins | 80 |
+| HTTPSPROXYHOST                   | Hostname of the HTTPS proxy to use when downloading plugins. If specified, this will be the proxy used to download plugins from any HTTPS scheme resource, including https://artifacts.elastic.co ||
+| HTTPSPROXYPORT                   | Port of the HTTPS proxy to use when downloading plugins | 443 |
+| PLUGINS                          | Comma-delimited list of plugins to install ||
 
 ## Running as a service
 

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -12,11 +12,15 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Text.RegularExpressions
+open System.Net
 open Fake
 open FSharp.Data
 open FSharp.Text.RegexProvider
 open Products.Products
 open Products.Paths
+
+ServicePointManager.SecurityProtocol <- SecurityProtocolType.Ssl3 ||| SecurityProtocolType.Tls ||| SecurityProtocolType.Tls11 ||| SecurityProtocolType.Tls12;
+ServicePointManager.ServerCertificateValidationCallback <- (fun _ _ _ _ -> true)
 
 module Commandline =
 
@@ -118,8 +122,10 @@ Whether to skip unit tests.
 
     [<Literal>]
     let private feedUrl = "https://www.elastic.co/downloads/past-releases/feed"
-
-    type DownloadFeed = XmlProvider< feedUrl >
+    [<Literal>]
+    let private feedExample = "feed-example.xml"
+    
+    type DownloadFeed = XmlProvider< feedExample >
 
     type VersionRegex = Regex< @"^(?:\s*(?<Product>.*?)\s*)?((?<Source>\w*)\:)?(?<Version>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+)(?:\-(?<Prerelease>[\w\-]+))?)$", noMethodPrefix=true >
 

--- a/build/scripts/feed-example.xml
+++ b/build/scripts/feed-example.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title><![CDATA[Elasticsearch]]></title>
+        <description><![CDATA[Open Source Distributed Real Time Search & Analytics]]></description>
+        <link>https://www.elastic.co</link>
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Sat, 28 Oct 2017 12:49:17 GMT</lastBuildDate>
+        <pubDate>Sat, 28 Oct 2017 12:49:16 GMT</pubDate>
+        <language><![CDATA[en-us]]></language>
+        <item>
+            <title><![CDATA[Logstash Contrib 1.4.5]]></title>
+            <link>https://www.elastic.co/downloads/past-releases/logstash-1-4-5</link>
+            <guid isPermaLink="true">https://www.elastic.co/downloads/past-releases/logstash-1-4-5</guid>
+        </item>
+        <item>
+            <title><![CDATA[Elasticsearch 5.6.3]]></title>
+            <description><![CDATA[Elasticsearch 5.6.3]]></description>
+            <link>https://www.elastic.co/downloads/past-releases/elasticsearch-5-6-3</link>
+            <guid isPermaLink="true">https://www.elastic.co/downloads/past-releases/elasticsearch-5-6-3</guid>
+            <pubDate>Tue, 10 Oct 2017 18:00:01 GMT</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/src/Installer/Elastic.Installer.Domain/Configuration/Plugin/IPluginStateProvider.cs
+++ b/src/Installer/Elastic.Installer.Domain/Configuration/Plugin/IPluginStateProvider.cs
@@ -5,9 +5,14 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 {
 	public interface IPluginStateProvider
 	{
-		void Install(int pluginTicks, string installDirectory, string configDirectory, string plugin, params string[] additionalArguments);
-		void Remove(int pluginTicks, string installDirectory, string configDirectory, string plugin, params string[] additionalArguments);
-		IList<string> InstalledPlugins(string installDirectory, string configDirectory);
+		void Install(int pluginTicks, string installDirectory, string configDirectory, 
+			string plugin, string[] additionalArguments = null, IDictionary<string, string> environmentVariables = null);
+		
+		void Remove(int pluginTicks, string installDirectory, string configDirectory, 
+			string plugin, string[] additionalArguments = null, IDictionary<string, string> environmentVariables = null);
+		
+		IList<string> InstalledPlugins(string installDirectory, string configDirectory, IDictionary<string, string> environmentVariables = null);
+
 		Task<bool> HasInternetConnection();
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Configuration/Plugin/NoopPluginStateProvider.cs
+++ b/src/Installer/Elastic.Installer.Domain/Configuration/Plugin/NoopPluginStateProvider.cs
@@ -15,13 +15,13 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 			this.InstalledBefore = installedBefore;
 		}
 
-		public void Install(int pluginTicks, string installDirectory, string configDirectory, string plugin, params string[] additionalArguments) =>
+		public void Install(int pluginTicks, string installDirectory, string configDirectory, string plugin, string[] additionalArguments = null, IDictionary<string, string> environmentVariables = null) =>
 			this.InstalledAfter.Add(plugin);
 
-		public IList<string> InstalledPlugins(string installDirectory, string configDirectory) => 
+		public IList<string> InstalledPlugins(string installDirectory, string configDirectory, IDictionary<string, string> environmentVariables = null) => 
 			this.InstalledBefore?.ToList() ?? new List<string>();
 
-		public void Remove(int pluginTicks, string installDirectory, string configDirectory, string plugin, params string[] additionalArguments)
+		public void Remove(int pluginTicks, string installDirectory, string configDirectory, string plugin, string[] additionalArguments = null, IDictionary<string, string> environmentVariables = null)
 		{
 		}
 

--- a/src/Installer/Elastic.Installer.Domain/Configuration/Plugin/PluginStateProviderBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Configuration/Plugin/PluginStateProviderBase.cs
@@ -36,7 +36,7 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 			_fileSystem = fileSystem;
 		}
 
-		public IList<string> InstalledPlugins(string installDirectory, string configDirectory)
+		public IList<string> InstalledPlugins(string installDirectory, string configDirectory, IDictionary<string, string> environmentVariables = null)
 		{
 			var pluginsDirectory = Path.Combine(installDirectory, "plugins");
 			if (!this._fileSystem.Directory.Exists(pluginsDirectory)
@@ -45,15 +45,17 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 			
 			var command = "list";
 			var pluginScript = PluginScript(installDirectory);
-			var process = PluginProcess(configDirectory, pluginScript, command);
+			var process = PluginProcess(configDirectory, pluginScript, command, environmentVariables);
 			var sb = new StringBuilder();
-			DataReceivedEventHandler processOnOutputDataReceived = (sender, args) =>
+
+			void ProcessOnOutputDataReceived(object sender, DataReceivedEventArgs args)
 			{
 				var message = args.Data;
 				if (string.IsNullOrEmpty(message)) return;
 				sb.AppendLine(message);
-			};
-			var invokeResult = InvokeProcess(process, processOnOutputDataReceived);
+			}
+
+			var invokeResult = InvokeProcess(process, ProcessOnOutputDataReceived);
 			var exitCode = invokeResult.Item1;
 			var errors = invokeResult.Item2;
 			var errorOut = invokeResult.Item3;
@@ -73,15 +75,16 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 
 		public abstract DataReceivedEventHandler CreateInstallHandler(int perDownloadIncrement, string plugin);
 
-		public void Install(int pluginTicks, string installDirectory, string configDirectory, string plugin, params string[] additionalArguments)
+		public void Install(int pluginTicks, string installDirectory, string configDirectory, 
+			string plugin, string[] additionalArguments = null, IDictionary<string, string> environmentVariables = null)
 		{
 			var downloadingTicks = pluginTicks * 0.9;
 			var perDownloadIncrement = (int)Math.Floor(downloadingTicks / 100);
 			var installingTicks = pluginTicks - perDownloadIncrement * 100;
 
-			var command = $"install {plugin} {string.Join(" ", additionalArguments)}";
+			var command = $"install {plugin} {string.Join(" ", additionalArguments ?? Enumerable.Empty<string>())}";
 			var pluginScript = this.PluginScript(installDirectory);
-			var process = PluginProcess(configDirectory, pluginScript, command);
+			var process = PluginProcess(configDirectory, pluginScript, command, environmentVariables);
 			var processOnOutputDataReceived = CreateInstallHandler(perDownloadIncrement, plugin);
 			var invokeResult = InvokeProcess(process, processOnOutputDataReceived);
 			var exitCode = invokeResult.Item1;
@@ -92,19 +95,21 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 				throw new Exception($"Execution failed ({pluginScript} {command}). ExitCode: {exitCode} ErrorCheck: {errors} ErrorOut:{errorOut}");
 		}
 
-		public void Remove(int pluginTicks, string installDirectory, string configDirectory, string plugin, params string[] additionalArguments)
+		public void Remove(int pluginTicks, string installDirectory, string configDirectory, 
+			string plugin, string[] additionalArguments = null, IDictionary<string, string> environmentVariables = null)
 		{
-			var command = $"remove {plugin} {string.Join(" ", additionalArguments)}";
+			var command = $"remove {plugin} {string.Join(" ", additionalArguments ?? Enumerable.Empty<string>())}";
 			var pluginScript = this.PluginScript(installDirectory);
-			var process = PluginProcess(configDirectory, pluginScript, command);
+			var process = PluginProcess(configDirectory, pluginScript, command, environmentVariables);
 
-			DataReceivedEventHandler processOnOutputDataReceived = (sender, args) =>
+			void ProcessOnOutputDataReceived(object sender, DataReceivedEventArgs args)
 			{
 				var message = args.Data;
 				if (string.IsNullOrEmpty(message)) return;
 				Session.Log(message);
-			};
-			var invokeResult = InvokeProcess(process, processOnOutputDataReceived);
+			}
+
+			var invokeResult = InvokeProcess(process, ProcessOnOutputDataReceived);
 			var exitCode = invokeResult.Item1;
 			var errors = invokeResult.Item2;
 			var errorOut = invokeResult.Item3;
@@ -120,6 +125,7 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 
 			var errorsBuilder = new StringBuilder();
 			var errors = false;
+			
 			process.ErrorDataReceived += (s, a) =>
 			{
 				if (string.IsNullOrEmpty(a.Data)) return;
@@ -141,7 +147,8 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 			return Tuple.Create(exitCode, errors, errorsBuilder.ToString());
 		}
 
-		private static Process PluginProcess(string configDirectory, string pluginScript, string command)
+		private static Process PluginProcess(string configDirectory, string pluginScript, 
+			string command, IEnumerable<KeyValuePair<string,string>> environmentVariables = null)
 		{
 			var start = new ProcessStartInfo
 			{
@@ -154,14 +161,19 @@ namespace Elastic.Installer.Domain.Configuration.Plugin
 				CreateNoWindow = true,
 				UseShellExecute = false
 			};
-			start.EnvironmentVariables[ElasticsearchEnvironmentStateProvider.ConfDir] = configDirectory;
+
+			if (environmentVariables != null)
+			{
+				foreach (var environmentVariable in environmentVariables)
+					start.EnvironmentVariables[environmentVariable.Key] = environmentVariable.Value;
+			}
+			
 			return new Process { StartInfo = start };
 		}
 
 		private bool _hasInterNetConnection;
 		public async Task<bool> HasInternetConnection()
 		{
-			//if (_hasInterNetConnection) return true;
 			_hasInterNetConnection = await CanReadArtifactsUrl();
 			return _hasInterNetConnection;
 		}

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/InstallationModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/InstallationModelBase.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Elastic.Installer.Domain.Configuration.Wix;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Base.Closing;
+using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
 using Elastic.Installer.Domain.Properties;
 using FluentValidation;
 using FluentValidation.Results;
@@ -32,6 +33,7 @@ namespace Elastic.Installer.Domain.Model.Base
 
 		public ReactiveCommand<object> Next { get; }
 		public ReactiveCommand<object> Back { get; }
+		public ReactiveCommand<object> Proxy { get; }
 		public ReactiveCommand<object> Help { get; set; }
 		public ReactiveCommand<object> RefreshCurrentStep { get; }
 		public ReactiveCommand<object> ShowCurrentStepErrors { get; set; }
@@ -75,6 +77,7 @@ namespace Elastic.Installer.Domain.Model.Base
 			this.RefreshCurrentStep = ReactiveCommand.Create();
 			this.RefreshCurrentStep.Subscribe(x => { this.Steps[this.TabSelectedIndex].Refresh(); });
 			this.Exit = ReactiveCommand.Create();
+			this.Proxy = ReactiveCommand.Create();
 
 			this.WhenAny(vm => vm.TabSelectedIndex, v => v.GetValue())
 				.Subscribe(i =>
@@ -83,6 +86,7 @@ namespace Elastic.Installer.Domain.Model.Base
 					if (i == (c - 1)) this.NextButtonText = TextResources.SetupView_ExitText;
 					else if (i == (c - 2)) this.NextButtonText = TextResources.SetupView_InstallText;
 					else this.NextButtonText = TextResources.SetupView_NextText;
+					ProxyButtonVisible = c > 0 && ActiveStep is PluginsModel;
 				});
 
 			this.WhenAnyValue(view => view.ValidationFailures)
@@ -141,6 +145,13 @@ namespace Elastic.Installer.Domain.Model.Base
 		{
 			get => higherVersionAlreadyInstalled;
 			set => this.RaiseAndSetIfChanged(ref higherVersionAlreadyInstalled, value);
+		}
+
+		bool proxyButtonVisible;
+		public bool ProxyButtonVisible
+		{
+			get => proxyButtonVisible;
+			set => this.RaiseAndSetIfChanged(ref proxyButtonVisible, value);
 		}
 
 		public string ToMsiParamsString() => this.ParsedArguments.ToMsiParamsString();

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Elastic.Configuration.EnvironmentBased;
 using Elastic.Installer.Domain.Configuration.Plugin;
 using FluentValidation;
 using ReactiveUI;
@@ -50,9 +51,11 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 			this.AvailablePlugins.Clear();
 			var plugins = this.GetPlugins();
 			this.AvailablePlugins.AddRange(plugins);
+			
+			var environmentVariables = new Dictionary<string, string> { { ElasticsearchEnvironmentStateProvider.ConfDir, this.ConfigDirectory } };
 			var selectedPlugins = !this.AlreadyInstalled
 				? this.DefaultPlugins()
-				: this.PluginStateProvider.InstalledPlugins(this.InstallDirectory, this.ConfigDirectory).ToList();
+				: this.PluginStateProvider.InstalledPlugins(this.InstallDirectory, this.ConfigDirectory, environmentVariables).ToList();
 			foreach (var plugin in this.AvailablePlugins.Where(p => selectedPlugins.Contains(p.Url)))
 				plugin.Selected = true;
 		}

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Elastic.Installer.Domain.Configuration.Plugin;
 using Elastic.Installer.Domain.Model.Base.Plugins;
@@ -12,6 +13,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 {
 	public class PluginsModel : PluginsModelBase<PluginsModel, PluginsModelValidator>
 	{
+		private static readonly Regex Scheme = new Regex(@".*?:\/\/(.*)");
+
 		public const int HttpPortMinimum = 80;
 		public const int HttpsPortMinimum = 443;
 		public const int PortMaximum = 65535;
@@ -36,6 +39,29 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 			Observable.Timer(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(2))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(async _ => await SetInternetConnection());
+
+			this.SetHttpsProxy = ReactiveCommand.CreateAsyncTask(async _ => await this.HttpsProxyUITask());
+			this.WhenAnyObservable(vm => vm.SetHttpsProxy)
+				.Subscribe(x =>
+				{
+					// handle the cancel dialog button. Don't remove the current values
+					if (x == null) return;
+					
+					if (x.Length == 0)
+					{
+						HttpsProxyHost = null;
+						HttpsProxyPort = null;
+						return;
+					}
+
+					x = Scheme.Replace(x, "$1");
+					var proxyParts = x.Split(new [] { ':' }, 2);
+					this.HttpsProxyHost = proxyParts[0];
+
+					this.HttpsProxyPort = proxyParts.Length == 2 && int.TryParse(proxyParts[1], out var port) 
+						? (int?) port 
+						: null;
+				});
 		}
 
 		private async Task SetInternetConnection()
@@ -83,7 +109,14 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 		{
 			get => this.httpsProxyPort;
 			set => this.RaiseAndSetIfChanged(ref this.httpsProxyPort, value);
-		}	
+		}
+
+		public string HttpsProxyHostAndPort => this.HttpsProxyPort.HasValue
+			? $"{this.HttpsProxyHost}:{this.HttpsProxyPort}"
+			: this.HttpsProxyHost;
+
+		public Func<Task<string>> HttpsProxyUITask { get; set; }
+		public ReactiveCommand<string> SetHttpsProxy { get; }
 
 		protected override IEnumerable<Plugin> GetPlugins()
 		{
@@ -241,6 +274,16 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				DisplayName = "Store SMB",
 				Description = TextResources.PluginsModel_StoreSmb
 			};
+		}
+
+		public override void Refresh()
+		{
+			base.Refresh();
+
+			this.HttpProxyHost = null;
+			this.HttpProxyPort = null;
+			this.HttpsProxyHost = null;
+			this.HttpsProxyPort = null;		
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -12,6 +12,10 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 {
 	public class PluginsModel : PluginsModelBase<PluginsModel, PluginsModelValidator>
 	{
+		public const int HttpPortMinimum = 80;
+		public const int HttpsPortMinimum = 443;
+		public const int PortMaximum = 65535;
+
 		public PluginsModel(IPluginStateProvider pluginStateProvider, IObservable<Tuple<bool, string, string>> pluginDependencies)
 			: base(pluginStateProvider)
 		{

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -49,6 +49,38 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 			set => this.RaiseAndSetIfChanged(ref this.hasInternetConnection, value);
 		}
 
+		private string httpProxy;
+		[StaticArgument(nameof(HttpProxyHost))]
+		public string HttpProxyHost
+		{
+			get => this.httpProxy;
+			set => this.RaiseAndSetIfChanged(ref this.httpProxy, value);
+		}			
+		
+		private int? httpProxyPort;
+		[StaticArgument(nameof(HttpProxyPort))]
+		public int? HttpProxyPort
+		{
+			get => this.httpProxyPort;
+			set => this.RaiseAndSetIfChanged(ref this.httpProxyPort, value);
+		}		
+		
+		private string httpsProxyHost;
+		[StaticArgument(nameof(HttpsProxyHost))]
+		public string HttpsProxyHost
+		{
+			get => this.httpsProxyHost;
+			set => this.RaiseAndSetIfChanged(ref this.httpsProxyHost, value);
+		}
+		
+		private int? httpsProxyPort;
+		[StaticArgument(nameof(HttpsProxyPort))]
+		public int? HttpsProxyPort
+		{
+			get => this.httpsProxyPort;
+			set => this.RaiseAndSetIfChanged(ref this.httpsProxyPort, value);
+		}	
+
 		protected override IEnumerable<Plugin> GetPlugins()
 		{
 			yield return new Plugin

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModelValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Net;
 using Elastic.Installer.Domain.Properties;
 using FluentValidation;
@@ -7,7 +8,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 {
 	public class PluginsModelValidator : AbstractValidator<PluginsModel>
 	{
-		private static readonly string NoInternet = TextResources.PluginsModelValidator_NoInternet;
+		public static string NoInternet = TextResources.PluginsModelValidator_NoInternet;
+		public static string InvalidHttpProxyHost = TextResources.PluginsModelValidator_InvalidHttpProxyHost;
+		public static string InvalidHttpsProxyHost = TextResources.PluginsModelValidator_InvalidHttpsProxyHost;
 
 		public PluginsModelValidator()
 		{
@@ -15,6 +18,16 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				.Must(v => v)
 				.When(vm => vm.Plugins.Any())
 				.WithMessage(NoInternet);
+
+			RuleFor(vm => vm.HttpProxyHost)
+				.Must(v => Uri.CheckHostName(v) != UriHostNameType.Unknown)
+				.When(vm => !string.IsNullOrWhiteSpace(vm.HttpProxyHost))
+				.WithMessage(InvalidHttpProxyHost);
+
+			RuleFor(vm => vm.HttpsProxyHost)
+				.Must(v => Uri.CheckHostName(v) != UriHostNameType.Unknown)
+				.When(vm => !string.IsNullOrWhiteSpace(vm.HttpsProxyHost))
+				.WithMessage(InvalidHttpsProxyHost);
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModelValidator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Net;
 using Elastic.Installer.Domain.Properties;
 using FluentValidation;
 
@@ -10,7 +9,12 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 	{
 		public static string NoInternet = TextResources.PluginsModelValidator_NoInternet;
 		public static string InvalidHttpProxyHost = TextResources.PluginsModelValidator_InvalidHttpProxyHost;
+		public static string HttpProxyHostRequiredWhenPortSpecified = TextResources.PluginsModelValidator_HttpProxyHostRequiredWhenPortSpecified;
+		public static string InvalidHttpProxyPort = TextResources.PluginsModelValidator_InvalidHttpProxyPort;
+
 		public static string InvalidHttpsProxyHost = TextResources.PluginsModelValidator_InvalidHttpsProxyHost;
+		public static string HttpsProxyHostRequiredWhenPortSpecified = TextResources.PluginsModelValidator_HttpsProxyHostRequiredWhenPortSpecified;
+		public static string InvalidHttpsProxyPort = TextResources.PluginsModelValidator_InvalidHttpsProxyPort;
 
 		public PluginsModelValidator()
 		{
@@ -20,14 +24,36 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				.WithMessage(NoInternet);
 
 			RuleFor(vm => vm.HttpProxyHost)
+				.NotEmpty()
+				.When(vm => vm.HttpProxyPort.HasValue)
+				.WithMessage(HttpProxyHostRequiredWhenPortSpecified);
+
+			RuleFor(vm => vm.HttpProxyHost)
 				.Must(v => Uri.CheckHostName(v) != UriHostNameType.Unknown)
 				.When(vm => !string.IsNullOrWhiteSpace(vm.HttpProxyHost))
 				.WithMessage(InvalidHttpProxyHost);
+
+			RuleFor(vm => vm.HttpProxyPort)
+				.GreaterThanOrEqualTo(PluginsModel.HttpPortMinimum)
+				.WithMessage(string.Format(InvalidHttpProxyPort, PluginsModel.HttpPortMinimum, PluginsModel.PortMaximum))
+				.LessThanOrEqualTo(PluginsModel.PortMaximum)
+				.WithMessage(string.Format(InvalidHttpProxyPort, PluginsModel.HttpPortMinimum, PluginsModel.PortMaximum));
+
+			RuleFor(vm => vm.HttpsProxyHost)
+				.NotEmpty()
+				.When(vm => vm.HttpsProxyPort.HasValue)
+				.WithMessage(HttpsProxyHostRequiredWhenPortSpecified);
 
 			RuleFor(vm => vm.HttpsProxyHost)
 				.Must(v => Uri.CheckHostName(v) != UriHostNameType.Unknown)
 				.When(vm => !string.IsNullOrWhiteSpace(vm.HttpsProxyHost))
 				.WithMessage(InvalidHttpsProxyHost);
+
+			RuleFor(vm => vm.HttpsProxyPort)
+				.GreaterThanOrEqualTo(PluginsModel.HttpsPortMinimum)
+				.WithMessage(string.Format(InvalidHttpsProxyPort, PluginsModel.HttpsPortMinimum, PluginsModel.PortMaximum))
+				.LessThanOrEqualTo(PluginsModel.PortMaximum)
+				.WithMessage(string.Format(InvalidHttpsProxyPort, PluginsModel.HttpsPortMinimum, PluginsModel.PortMaximum));
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -865,6 +865,24 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTP proxy host is unknown. Enter a valid host name .
+        /// </summary>
+        public static string PluginsModelValidator_InvalidHttpProxyHost {
+            get {
+                return ResourceManager.GetString("PluginsModelValidator_InvalidHttpProxyHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HTTPS proxy host is unknown. Enter a valid host name.
+        /// </summary>
+        public static string PluginsModelValidator_InvalidHttpsProxyHost {
+            get {
+                return ResourceManager.GetString("PluginsModelValidator_InvalidHttpsProxyHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Plugin installation is online, meaning you need a connection to the 
         ///    internet to commence. Either deselect all plugins or connect 
         ///    to the internet and refresh the installer..

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -865,6 +865,24 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTP proxy host is required when HTTP proxy port is specified..
+        /// </summary>
+        public static string PluginsModelValidator_HttpProxyHostRequiredWhenPortSpecified {
+            get {
+                return ResourceManager.GetString("PluginsModelValidator_HttpProxyHostRequiredWhenPortSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HTTPS proxy host is required when HTTPS proxy port is specified..
+        /// </summary>
+        public static string PluginsModelValidator_HttpsProxyHostRequiredWhenPortSpecified {
+            get {
+                return ResourceManager.GetString("PluginsModelValidator_HttpsProxyHostRequiredWhenPortSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HTTP proxy host is unknown. Enter a valid host name .
         /// </summary>
         public static string PluginsModelValidator_InvalidHttpProxyHost {
@@ -874,11 +892,29 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTP proxy port must be between {0} and {1}..
+        /// </summary>
+        public static string PluginsModelValidator_InvalidHttpProxyPort {
+            get {
+                return ResourceManager.GetString("PluginsModelValidator_InvalidHttpProxyPort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HTTPS proxy host is unknown. Enter a valid host name.
         /// </summary>
         public static string PluginsModelValidator_InvalidHttpsProxyHost {
             get {
                 return ResourceManager.GetString("PluginsModelValidator_InvalidHttpsProxyHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HTTPS proxy port must be between {0} and {1}..
+        /// </summary>
+        public static string PluginsModelValidator_InvalidHttpsProxyPort {
+            get {
+                return ResourceManager.GetString("PluginsModelValidator_InvalidHttpsProxyPort", resourceCulture);
             }
         }
         

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -482,4 +482,18 @@ PLEASE NOTE: an uninstall will always remove the data folder be sure you move it
   <data name="PluginsModelValidator_InvalidHttpsProxyHost" xml:space="preserve">
     <value>HTTPS proxy host is unknown. Enter a valid host name</value>
   </data>
+  <data name="PluginsModelValidator_HttpProxyHostRequiredWhenPortSpecified" xml:space="preserve">
+    <value>HTTP proxy host is required when HTTP proxy port is specified.</value>
+  </data>
+  <data name="PluginsModelValidator_HttpsProxyHostRequiredWhenPortSpecified" xml:space="preserve">
+    <value>HTTPS proxy host is required when HTTPS proxy port is specified.</value>
+  </data>
+  <data name="PluginsModelValidator_InvalidHttpProxyPort" xml:space="preserve">
+    <value>HTTP proxy port must be between {0} and {1}.</value>
+    <comment>{0} = minimum port number. {1} = maximum port number</comment>
+  </data>
+  <data name="PluginsModelValidator_InvalidHttpsProxyPort" xml:space="preserve">
+    <value>HTTPS proxy port must be between {0} and {1}.</value>
+    <comment>{0} = minimum port number. {1} = maximum port number</comment>
+  </data>
 </root>

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -476,4 +476,10 @@ PLEASE NOTE: an uninstall will always remove the data folder be sure you move it
     internet to commence. Either deselect all plugins or connect 
     to the internet and refresh the installer.</value>
   </data>
+  <data name="PluginsModelValidator_InvalidHttpProxyHost" xml:space="preserve">
+    <value>HTTP proxy host is unknown. Enter a valid host name </value>
+  </data>
+  <data name="PluginsModelValidator_InvalidHttpsProxyHost" xml:space="preserve">
+    <value>HTTPS proxy host is unknown. Enter a valid host name</value>
+  </data>
 </root>

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="1f75dce6-5c9e-43c4-ad23-72d94bfec22d" Name="Elasticsearch 5.5.3" Language="1033" Codepage="Windows-1252" Version="5.5.3" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="72029505-94e9-4c29-a604-1da02d9d0402" Name="Elasticsearch 5.6.0" Language="1033" Codepage="Windows-1252" Version="5.6.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_5.5.3_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_5.6.0_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -17,15 +17,15 @@
             </Component>
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-5.5.3\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-5.6.0\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-5.5.3\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-5.6.0\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-5.5.3\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-5.6.0\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -44,19 +44,19 @@
               </Component>
 
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-5.5.3\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch.exe" />
 
                 <ServiceControl Id="elasticsearch.exe" Name="Elasticsearch" Stop="both" Wait="yes" />
               </Component>
@@ -71,15 +71,15 @@
               </Component>
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-5.5.3\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-5.6.0\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-5.5.3\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-5.6.0\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-5.5.3\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-5.6.0\config\log4j2.properties" />
               </Component>
 
             </Directory>
@@ -91,144 +91,144 @@
                 <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478134af927" Win64="yes">
-                <File Id="elasticsearch_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\elasticsearch-5.5.3.jar" />
+              <Component Id="Component.elasticsearch_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786103da43" Win64="yes">
+                <File Id="elasticsearch_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\elasticsearch-5.6.0.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component.java_version_checker_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c981c2cd" Win64="yes">
-                <File Id="java_version_checker_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\java-version-checker-5.5.3.jar" />
+              <Component Id="Component.java_version_checker_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f8fc2cd" Win64="yes">
+                <File Id="java_version_checker_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\java-version-checker-5.6.0.jar" />
               </Component>
 
-              <Component Id="Component.jna_4.4.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa115652" Win64="yes">
-                <File Id="jna_4.4.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jna-4.4.0.jar" />
+              <Component Id="Component.jna_4.4.0_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838772020" Win64="yes">
+                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jna-4.4.0-1.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jts-1.13.jar" />
               </Component>
 
-              <Component Id="Component.log4j_1.2_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd896f3f" Win64="yes">
-                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\log4j-1.2-api-2.8.2.jar" />
+              <Component Id="Component.log4j_1.2_api_2.9.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e50" Win64="yes">
+                <File Id="log4j_1.2_api_2.9.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\log4j-1.2-api-2.9.0.jar" />
               </Component>
 
-              <Component Id="Component.log4j_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830b6218a" Win64="yes">
-                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\log4j-api-2.8.2.jar" />
+              <Component Id="Component.log4j_api_2.9.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f03ff" Win64="yes">
+                <File Id="log4j_api_2.9.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\log4j-api-2.9.0.jar" />
               </Component>
 
-              <Component Id="Component.log4j_core_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b3cb698" Win64="yes">
-                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\log4j-core-2.8.2.jar" />
+              <Component Id="Component.log4j_core_2.9.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7efb698" Win64="yes">
+                <File Id="log4j_core_2.9.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\log4j-core-2.9.0.jar" />
               </Component>
 
               <Component Id="Component._...ene_analyzers_common_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818972dca" Win64="yes">
-                <File Id="_...ene_analyzers_common_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-analyzers-common-6.6.0.jar" />
+                <File Id="_...ene_analyzers_common_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-analyzers-common-6.6.0.jar" />
               </Component>
 
               <Component Id="Component._...cene_backward_codecs_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478587b7ac6" Win64="yes">
-                <File Id="_...cene_backward_codecs_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-backward-codecs-6.6.0.jar" />
+                <File Id="_...cene_backward_codecs_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-backward-codecs-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_core_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820309523" Win64="yes">
-                <File Id="lucene_core_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-core-6.6.0.jar" />
+                <File Id="lucene_core_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-core-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_grouping_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478200823f6" Win64="yes">
-                <File Id="lucene_grouping_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-grouping-6.6.0.jar" />
+                <File Id="lucene_grouping_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-grouping-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_highlighter_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cf520fdb" Win64="yes">
-                <File Id="lucene_highlighter_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-highlighter-6.6.0.jar" />
+                <File Id="lucene_highlighter_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-highlighter-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_join_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788bdd052a" Win64="yes">
-                <File Id="lucene_join_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-join-6.6.0.jar" />
+                <File Id="lucene_join_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-join-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_memory_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547821ad2a45" Win64="yes">
-                <File Id="lucene_memory_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-memory-6.6.0.jar" />
+                <File Id="lucene_memory_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-memory-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_misc_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868e10357" Win64="yes">
-                <File Id="lucene_misc_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-misc-6.6.0.jar" />
+                <File Id="lucene_misc_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-misc-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_queries_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478acaa136d" Win64="yes">
-                <File Id="lucene_queries_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-queries-6.6.0.jar" />
+                <File Id="lucene_queries_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-queries-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_queryparser_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785a63e130" Win64="yes">
-                <File Id="lucene_queryparser_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-queryparser-6.6.0.jar" />
+                <File Id="lucene_queryparser_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-queryparser-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_sandbox_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547865c0a387" Win64="yes">
-                <File Id="lucene_sandbox_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-sandbox-6.6.0.jar" />
+                <File Id="lucene_sandbox_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-sandbox-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_spatial_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785099eaf2" Win64="yes">
-                <File Id="lucene_spatial_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-spatial-6.6.0.jar" />
+                <File Id="lucene_spatial_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-spatial-6.6.0.jar" />
               </Component>
 
               <Component Id="Component._...ucene_spatial_extras_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478101d1172" Win64="yes">
-                <File Id="_...ucene_spatial_extras_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-spatial-extras-6.6.0.jar" />
+                <File Id="_...ucene_spatial_extras_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-spatial-extras-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_spatial3d_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fe531cc7" Win64="yes">
-                <File Id="lucene_spatial3d_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-spatial3d-6.6.0.jar" />
+                <File Id="lucene_spatial3d_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-spatial3d-6.6.0.jar" />
               </Component>
 
               <Component Id="Component.lucene_suggest_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c90c821" Win64="yes">
-                <File Id="lucene_suggest_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\lucene-suggest-6.6.0.jar" />
+                <File Id="lucene_suggest_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-suggest-6.6.0.jar" />
               </Component>
 
-              <Component Id="Component.plugin_cli_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ae9f650f" Win64="yes">
-                <File Id="plugin_cli_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\plugin-cli-5.5.3.jar" />
+              <Component Id="Component.plugin_cli_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781529650f" Win64="yes">
+                <File Id="plugin_cli_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\plugin-cli-5.6.0.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -241,12 +241,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.aggs_matrix_stats_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478261442da" Win64="yes">
-                  <File Id="aggs_matrix_stats_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\aggs-matrix-stats\aggs-matrix-stats-5.5.3.jar" />
+                <Component Id="Component.aggs_matrix_stats_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547874cd2334" Win64="yes">
+                  <File Id="aggs_matrix_stats_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\aggs-matrix-stats\aggs-matrix-stats-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -258,20 +258,20 @@
                   <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.ingest_common_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547872ac12f9" Win64="yes">
-                  <File Id="ingest_common_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\ingest-common-5.5.3.jar" />
+                <Component Id="Component.ingest_common_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d7e95dd" Win64="yes">
+                  <File Id="ingest_common_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\ingest-common-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\ingest-common\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -284,35 +284,35 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component.lang_expression_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547869913535" Win64="yes">
-                  <File Id="lang_expression_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\lang-expression-5.5.3.jar" />
+                <Component Id="Component.lang_expression_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a576270d" Win64="yes">
+                  <File Id="lang_expression_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\lang-expression-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_expressions_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bdb326c8" Win64="yes">
-                  <File Id="lucene_expressions_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\lucene-expressions-6.6.0.jar" />
+                  <File Id="lucene_expressions_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\lucene-expressions-6.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-expression\plugin-security.policy" />
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -325,19 +325,19 @@
                 </Component>
 
                 <Component Id="Component.groovy_2.4.6_indy.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c4b086e8" Win64="yes">
-                  <File Id="groovy_2.4.6_indy.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\groovy-2.4.6-indy.jar" />
+                  <File Id="groovy_2.4.6_indy.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\groovy-2.4.6-indy.jar" />
                 </Component>
 
-                <Component Id="Component.lang_groovy_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782da4b593" Win64="yes">
-                  <File Id="lang_groovy_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\lang-groovy-5.5.3.jar" />
+                <Component Id="Component.lang_groovy_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787a5d96af" Win64="yes">
+                  <File Id="lang_groovy_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\lang-groovy-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-groovy\plugin-security.policy" />
+                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -350,19 +350,19 @@
                 </Component>
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784419a698" Win64="yes">
-                  <File Id="lang_mustache_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\lang-mustache-5.5.3.jar" />
+                <Component Id="Component.lang_mustache_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547829dc94d8" Win64="yes">
+                  <File Id="lang_mustache_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\lang-mustache-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-mustache\plugin-security.policy" />
+                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -375,23 +375,23 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547840c9a1fe" Win64="yes">
-                  <File Id="lang_painless_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\lang-painless-5.5.3.jar" />
+                <Component Id="Component.lang_painless_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818205544" Win64="yes">
+                  <File Id="lang_painless_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\lang-painless-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\lang-painless\plugin-security.policy" />
+                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -403,12 +403,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.parent_join_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478aba0a9e7" Win64="yes">
-                  <File Id="parent_join_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\parent-join\parent-join-5.5.3.jar" />
+                <Component Id="Component.parent_join_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f8598ac1" Win64="yes">
+                  <File Id="parent_join_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\parent-join\parent-join-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\parent-join\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\parent-join\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -420,12 +420,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.percolator_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d894ddf2" Win64="yes">
-                  <File Id="percolator_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\percolator\percolator-5.5.3.jar" />
+                <Component Id="Component.percolator_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786194ddf2" Win64="yes">
+                  <File Id="percolator_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\percolator\percolator-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\percolator\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\percolator\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -438,39 +438,43 @@
                 </Component>
 
                 <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
-                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\commons-codec-1.10.jar" />
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\commons-codec-1.10.jar" />
                 </Component>
 
                 <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
-                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\commons-logging-1.1.3.jar" />
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\commons-logging-1.1.3.jar" />
+                </Component>
+
+                <Component Id="Component._...icsearch_rest_client_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547842d1608f" Win64="yes">
+                  <File Id="_...icsearch_rest_client_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\elasticsearch-rest-client-5.6.0.jar" />
                 </Component>
 
                 <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
-                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpasyncclient-4.1.2.jar" />
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpasyncclient-4.1.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
-                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpclient-4.5.2.jar" />
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpclient-4.5.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
-                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpcore-4.4.5.jar" />
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpcore-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
-                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\httpcore-nio-4.4.5.jar" />
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.reindex_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547884ba0af4" Win64="yes">
-                  <File Id="reindex_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\reindex-5.5.3.jar" />
+                <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
+                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.rest_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbf23a5b" Win64="yes">
-                  <File Id="rest_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\reindex\rest-5.5.3.jar" />
+                <Component Id="Component.reindex_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547836012a9a" Win64="yes">
+                  <File Id="reindex_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\reindex-5.6.0.jar" />
                 </Component>
 
               </Directory>
@@ -483,19 +487,19 @@
                 </Component>
 
                 <Component Id="Component.netty_3.10.6.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786aa11ed2" Win64="yes">
-                  <File Id="netty_3.10.6.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\netty-3.10.6.Final.jar" />
+                  <File Id="netty_3.10.6.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\netty-3.10.6.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
+                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty3_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785d681d4e" Win64="yes">
-                  <File Id="transport_netty3_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty3\transport-netty3-5.5.3.jar" />
+                <Component Id="Component.transport_netty3_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783ec41d4e" Win64="yes">
+                  <File Id="transport_netty3_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\transport-netty3-5.6.0.jar" />
                 </Component>
 
               </Directory>
@@ -507,44 +511,44 @@
                   <RemoveFolder Id="INSTALLDIR.modules.transport_netty4.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.netty_buffer_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881351e3b" Win64="yes">
-                  <File Id="netty_buffer_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-buffer-4.1.11.Final.jar" />
+                <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
+                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component.netty_codec_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547885592eca" Win64="yes">
-                  <File Id="netty_codec_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-codec-4.1.11.Final.jar" />
+                <Component Id="Component.netty_codec_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478677b2eca" Win64="yes">
+                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component._...ty_codec_http_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d644a9fe" Win64="yes">
-                  <File Id="_...ty_codec_http_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-codec-http-4.1.11.Final.jar" />
+                <Component Id="Component._...ty_codec_http_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bebaa9fe" Win64="yes">
+                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component.netty_common_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7fe90e" Win64="yes">
-                  <File Id="netty_common_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-common-4.1.11.Final.jar" />
+                <Component Id="Component.netty_common_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7df66c" Win64="yes">
+                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component.netty_handler_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780908ab4a" Win64="yes">
-                  <File Id="netty_handler_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-handler-4.1.11.Final.jar" />
+                <Component Id="Component.netty_handler_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fda2ab4a" Win64="yes">
+                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component._...etty_resolver_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785ae2d95f" Win64="yes">
-                  <File Id="_...etty_resolver_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-resolver-4.1.11.Final.jar" />
+                <Component Id="Component._...etty_resolver_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785164d95f" Win64="yes">
+                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component._...tty_transport_4.1.11.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b258d01b" Win64="yes">
-                  <File Id="_...tty_transport_4.1.11.Final.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\netty-transport-4.1.11.Final.jar" />
+                <Component Id="Component._...tty_transport_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbded01b" Win64="yes">
+                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.10" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae8" Win64="yes">
-                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.6" Guid="daaa2cba-a1ed-4f29-afbf-5478374d00dd" Win64="yes">
+                  <File Id="plugin_security.policy.6" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty4_5.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547870411d4e" Win64="yes">
-                  <File Id="transport_netty4_5.5.3.jar" Source="..\..\..\build\in\elasticsearch-5.5.3\modules\transport-netty4\transport-netty4-5.5.3.jar" />
+                <Component Id="Component.transport_netty4_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850db1d4e" Win64="yes">
+                  <File Id="transport_netty4_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\transport-netty4-5.6.0.jar" />
                 </Component>
 
               </Directory>
@@ -564,8 +568,8 @@
     </UI>
 
     <Upgrade Id="daaa2cba-a1ed-4f29-afbf-5478617b00f6">
-      <UpgradeVersion Minimum="0.0.0.0" Maximum="5.5.3" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
-      <UpgradeVersion Minimum="5.5.3" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
+      <UpgradeVersion Minimum="0.0.0.0" Maximum="5.6.0" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
+      <UpgradeVersion Minimum="5.6.0" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
     </Upgrade>
 
     <Icon Id="app_icon.ico" SourceFile="Resources\elasticsearch.ico" />
@@ -574,47 +578,47 @@
     <CustomAction Id="Action2SetProp_CONFIGDIRECTORY" Property="CONFIGDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\config" Return="check" Execute="immediate" />
     <CustomAction Id="Action3SetProp_LOGSDIRECTORY" Property="LOGSDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\logs" Return="check" Execute="immediate" />
     <CustomAction Id="Action4SetProp_NODENAME" Property="NODENAME" Value="[%COMPUTERNAME]" Return="check" Execute="immediate" />
-    <CustomAction Id="ElasticsearchValidateArgumentsAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchValidateArguments" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchUninstallServiceAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchUninstallService" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchRollbackEnvironmentAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchRollbackEnvironment" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchCleanupAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchCleanup" Return="ignore" Impersonate="no" Execute="commit" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchUninstallPluginsAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchUninstallPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchRollbackDirectoriesAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchRollbackDirectories" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchUninstallDirectoriesAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchUninstallDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchRollbackServiceStartAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchRollbackServiceStart" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchPreserveInstallAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchPreserveInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchUninstallEnvironmentAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchUninstallEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchRollbackInstallServiceAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchRollbackInstallService" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchEnvironmentAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchDirectoriesAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchConfigurationAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchConfiguration" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchJvmOptionsAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchJvmOptions" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchPluginsAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchServiceInstallAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchServiceInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
-    <CustomAction Id="ElasticsearchServiceStartAction" BinaryKey="ElasticsearchValidateArgumentsAction_File" DllEntry="ElasticsearchServiceStart" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchUninstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallService" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchRollbackEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackEnvironment" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
+    <CustomAction Id="ElasticsearchValidateArgumentsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchValidateArguments" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchCleanupAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchCleanup" Return="ignore" Impersonate="no" Execute="commit" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchUninstallPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchRollbackDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackDirectories" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchUninstallDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchRollbackServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackServiceStart" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchPreserveInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPreserveInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchUninstallEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchRollbackInstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackInstallService" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchConfigurationAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchConfiguration" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchJvmOptionsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchJvmOptions" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchServiceInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceStart" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
     <CustomAction Id="PreventDowngrading" Error="Newer version already installed" />
 
-    <Binary Id="ElasticsearchValidateArgumentsAction_File" SourceFile="%this%.CA.dll" />
+    <Binary Id="ElasticsearchUninstallServiceAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="5.5.3" />
+    <Property Id="CurrentVersion" Value="5.6.0" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -631,6 +635,10 @@
     <Property Id="LOCKMEMORY" Value="false" />
     <Property Id="HTTPPORT" Value="9200" />
     <Property Id="TRANSPORTPORT" Value="9300" />
+    <Property Id="HTTPPROXYHOST" />
+    <Property Id="HTTPPROXYPORT" />
+    <Property Id="HTTPSPROXYHOST" />
+    <Property Id="HTTPSPROXYPORT" />
     <Property Id="PLUGINS" />
     <Property Id="ARPHELPLINK" Value="https://discuss.elastic.co/c/elasticsearch" />
     <Property Id="ARPPRODUCTICON" Value="app_icon.ico" />
@@ -647,21 +655,21 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_5.5.3.jar" />
+      <ComponentRef Id="Component.elasticsearch_5.6.0.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component.java_version_checker_5.5.3.jar" />
-      <ComponentRef Id="Component.jna_4.4.0.jar" />
+      <ComponentRef Id="Component.java_version_checker_5.6.0.jar" />
+      <ComponentRef Id="Component.jna_4.4.0_1.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
       <ComponentRef Id="Component.jts_1.13.jar" />
-      <ComponentRef Id="Component.log4j_1.2_api_2.8.2.jar" />
-      <ComponentRef Id="Component.log4j_api_2.8.2.jar" />
-      <ComponentRef Id="Component.log4j_core_2.8.2.jar" />
+      <ComponentRef Id="Component.log4j_1.2_api_2.9.0.jar" />
+      <ComponentRef Id="Component.log4j_api_2.9.0.jar" />
+      <ComponentRef Id="Component.log4j_core_2.9.0.jar" />
       <ComponentRef Id="Component._...ene_analyzers_common_6.6.0.jar" />
       <ComponentRef Id="Component._...cene_backward_codecs_6.6.0.jar" />
       <ComponentRef Id="Component.lucene_core_6.6.0.jar" />
@@ -677,14 +685,14 @@
       <ComponentRef Id="Component._...ucene_spatial_extras_6.6.0.jar" />
       <ComponentRef Id="Component.lucene_spatial3d_6.6.0.jar" />
       <ComponentRef Id="Component.lucene_suggest_6.6.0.jar" />
-      <ComponentRef Id="Component.plugin_cli_5.5.3.jar" />
+      <ComponentRef Id="Component.plugin_cli_5.6.0.jar" />
       <ComponentRef Id="Component.securesm_1.1.jar" />
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component.aggs_matrix_stats_5.5.3.jar" />
+      <ComponentRef Id="Component.aggs_matrix_stats_5.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.ingest_common_5.5.3.jar" />
+      <ComponentRef Id="Component.ingest_common_5.6.0.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.1" />
@@ -692,50 +700,51 @@
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component.lang_expression_5.5.3.jar" />
+      <ComponentRef Id="Component.lang_expression_5.6.0.jar" />
       <ComponentRef Id="Component.lucene_expressions_6.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.2" />
       <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.groovy_2.4.6_indy.jar" />
-      <ComponentRef Id="Component.lang_groovy_5.5.3.jar" />
+      <ComponentRef Id="Component.lang_groovy_5.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.3" />
       <ComponentRef Id="Component.plugin_security.policy.1" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_5.5.3.jar" />
+      <ComponentRef Id="Component.lang_mustache_5.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.4" />
       <ComponentRef Id="Component.plugin_security.policy.2" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_5.5.3.jar" />
+      <ComponentRef Id="Component.lang_painless_5.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.5" />
       <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.parent_join_5.5.3.jar" />
+      <ComponentRef Id="Component.parent_join_5.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.6" />
-      <ComponentRef Id="Component.percolator_5.5.3.jar" />
+      <ComponentRef Id="Component.percolator_5.6.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.7" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
+      <ComponentRef Id="Component._...icsearch_rest_client_5.6.0.jar" />
       <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
       <ComponentRef Id="Component.httpclient_4.5.2.jar" />
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.8" />
-      <ComponentRef Id="Component.reindex_5.5.3.jar" />
-      <ComponentRef Id="Component.rest_5.5.3.jar" />
+      <ComponentRef Id="Component.plugin_security.policy.4" />
+      <ComponentRef Id="Component.reindex_5.6.0.jar" />
       <ComponentRef Id="Component.netty_3.10.6.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.9" />
-      <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.transport_netty3_5.5.3.jar" />
-      <ComponentRef Id="Component.netty_buffer_4.1.11.Final.jar" />
-      <ComponentRef Id="Component.netty_codec_4.1.11.Final.jar" />
-      <ComponentRef Id="Component._...ty_codec_http_4.1.11.Final.jar" />
-      <ComponentRef Id="Component.netty_common_4.1.11.Final.jar" />
-      <ComponentRef Id="Component.netty_handler_4.1.11.Final.jar" />
-      <ComponentRef Id="Component._...etty_resolver_4.1.11.Final.jar" />
-      <ComponentRef Id="Component._...tty_transport_4.1.11.Final.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.10" />
       <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component.transport_netty4_5.5.3.jar" />
+      <ComponentRef Id="Component.transport_netty3_5.6.0.jar" />
+      <ComponentRef Id="Component.netty_buffer_4.1.13.Final.jar" />
+      <ComponentRef Id="Component.netty_codec_4.1.13.Final.jar" />
+      <ComponentRef Id="Component._...ty_codec_http_4.1.13.Final.jar" />
+      <ComponentRef Id="Component.netty_common_4.1.13.Final.jar" />
+      <ComponentRef Id="Component.netty_handler_4.1.13.Final.jar" />
+      <ComponentRef Id="Component._...etty_resolver_4.1.13.Final.jar" />
+      <ComponentRef Id="Component._...tty_transport_4.1.13.Final.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.10" />
+      <ComponentRef Id="Component.plugin_security.policy.6" />
+      <ComponentRef Id="Component.transport_netty4_5.6.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR" />
       <ComponentRef Id="Component.INSTALLDIR.bin.xpack" />
       <ComponentRef Id="Component.INSTALLDIR.bin" />
@@ -759,11 +768,11 @@
       <Custom Action="Action2SetProp_CONFIGDIRECTORY" After="Action1SetProp_DATADIRECTORY">(NOT Installed) AND (CONFIGDIRECTORY="")</Custom>
       <Custom Action="Action3SetProp_LOGSDIRECTORY" After="Action2SetProp_CONFIGDIRECTORY">(NOT Installed) AND (LOGSDIRECTORY="")</Custom>
       <Custom Action="Action4SetProp_NODENAME" After="Action3SetProp_LOGSDIRECTORY">(NOT Installed) AND (NODENAME="")</Custom>
-      <Custom Action="ElasticsearchValidateArgumentsAction" After="InstallInitialize"> (1) </Custom>
       <Custom Action="Set_ElasticsearchUninstallServiceAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchUninstallServiceAction" After="ElasticsearchUninstallPluginsAction">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
       <Custom Action="Set_ElasticsearchRollbackEnvironmentAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchRollbackEnvironmentAction" Before="ElasticsearchEnvironmentAction" />
+      <Custom Action="ElasticsearchValidateArgumentsAction" After="InstallInitialize"> (1) </Custom>
       <Custom Action="Set_ElasticsearchCleanupAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchCleanupAction" Before="InstallFinalize" />
       <Custom Action="Set_ElasticsearchUninstallPluginsAction_Props" After="InstallInitialize" />

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml
@@ -76,7 +76,8 @@
     <Grid Margin="10, 0, 10, 0">
       <Grid.RowDefinitions>
         <RowDefinition Height="*" />
-        <RowDefinition Height="75" />
+        <RowDefinition Height="45" />
+        <RowDefinition Height="30" />
       </Grid.RowDefinitions>
       <controls:MetroAnimatedSingleRowTabControl x:Name="StepsTab" Grid.Row="0" Padding="-5" Margin="0, 0, 0,0 "/>
       <Grid Grid.Row="1" Margin="5, 0,0,0">
@@ -84,6 +85,7 @@
           <ColumnDefinition Width="50"/>
           <ColumnDefinition Width="50"/>
           <ColumnDefinition Width="50"/>
+          <ColumnDefinition Width="100"/>
           <ColumnDefinition Width="*"/>
           <ColumnDefinition Width="100"/>
           <ColumnDefinition Width="10"/>
@@ -117,7 +119,8 @@
             </Rectangle.Fill>
           </Rectangle>
         </Button>
-        <TextBlock x:Name="ValidationErrorLink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Top" FontWeight="SemiBold">
+        <Button x:Name="ProxyButton" Grid.Column="3" Content="Proxy" Command="{Binding Path=Proxy}" Height="40"  HorizontalAlignment="Left" Padding="0,0,0,0" VerticalAlignment="Top" Width="100" />
+        <TextBlock x:Name="ValidationErrorLink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Top" FontWeight="SemiBold">
           <TextBlock.InputBindings>
             <MouseBinding Command="{Binding Path=ShowCurrentStepErrors}" MouseAction="LeftClick" />
           </TextBlock.InputBindings>
@@ -134,9 +137,10 @@
             </Style>
           </TextBlock.Style>
         </TextBlock>
-        <Button x:Name="BackButton" Grid.Column="4" Content="Back" Command="{Binding Path=Back}" Height="40"  HorizontalAlignment="Left" Padding="0,0,0,0" VerticalAlignment="Top" Width="100" />
-        <Button x:Name="NextButton" Grid.Column="6" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top" Width="100" Height="40" />
+        <Button x:Name="BackButton" Grid.Column="5" Content="Back" Command="{Binding Path=Back}" Height="40"  HorizontalAlignment="Left" Padding="0,0,0,0" VerticalAlignment="Top" Width="100" />
+        <Button x:Name="NextButton" Grid.Column="7" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top" Width="100" Height="40" />
       </Grid>
+      <Label x:Name="ProxyLabel" Grid.Row="2" HorizontalAlignment="Left" Padding="10,0,0,0" VerticalAlignment="Top" Foreground="{DynamicResource AccentColorBrush2}" FontSize="14"></Label>
     </Grid>
   </controls:MetroContentControl>
 </controls:MetroWindow>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml
@@ -103,11 +103,11 @@
       <TextBox Grid.Row="1" Grid.Column="1" x:Name="NetworkHostTextBox" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="30"  VerticalAlignment="Center" />
       <Label Grid.Row="2" Grid.Column="0" x:Name="HttpPortLabel" Content="{x:Static resx:ViewResources.ConfigurationView_HttpPortLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" />
       <mahapps:NumericUpDown  Grid.Row="2" Grid.Column="1" x:Name="HttpPortTextBox" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" 
-         StringFormat="{}{0:0}" 
+         StringFormat="{}{0:0}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
       />
       <Label Grid.Row="2" Grid.Column="2" x:Name="TransportPortLabel" Content="{x:Static resx:ViewResources.ConfigurationView_TransportPortLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" />
       <mahapps:NumericUpDown  Grid.Row="2" Grid.Column="3" x:Name="TransportPortTextBox" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" 
-          StringFormat="{}{0:0}" 
+          StringFormat="{}{0:0}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
       />
       
       

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml.cs
@@ -118,7 +118,6 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 				this.MinimumMasterTextBox.StringFormat = ViewResources.ConfigurationView_MinimumMasterNodesNotSet;
 				this.MinimumMasterTextBox.FontWeight = FontWeights.Normal;
 				this.MinimumMasterTextBox.Foreground = this._defaultBrush;
-
 			}
 			else
 			{

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml
@@ -4,55 +4,13 @@
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                      xmlns:resx="clr-namespace:Elastic.Installer.UI.Properties"
-                      xmlns:mahapps="http://metro.mahapps.com/winfx/xaml/controls"
                       xmlns:controls="clr-namespace:Elastic.Installer.UI.Controls"
                       xmlns:steps="clr-namespace:Elastic.Installer.UI.Elasticsearch.Steps"
                       xmlns:plugins="clr-namespace:Elastic.Installer.Domain.Model.Elasticsearch.Plugins;assembly=Elastic.Installer.Domain"
                       mc:Ignorable="d"
                       d:DataContext="{d:DesignInstance d:Type=plugins:PluginsModel }"
                       d:DesignHeight="300" d:DesignWidth="600">
-  
-  
-  
-  <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
-
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="*" />
-    </Grid.RowDefinitions>
-
-    <Grid Grid.Row="0" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="Auto"/>
-        <ColumnDefinition Width="*"/>
-        <ColumnDefinition Width="100"/>
-        <ColumnDefinition Width="Auto"/>
-        <ColumnDefinition Width="*"/>
-        <ColumnDefinition Width="100"/>
-      </Grid.ColumnDefinitions>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="40" />
-        <RowDefinition Height="45" />
-      </Grid.RowDefinitions>
-      <Label Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" x:Name="ProxyLabel" 
-             Content="{x:Static resx:ViewResources.PluginsView_ProxiesLabel}" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
-
-      <Label x:Name="HttpProxyHostLabel" Grid.Row="1" Grid.Column="0"
-             Content="{x:Static resx:ViewResources.PluginsView_HttpProxyHostLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
-      <TextBox Grid.Row="1" Grid.Column="1" x:Name="HttpProxyHostTextbox" HorizontalAlignment="Stretch" Height="30" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,5,0" />
-      <mahapps:NumericUpDown  Grid.Row="1" Grid.Column="2" x:Name="HttpProxyPortNumericUpDown" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" 
-                              StringFormat="{}{0:0}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-      />
-      <Label x:Name="HttpsProxyHostLabel" Grid.Row="1" Grid.Column="3"
-             Content="{x:Static resx:ViewResources.PluginsView_HttpsProxyHostLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,10,0" />
-      <TextBox Grid.Row="1" Grid.Column="4" x:Name="HttpsProxyHostTextbox" HorizontalAlignment="Stretch" Height="30" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,5,0" />
-      <mahapps:NumericUpDown  Grid.Row="1" Grid.Column="5" x:Name="HttpsProxyPortNumericUpDown" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" 
-                              StringFormat="{}{0:0}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-      />
-    </Grid>
-
-    <Grid Grid.Row="1" Grid.Column="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+  <Grid>
     <Grid.Resources>
       <ControlTemplate TargetType="CheckBox" x:Key="chkboxTemplate">
         <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
@@ -78,16 +36,8 @@
         </ControlTemplate.Triggers>
       </ControlTemplate>
     </Grid.Resources>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="*" />
-      </Grid.RowDefinitions>
 
-      <Label Grid.Row="0" Grid.Column="0" x:Name="PluginsLabel" Content="{x:Static resx:ViewResources.PluginsView_PluginsLabel}" 
-             HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
-
-      <ListBox x:Name="PluginsListBox"
-             Grid.Row="1" Grid.Column="0"
+    <ListBox x:Name="PluginsListBox"
              VerticalContentAlignment="Stretch"
              Background="Transparent"
              BorderBrush="Transparent"
@@ -121,7 +71,5 @@
         </GroupStyle>
       </ListBox.GroupStyle>
     </ListBox>
-  </Grid>
-  
   </Grid>
 </controls:StepControl>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml
@@ -4,13 +4,55 @@
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:resx="clr-namespace:Elastic.Installer.UI.Properties"
+                      xmlns:mahapps="http://metro.mahapps.com/winfx/xaml/controls"
                       xmlns:controls="clr-namespace:Elastic.Installer.UI.Controls"
                       xmlns:steps="clr-namespace:Elastic.Installer.UI.Elasticsearch.Steps"
                       xmlns:plugins="clr-namespace:Elastic.Installer.Domain.Model.Elasticsearch.Plugins;assembly=Elastic.Installer.Domain"
                       mc:Ignorable="d"
                       d:DataContext="{d:DesignInstance d:Type=plugins:PluginsModel }"
                       d:DesignHeight="300" d:DesignWidth="600">
-  <Grid>
+  
+  
+  
+  <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
+
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+
+    <Grid Grid.Row="0" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="100"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="100"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="40" />
+        <RowDefinition Height="45" />
+      </Grid.RowDefinitions>
+      <Label Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" x:Name="ProxyLabel" 
+             Content="{x:Static resx:ViewResources.PluginsView_ProxiesLabel}" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
+
+      <Label x:Name="HttpProxyHostLabel" Grid.Row="1" Grid.Column="0"
+             Content="{x:Static resx:ViewResources.PluginsView_HttpProxyHostLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
+      <TextBox Grid.Row="1" Grid.Column="1" x:Name="HttpProxyHostTextbox" HorizontalAlignment="Stretch" Height="30" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,5,0" />
+      <mahapps:NumericUpDown  Grid.Row="1" Grid.Column="2" x:Name="HttpProxyPortNumericUpDown" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" 
+                              StringFormat="{}{0:0}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+      />
+      <Label x:Name="HttpsProxyHostLabel" Grid.Row="1" Grid.Column="3"
+             Content="{x:Static resx:ViewResources.PluginsView_HttpsProxyHostLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,10,0" />
+      <TextBox Grid.Row="1" Grid.Column="4" x:Name="HttpsProxyHostTextbox" HorizontalAlignment="Stretch" Height="30" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,5,0" />
+      <mahapps:NumericUpDown  Grid.Row="1" Grid.Column="5" x:Name="HttpsProxyPortNumericUpDown" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" 
+                              StringFormat="{}{0:0}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+      />
+    </Grid>
+
+    <Grid Grid.Row="1" Grid.Column="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
     <Grid.Resources>
       <ControlTemplate TargetType="CheckBox" x:Key="chkboxTemplate">
         <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
@@ -36,8 +78,16 @@
         </ControlTemplate.Triggers>
       </ControlTemplate>
     </Grid.Resources>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
 
-    <ListBox x:Name="PluginsListBox"
+      <Label Grid.Row="0" Grid.Column="0" x:Name="PluginsLabel" Content="{x:Static resx:ViewResources.PluginsView_PluginsLabel}" 
+             HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
+
+      <ListBox x:Name="PluginsListBox"
+             Grid.Row="1" Grid.Column="0"
              VerticalContentAlignment="Stretch"
              Background="Transparent"
              BorderBrush="Transparent"
@@ -71,5 +121,7 @@
         </GroupStyle>
       </ListBox.GroupStyle>
     </ListBox>
+  </Grid>
+  
   </Grid>
 </controls:StepControl>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml.cs
@@ -3,6 +3,9 @@ using System.Windows.Controls;
 using Elastic.Installer.Domain.Model.Base.Plugins;
 using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
 using Elastic.Installer.UI.Controls;
+using Elastic.Installer.UI.Properties;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
 using ReactiveUI;
 
 namespace Elastic.Installer.UI.Elasticsearch.Steps
@@ -27,15 +30,18 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 		{
 			this.OneWayBind(ViewModel, vm => vm.AvailablePlugins, v => v.PluginsListBox.ItemsSource);
 
-			this.HttpProxyPortNumericUpDown.Minimum = PluginsModel.HttpPortMinimum;
-			this.HttpProxyPortNumericUpDown.Maximum = PluginsModel.PortMaximum;
-			this.HttpsProxyPortNumericUpDown.Minimum = PluginsModel.HttpsPortMinimum;
-			this.HttpsProxyPortNumericUpDown.Maximum = PluginsModel.PortMaximum;
+			(Application.Current.MainWindow as MainWindow).ProxyButton.Command = this.ViewModel.SetHttpsProxy;
 
-			this.Bind(ViewModel, vm => vm.HttpProxyHost, v => v.HttpProxyHostTextbox.Text);
-			this.Bind(ViewModel, vm => vm.HttpProxyPort, v => v.HttpProxyPortNumericUpDown.Value, null, new NullableIntToNullableDoubleConverter(), new NullableDoubleToNullableIntConverter());
-			this.Bind(ViewModel, vm => vm.HttpsProxyHost, v => v.HttpsProxyHostTextbox.Text);
-			this.Bind(ViewModel, vm => vm.HttpsProxyPort, v => v.HttpsProxyPortNumericUpDown.Value, null, new NullableIntToNullableDoubleConverter(), new NullableDoubleToNullableIntConverter());
+			this.ViewModel.HttpsProxyUITask = () =>
+			{
+				var metroWindow = Application.Current.MainWindow as MetroWindow;
+				return metroWindow.ShowInputAsync(
+					ViewResources.PluginsView_SetHttpsProxy_Title,
+					ViewResources.PluginsView_SetHttpsProxy_Message, new MetroDialogSettings
+					{
+						DefaultText = this.ViewModel.HttpsProxyHostAndPort
+					});
+			};
 		}
 
 		private void OnActualCheckboxClick(object sender, RoutedEventArgs e)

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/PluginsView.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using System.Reactive.Linq;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using Elastic.Installer.Domain.Model.Base.Plugins;
 using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
@@ -28,6 +26,16 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 		protected override void InitializeBindings()
 		{
 			this.OneWayBind(ViewModel, vm => vm.AvailablePlugins, v => v.PluginsListBox.ItemsSource);
+
+			this.HttpProxyPortNumericUpDown.Minimum = PluginsModel.HttpPortMinimum;
+			this.HttpProxyPortNumericUpDown.Maximum = PluginsModel.PortMaximum;
+			this.HttpsProxyPortNumericUpDown.Minimum = PluginsModel.HttpsPortMinimum;
+			this.HttpsProxyPortNumericUpDown.Maximum = PluginsModel.PortMaximum;
+
+			this.Bind(ViewModel, vm => vm.HttpProxyHost, v => v.HttpProxyHostTextbox.Text);
+			this.Bind(ViewModel, vm => vm.HttpProxyPort, v => v.HttpProxyPortNumericUpDown.Value, null, new NullableIntToNullableDoubleConverter(), new NullableDoubleToNullableIntConverter());
+			this.Bind(ViewModel, vm => vm.HttpsProxyHost, v => v.HttpsProxyHostTextbox.Text);
+			this.Bind(ViewModel, vm => vm.HttpsProxyPort, v => v.HttpsProxyPortNumericUpDown.Value, null, new NullableIntToNullableDoubleConverter(), new NullableDoubleToNullableIntConverter());
 		}
 
 		private void OnActualCheckboxClick(object sender, RoutedEventArgs e)

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -1361,7 +1361,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///We&apos;ve only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins are downloaded at installation time.
         ///
-        ///It is common for many companies to set up a HTTP proxy through which resources will be downloaded from th [rest of string was truncated]&quot;;.
+        ///It is common for many companies to set up a proxy through which resources will be downloaded from the int [rest of string was truncated]&quot;;.
         /// </summary>
         public static string PluginsView_Elasticsearch_Help {
             get {
@@ -1379,24 +1379,6 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to HTTP host/port.
-        /// </summary>
-        public static string PluginsView_HttpProxyHostLabel {
-            get {
-                return ResourceManager.GetString("PluginsView_HttpProxyHostLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to HTTPS host/port.
-        /// </summary>
-        public static string PluginsView_HttpsProxyHostLabel {
-            get {
-                return ResourceManager.GetString("PluginsView_HttpsProxyHostLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Plugins are a way to enhance the basic Kibana functionality in a custom manner.  We&apos;ve only listed the official Kibanas plugins here, but there are many more community plugins that can be installed manually..
         /// </summary>
         public static string PluginsView_Kibana_Help {
@@ -1406,20 +1388,20 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugins.
+        ///   Looks up a localized string similar to Configure a HTTPS proxy through which to download plugins as part of installation. A proxy can be specified in the form of host or host:port. If no port is specified, defaults to using port 443..
         /// </summary>
-        public static string PluginsView_PluginsLabel {
+        public static string PluginsView_SetHttpsProxy_Message {
             get {
-                return ResourceManager.GetString("PluginsView_PluginsLabel", resourceCulture);
+                return ResourceManager.GetString("PluginsView_SetHttpsProxy_Message", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Proxies.
+        ///   Looks up a localized string similar to HTTPS proxy.
         /// </summary>
-        public static string PluginsView_ProxiesLabel {
+        public static string PluginsView_SetHttpsProxy_Title {
             get {
-                return ResourceManager.GetString("PluginsView_ProxiesLabel", resourceCulture);
+                return ResourceManager.GetString("PluginsView_SetHttpsProxy_Title", resourceCulture);
             }
         }
         

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Elastic.Installer.UI.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ViewResources {
@@ -1359,7 +1359,9 @@ namespace Elastic.Installer.UI.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), custom discovery, and more.
         ///
-        ///We&apos;ve only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually..
+        ///We&apos;ve only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins are downloaded at installation time.
+        ///
+        ///It is common for many companies to set up a HTTP proxy through which resources will be downloaded from th [rest of string was truncated]&quot;;.
         /// </summary>
         public static string PluginsView_Elasticsearch_Help {
             get {
@@ -1377,11 +1379,47 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTP host/port.
+        /// </summary>
+        public static string PluginsView_HttpProxyHostLabel {
+            get {
+                return ResourceManager.GetString("PluginsView_HttpProxyHostLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HTTPS host/port.
+        /// </summary>
+        public static string PluginsView_HttpsProxyHostLabel {
+            get {
+                return ResourceManager.GetString("PluginsView_HttpsProxyHostLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Plugins are a way to enhance the basic Kibana functionality in a custom manner.  We&apos;ve only listed the official Kibanas plugins here, but there are many more community plugins that can be installed manually..
         /// </summary>
         public static string PluginsView_Kibana_Help {
             get {
                 return ResourceManager.GetString("PluginsView_Kibana_Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plugins.
+        /// </summary>
+        public static string PluginsView_PluginsLabel {
+            get {
+                return ResourceManager.GetString("PluginsView_PluginsLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Proxies.
+        /// </summary>
+        public static string PluginsView_ProxiesLabel {
+            get {
+                return ResourceManager.GetString("PluginsView_ProxiesLabel", resourceCulture);
             }
         }
         

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -450,15 +450,8 @@ This installer will walk you through various steps to help you configure and ins
 
 We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins are downloaded at installation time.
 
-It is common for many companies to set up a HTTP proxy through which resources will be downloaded from the internet. As such, you may need to specify the host name and port of a corporate proxy to allow the installer to successfully install plugins. Since official Elasticsearch plugins are installed from https://artifacts.elastic.co, a HTTPS proxy would be used, if specified.
-
-[b]HTTP host[/b]: This setting specifies the host of the HTTP proxy through which plugins will be downloaded.
-
-[b]HTTP port[/b]: This setting specifies the port of the HTTP proxy through which plugins will be downloaded. If not specified, defaults to port 80.
-
-[b]HTTPS host[/b]: This setting specifies the host of the HTTPS proxy through which plugins will be downloaded.
-
-[b]HTTPS port[/b]: This setting specifies the port of the HTTPS proxy through which plugins will be downloaded. If not specified, defaults to port 443.</value>
+It is common for many companies to set up a proxy through which resources will be downloaded from the internet. As such, you may need to specify the host name and port of a corporate proxy to allow the installer to successfully install plugins. Since official Elasticsearch plugins are installed from 
+https://artifacts.elastic.co, a HTTPS proxy can be specified.</value>
   </data>
   <data name="ServiceView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Service Help</value>
@@ -767,16 +760,10 @@ Alternatively, you may choose to not install Kibana as a service and run it manu
   <data name="ClosingView_KibanaRunningAtHeaderWithCredentials" xml:space="preserve">
     <value>Open Kibana in the browser (User name: elastic, Password: changeme)</value>
   </data>
-  <data name="PluginsView_HttpProxyHostLabel" xml:space="preserve">
-    <value>HTTP host/port</value>
+  <data name="PluginsView_SetHttpsProxy_Message" xml:space="preserve">
+    <value>Configure a HTTPS proxy through which to download plugins as part of installation. A proxy can be specified in the form of host or host:port. If no port is specified, defaults to using port 443.</value>
   </data>
-  <data name="PluginsView_HttpsProxyHostLabel" xml:space="preserve">
-    <value>HTTPS host/port</value>
-  </data>
-  <data name="PluginsView_PluginsLabel" xml:space="preserve">
-    <value>Plugins</value>
-  </data>
-  <data name="PluginsView_ProxiesLabel" xml:space="preserve">
-    <value>Proxies</value>
+  <data name="PluginsView_SetHttpsProxy_Title" xml:space="preserve">
+    <value>HTTPS proxy</value>
   </data>
 </root>

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -448,7 +448,17 @@ This installer will walk you through various steps to help you configure and ins
   <data name="PluginsView_Elasticsearch_Help" xml:space="preserve">
     <value>Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), custom discovery, and more.
 
-We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually.</value>
+We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins are downloaded at installation time.
+
+It is common for many companies to set up a HTTP proxy through which resources will be downloaded from the internet. As such, you may need to specify the host name and port of a corporate proxy to allow the installer to successfully install plugins. Since official Elasticsearch plugins are installed from https://artifacts.elastic.co, a HTTPS proxy would be used, if specified.
+
+[b]HTTP host[/b]: This setting specifies the host of the HTTP proxy through which plugins will be downloaded.
+
+[b]HTTP port[/b]: This setting specifies the port of the HTTP proxy through which plugins will be downloaded. If not specified, defaults to port 80.
+
+[b]HTTPS host[/b]: This setting specifies the host of the HTTPS proxy through which plugins will be downloaded.
+
+[b]HTTPS port[/b]: This setting specifies the port of the HTTPS proxy through which plugins will be downloaded. If not specified, defaults to port 443.</value>
   </data>
   <data name="ServiceView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Service Help</value>
@@ -756,5 +766,17 @@ Alternatively, you may choose to not install Kibana as a service and run it manu
   </data>
   <data name="ClosingView_KibanaRunningAtHeaderWithCredentials" xml:space="preserve">
     <value>Open Kibana in the browser (User name: elastic, Password: changeme)</value>
+  </data>
+  <data name="PluginsView_HttpProxyHostLabel" xml:space="preserve">
+    <value>HTTP host/port</value>
+  </data>
+  <data name="PluginsView_HttpsProxyHostLabel" xml:space="preserve">
+    <value>HTTPS host/port</value>
+  </data>
+  <data name="PluginsView_PluginsLabel" xml:space="preserve">
+    <value>Plugins</value>
+  </data>
+  <data name="PluginsView_ProxiesLabel" xml:space="preserve">
+    <value>Proxies</value>
   </data>
 </root>

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Uninstall/UninstallPluginsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Uninstall/UninstallPluginsTask.cs
@@ -1,5 +1,7 @@
-﻿using System.IO.Abstractions;
+﻿using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Linq;
+using Elastic.Configuration.EnvironmentBased;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Elasticsearch;
 using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
@@ -19,8 +21,8 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			var installDirectory = this.InstallationModel.LocationsModel.InstallDir;
 			var configDirectory = this.InstallationModel.LocationsModel.ConfigDirectory;
 			var provider = this.InstallationModel.PluginsModel.PluginStateProvider;
-
-			var plugins = provider.InstalledPlugins(installDirectory, configDirectory);
+			var environmentVariables = new Dictionary<string, string> { { ElasticsearchEnvironmentStateProvider.ConfDir, configDirectory } };
+			var plugins = provider.InstalledPlugins(installDirectory, configDirectory, environmentVariables);
 
 			if (plugins.Count == 0)
 			{
@@ -29,13 +31,15 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 			}
 
 			var ticksPerPlugin = new[] { 20, 1930, 50 };
-			var totalTicks = plugins.Count * ticksPerPlugin.Sum();
-
+			var totalTicks = plugins.Count * ticksPerPlugin.Sum();		
+			var additionalArguments = new [] { "--purge" };
+			
 			this.Session.SendActionStart(totalTicks, ActionName, "Removing existing Elasticsearch plugins", "Elasticsearch plugin: [1]");
 			foreach (var plugin in plugins)
 			{
 				this.Session.SendProgress(ticksPerPlugin[0], $"removing {plugin}");
-				provider.Remove(ticksPerPlugin[1], installDirectory, configDirectory, plugin, "--purge");
+				
+				provider.Remove(ticksPerPlugin[1], installDirectory, configDirectory, plugin, additionalArguments, environmentVariables);
 				this.Session.SendProgress(ticksPerPlugin[2], $"removed {plugin}");
 			}
 			return true;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/InstallPluginsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/InstallPluginsTask.cs
@@ -34,7 +34,8 @@ namespace Elastic.InstallerHosts.Kibana.Tasks
 			foreach (var plugin in plugins)
 			{
 				this.Session.SendProgress(ticksPerPlugin[0], $"installing {plugin}");
-				provider.Install(ticksPerPlugin[1], installDirectory, configDirectory, plugin, "--config", configFile);
+				var additionalArguments = new [] { "--config", configFile };
+				provider.Install(ticksPerPlugin[1], installDirectory, configDirectory, plugin, additionalArguments);
 				this.Session.SendProgress(ticksPerPlugin[2], $"installed {plugin}");
 			}
 			return true;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/RemovePluginsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/RemovePluginsTask.cs
@@ -35,7 +35,8 @@ namespace Elastic.InstallerHosts.Kibana.Tasks
 			foreach (var plugin in plugins)
 			{
 				this.Session.SendProgress(ticksPerPlugin[0], $"removing {plugin}");
-				provider.Remove(ticksPerPlugin[1], installDirectory, configDirectory, plugin, "--config", configFile);
+				var additionalArguments = new [] { "--config", configFile };
+				provider.Remove(ticksPerPlugin[1], installDirectory, configDirectory, plugin, additionalArguments);
 				this.Session.SendProgress(ticksPerPlugin[2], $"removed {plugin}");
 			}
 			return true;

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","8d8f53")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","787c93")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
-[assembly: AssemblyVersionAttribute("5.5.3")]
-[assembly: AssemblyFileVersionAttribute("5.5.3")]
-[assembly: AssemblyInformationalVersionAttribute("5.5.3")]
+[assembly: AssemblyVersionAttribute("5.6.0")]
+[assembly: AssemblyFileVersionAttribute("5.6.0")]
+[assembly: AssemblyInformationalVersionAttribute("5.6.0")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "8d8f53";
+        internal const System.String AssemblyMetadata_GitBuildHash = "787c93";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
-        internal const System.String AssemblyVersion = "5.5.3";
-        internal const System.String AssemblyFileVersion = "5.5.3";
-        internal const System.String AssemblyInformationalVersion = "5.5.3";
+        internal const System.String AssemblyVersion = "5.6.0";
+        internal const System.String AssemblyFileVersion = "5.6.0";
+        internal const System.String AssemblyInformationalVersion = "5.6.0";
     }
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsArgumentsTests.cs
@@ -35,5 +35,37 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 			m.PluginsModel.AvailablePlugins.Count(p => p.Selected).Should().Be(2);
 		});
 
+		[Fact] void PluginsHttpProxyHost() => Argument(
+			nameof(PluginsModel.HttpProxyHost),
+			"localhost",
+			(m, v) =>
+			{
+				m.PluginsModel.HttpProxyHost.Should().NotBeNullOrEmpty().And.Be("localhost");
+			});
+
+		[Fact] void PluginsHttpProxyPort() => Argument(
+			nameof(PluginsModel.HttpProxyPort),
+			"8888",
+			(m, v) =>
+			{
+				m.PluginsModel.HttpProxyPort.Should().NotBeNull().And.Be(8888);
+			});
+
+		[Fact] void PluginsHttpsProxyHost() => Argument(
+			nameof(PluginsModel.HttpsProxyHost),
+			"localhost",
+			(m, v) =>
+			{
+				m.PluginsModel.HttpsProxyHost.Should().NotBeNullOrEmpty().And.Be("localhost");
+			});
+
+		[Fact] void PluginsHttpsProxyPort() => Argument(
+			nameof(PluginsModel.HttpsProxyPort),
+			"8888",
+			(m, v) =>
+			{
+				m.PluginsModel.HttpsProxyPort.Should().NotBeNull().And.Be(8888);
+			});
+
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
@@ -31,5 +32,39 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 				step.AvailablePlugins.Should().NotContain(a => a.Url == "ingest-geoip" && a.Selected);
 			})
 			.CanClickNext();
+
+		[Fact] void ValidHttpProxyHost() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpProxyHost = "localhost";
+			})
+			.CanClickNext();
+
+		[Fact] void ValidHttpsProxyHost() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpsProxyHost = "localhost";
+			})
+			.CanClickNext();
+
+		[Fact] void InvalidHttpProxyHost() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpProxyHost = "@";
+			})
+			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
+				.ShouldHaveErrors(PluginsModelValidator.InvalidHttpProxyHost)
+			)
+			.CanClickNext(false);
+
+		[Fact] void InvalidHttpsProxyHost() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpsProxyHost = "@";
+			})
+			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
+				.ShouldHaveErrors(PluginsModelValidator.InvalidHttpsProxyHost)
+			)
+			.CanClickNext(false);
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -57,6 +57,30 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 			)
 			.CanClickNext(false);
 
+		[Theory]
+		[InlineData(79)]
+		[InlineData(65536)]
+		void HttpProxyHostInvalidOutsideOfRange(int v) => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpProxyHost = "localhost";
+				step.HttpProxyPort = v;
+			})
+			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
+				.ShouldHaveErrors(string.Format(PluginsModelValidator.InvalidHttpProxyPort, PluginsModel.HttpPortMinimum, PluginsModel.PortMaximum))
+			)
+			.CanClickNext(false);
+
+		[Fact] void HttpProxyHostRequiredWhenPortSpecified() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpProxyPort = 80;
+			})
+			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
+				.ShouldHaveErrors(PluginsModelValidator.HttpProxyHostRequiredWhenPortSpecified)
+			)
+			.CanClickNext(false);
+
 		[Fact] void InvalidHttpsProxyHost() => this._model
 			.OnStep(m => m.PluginsModel, step =>
 			{
@@ -64,6 +88,32 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 			})
 			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
 				.ShouldHaveErrors(PluginsModelValidator.InvalidHttpsProxyHost)
+			)
+			.CanClickNext(false);
+
+		[Fact]
+		void HttpsProxyHostRequiredWhenPortSpecified() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpsProxyPort = 443;
+			})
+			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
+				.ShouldHaveErrors(PluginsModelValidator.HttpsProxyHostRequiredWhenPortSpecified)
+			)
+			.CanClickNext(false);
+
+
+		[Theory]
+		[InlineData(442)]
+		[InlineData(65536)]
+		void HttpsProxyHostInvalidOutsideOfRange(int v) => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.HttpsProxyHost = "localhost";
+				step.HttpsProxyPort = v;
+			})
+			.IsInvalidOnStep(m => m.PluginsModel, errors => errors
+				.ShouldHaveErrors(string.Format(PluginsModelValidator.InvalidHttpsProxyPort, PluginsModel.HttpsPortMinimum, PluginsModel.PortMaximum))
 			)
 			.CanClickNext(false);
 	}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -555,3 +555,16 @@ function Context-NodeNotRunning($Domain, $Port, $Credentials) {
     }
 }
 
+function Context-FiddlerSessionContainsEntry() {
+	Context "Fiddler session" {
+		$session = Get-FiddlerSession
+		$artifactsUrl = "artifacts.elastic.co"
+
+		log $session
+
+		It "Contains $artifactsUrl" {
+			$session | Should Match ([regex]::Escape($artifactsUrl))
+		}
+	}
+}
+

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CustomRules.js
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CustomRules.js
@@ -1,0 +1,21 @@
+﻿// Custom Fiddler JScript to dump the current session to file
+// place in [Environment]::GetFolderPath("MyDocuments")\Fiddler2\Scripts before loading Fiddler
+
+import System;
+import System.Windows.Forms;
+import Fiddler;
+
+class Handlers {
+  static function OnExecAction(sParams: String[]): Boolean {
+    FiddlerObject.StatusText = "ExecAction: " + sParams[0];
+    var sAction = sParams[0].toLowerCase();
+    switch(sAction) {
+      case "dump_session": 
+      var oSessions = FiddlerApplication.UI.GetAllSessions(); 
+      var oExportOptions = FiddlerObject.createDictionary(); 
+      oExportOptions.Add("Filename", "C:\\session.har"); 
+      FiddlerApplication.DoExport("HTTPArchive v1.2", oSessions, oExportOptions, null); 
+      break; 
+    }
+  }
+}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
@@ -417,6 +417,23 @@ function Get-Installer([string] $Location, $Product, $Version) {
 	return Get-Item $exePath
 }
 
+function Start-Fiddler($Port=8888) {
+	& "$($env:LOCALAPPDATA)\Programs\Fiddler\Fiddler.exe" /noattach /noversioncheck /port:$Port
+}
+
+function Get-FiddlerSession() {
+	$exitCode = (Start-Process "$($env:LOCALAPPDATA)\Programs\Fiddler\ExecAction.exe" -ArgumentList "dump_session" -Wait -PassThru).ExitCode
+	if ($exitCode -ne 0) {
+		log "ExecAction exited with code: $exitCode" -Level Error
+	}
+
+	return Get-Content C:\session.har
+}
+
+function Stop-Fiddler() {
+	Get-Process Fiddler -ErrorAction Ignore | Stop-Process
+}
+
 function Add-Quotes (
         [System.Collections.ArrayList]
         [Parameter(Position=0)]

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
@@ -1,20 +1,25 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.configure("2") do |config|
+# for linked clone support
+Vagrant.require_version ">= 1.8.0"
+
+Vagrant.configure(2) do |config|
 
   # when running locally
   config.vm.define "local" do |local|
     local.vm.box = "elastic/windows-2012_r2-x86_64"
 	local.vm.provider "virtualbox" do |vb, override|
       #vb.gui = true
-	  vb.memory = "4096"
+	  vb.memory = 4096
+	  vb.linked_clone = true
 	end
 	
     local.vm.synced_folder "./../../Common/", "/common"
     local.vm.synced_folder "./../../../../../build/out/", "/out"
     
-    local.vm.provision "powershellget", type: "shell", inline: configure_powershellget()  
+    local.vm.provision "powershellget", type: "shell", inline: configure_powershellget()
+    local.vm.provision "fiddler", 		type: "shell", inline: configure_fiddler()  
 	local.vm.provision "partition", 	type: "shell", inline: create_partition() 
   end
 
@@ -54,6 +59,7 @@ Vagrant.configure("2") do |config|
     azure.vm.provision "chocolatey", 	type: "shell", inline: configure_chocolatey() 
     azure.vm.provision "powershellget", type: "shell", inline: configure_powershellget()   
     azure.vm.provision "java", 			type: "shell", inline: configure_java()  
+    azure.vm.provision "fiddler", 		type: "shell", inline: configure_fiddler()  
   end
 
 end
@@ -74,6 +80,17 @@ end
 def configure_java()
   return <<-SHELL
     choco install jdk8 -y
+  SHELL
+end
+
+def configure_fiddler()
+  return <<-SHELL
+    choco install fiddler4 -y
+	$scriptsDir = "$([Environment]::GetFolderPath("MyDocuments"))\\Fiddler2\\Scripts"
+	if (-not(Test-Path $scriptsDir)) {
+		New-Item $scriptsDir -Type Directory | Out-Null
+	}
+	Copy-Item "C:\\common\\CustomRules.js" $scriptsDir
   SHELL
 end
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Proxy/SilentInstall-Proxy.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Proxy/SilentInstall-Proxy.Tests.ps1
@@ -1,0 +1,47 @@
+$currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
+Set-Location $currentDir
+
+# mapped sync folder for common scripts
+. $currentDir\..\common\Utils.ps1
+. $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
+
+Get-Version
+Get-PreviousVersions
+
+Describe "Silent Install x-pack through HTTPS proxy" {
+	$port = 8888
+	Start-Fiddler -Port $port
+
+    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack","HTTPSPROXYHOST=localhost", "HTTPSPROXYPORT=$port")
+
+    Context-PingNode -XPackSecurityInstalled $true
+
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack") }
+
+    Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:changeme" }
+
+	Context-FiddlerSessionContainsEntry
+
+	Stop-Fiddler
+}
+
+Describe "Silent Uninstall with x-pack through HTTPS proxy" {
+
+    Invoke-SilentUninstall
+
+	Context-NodeNotRunning
+
+	Context-EsConfigEnvironmentVariableNull
+
+	Context-EsHomeEnvironmentVariableNull
+
+	Context-MsiNotRegistered
+
+	Context-ElasticsearchServiceNotInstalled
+
+	$ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+	Context-EmptyInstallDirectory -Path $ExpectedHomeFolder
+}


### PR DESCRIPTION
Provide the ability to specify both a HTTP and HTTPS proxy that can used to download plugins. The HTTP proxy is used by any plugin hosted on a resource using the HTTP scheme, whilst the HTTPS proxy is used by any plugin hosted on a resource using the HTTPS scheme, such as the official plugins hosted at https://artifacts.elastic.co.

- Specify host and port separately
    Did investigate supplying together as a `Uri`, but there are challenges to doing this e.g.

    ```c#
    // UriKind.Absolute requires a scheme
    Uri.TryCreate("localhost", UriKind.Absolute, out var uri); // false

    // Parses the host as scheme and port as path
    Uri.TryCreate("localhost:80", UriKind.Absolute, out var uri); // true

    // Parses the host correctly, port will be 80, so cannot append a scheme
    // unless the scheme to be appended is known for a given context
   Uri.TryCreate("http://localhost", UriKind.Absolute, out var uri); // true
    ```

    went for the pragmatic approach of allowing them to be supplied separately
- Integration test for HTTPS proxy using Fiddler to capture the HTTPS CONNECT request to https://artifacts.elastic.co
- Use linked clones for virtual box Vagrant provider. Speeds up vagrant up for large images such as the Elastic Windows image.

Closes #61 