### PR TITLE
Verbiage updates for a variety of places

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -730,7 +730,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components..
+        ///   Looks up a localized string similar to The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding extended Unicode support using the ICU libraries, including better analysis of Asian languages, Unicode normalization, Unicode-aware case folding, collation support, and transliteration..
         /// </summary>
         public static string PluginsModel_ICUAnalysis {
             get {
@@ -739,7 +739,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF) by using the Apache text extraction library Tika.  You can use the ingest attachment plugin as a replacement for the mapper attachment plugin..
+        ///   Looks up a localized string similar to The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF) by using the Apache text and metadata extraction library Tika.  You can use the ingest attachment plugin as a replacement for the mapper attachment plugin..
         /// </summary>
         public static string PluginsModel_IngestAttachment {
             get {
@@ -748,7 +748,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The GeoIP processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases. This processor adds this information by default under the geoip field..
+        ///   Looks up a localized string similar to The GeoIP processor adds information about the geographical location of IP addresses, based on data from Geo-IP databases. This processor adds this information by default under the geoip field..
         /// </summary>
         public static string PluginsModel_IngestGeoIP {
             get {
@@ -757,7 +757,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch..
+        ///   Looks up a localized string similar to The Japanese (kuromoji) Analysis plugin integrates the Lucene kuromoji analysis module into Elasticsearch..
         /// </summary>
         public static string PluginsModel_JapaneseAnalysis {
             get {
@@ -784,7 +784,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The mapper-murmur3 plugin provides the ability to compute hash of field values at index-time and store them in the index. This can sometimes be helpful when running cardinality aggregations on high-cardinality and large string fields..
+        ///   Looks up a localized string similar to The mapper-murmur3 plugin provides the ability to compute a hash of field values at index-time and store them in the index. This can sometimes be helpful when running cardinality aggregations on high-cardinality and large string fields..
         /// </summary>
         public static string PluginsModel_MapperMurmur3 {
             get {
@@ -829,7 +829,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch..
+        ///   Looks up a localized string similar to The Smart Chinese Analysis plugin integrates the Lucene Smart Chinese analysis module into Elasticsearch..
         /// </summary>
         public static string PluginsModel_SmartChineseAnalysis {
             get {
@@ -838,7 +838,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Stempel (Polish) Analysis plugin integrates Lucene stempel (Polish) analysis module into elasticsearch..
+        ///   Looks up a localized string similar to The Stempel (Polish) Analysis plugin integrates the Lucene Stempel (Polish) analysis module into Elasticsearch..
         /// </summary>
         public static string PluginsModel_StempelPolishAnalysis {
             get {
@@ -847,7 +847,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Store SMB plugin works around for a bug in Windows SMB and Java on Windows..
+        ///   Looks up a localized string similar to The Store SMB plugin works around a bug in Windows SMB and Java on Windows..
         /// </summary>
         public static string PluginsModel_StoreSmb {
             get {
@@ -856,7 +856,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation..
+        ///   Looks up a localized string similar to X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, machine learning, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation..
         /// </summary>
         public static string PluginsModel_XPack {
             get {

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -189,16 +189,16 @@ Java won't used compressed pointers.</value>
     <value>The Azure Repository plugin adds support for using Azure as a repository for Snapshot/Restore.</value>
   </data>
   <data name="PluginsModel_ClojureLanguagePlugin" xml:space="preserve">
-    <value>An elasticsearch plugin written in Clojure that provides clojure as a scripting language for elasticsearch queries.</value>
+    <value>An Elasticsearch plugin written in Clojure that provides clojure as a scripting language for Elasticsearch queries.</value>
   </data>
   <data name="PluginsModel_HdfsRepository" xml:space="preserve">
     <value>Allows Elasticsearch to use the Haddop file-system as a repository for snapshot/restore.</value>
   </data>
   <data name="PluginsModel_ICUAnalysis" xml:space="preserve">
-    <value>The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.</value>
+    <value>The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding extended Unicode support using the ICU libraries, including better analysis of Asian languages, Unicode normalization, Unicode-aware case folding, collation support, and transliteration.</value>
   </data>
   <data name="PluginsModel_JapaneseAnalysis" xml:space="preserve">
-    <value>The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.</value>
+    <value>The Japanese (kuromoji) Analysis plugin integrates the Lucene kuromoji analysis module into Elasticsearch.</value>
   </data>
   <data name="PluginsModel_JavaScriptLanguagePlugin" xml:space="preserve">
     <value>The JavaScript language plugin allows to have javascript (or js) as the language of scripts to execute.</value>
@@ -210,10 +210,10 @@ Java won't used compressed pointers.</value>
     <value>The Python (jython) language plugin allows to have python as the language of scripts to execute.</value>
   </data>
   <data name="PluginsModel_SmartChineseAnalysis" xml:space="preserve">
-    <value>The Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.</value>
+    <value>The Smart Chinese Analysis plugin integrates the Lucene Smart Chinese analysis module into Elasticsearch.</value>
   </data>
   <data name="PluginsModel_StempelPolishAnalysis" xml:space="preserve">
-    <value>The Stempel (Polish) Analysis plugin integrates Lucene stempel (Polish) analysis module into elasticsearch.</value>
+    <value>The Stempel (Polish) Analysis plugin integrates the Lucene Stempel (Polish) analysis module into Elasticsearch.</value>
   </data>
   <data name="PluginType_Analysis" xml:space="preserve">
     <value>Analysis</value>
@@ -316,13 +316,13 @@ in this cluster are empty. To migrate this data back into the downgraded cluster
     <value>The Google Compute Engine Discovery plugin uses the GCE API for unicast discovery.</value>
   </data>
   <data name="PluginsModel_IngestAttachment" xml:space="preserve">
-    <value>The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF) by using the Apache text extraction library Tika.  You can use the ingest attachment plugin as a replacement for the mapper attachment plugin.</value>
+    <value>The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF) by using the Apache text and metadata extraction library Tika.  You can use the ingest attachment plugin as a replacement for the mapper attachment plugin.</value>
   </data>
   <data name="PluginsModel_IngestGeoIP" xml:space="preserve">
-    <value>The GeoIP processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases. This processor adds this information by default under the geoip field.</value>
+    <value>The GeoIP processor adds information about the geographical location of IP addresses, based on data from Geo-IP databases. This processor adds this information by default under the geoip field.</value>
   </data>
   <data name="PluginsModel_MapperMurmur3" xml:space="preserve">
-    <value>The mapper-murmur3 plugin provides the ability to compute hash of field values at index-time and store them in the index. This can sometimes be helpful when running cardinality aggregations on high-cardinality and large string fields.</value>
+    <value>The mapper-murmur3 plugin provides the ability to compute a hash of field values at index-time and store them in the index. This can sometimes be helpful when running cardinality aggregations on high-cardinality and large string fields.</value>
   </data>
   <data name="PluginsModel_MapperSize" xml:space="preserve">
     <value>The mapper-size plugin provides the _size meta field which, when enabled, indexes the size in bytes of the original _source field.</value>
@@ -331,10 +331,10 @@ in this cluster are empty. To migrate this data back into the downgraded cluster
     <value>The Phonetic Analysis plugin provides token filters which convert tokens to their phonetic representation using Soundex, Metaphone, and a variety of other algorithms.</value>
   </data>
   <data name="PluginsModel_StoreSmb" xml:space="preserve">
-    <value>The Store SMB plugin works around for a bug in Windows SMB and Java on Windows.</value>
+    <value>The Store SMB plugin works around a bug in Windows SMB and Java on Windows.</value>
   </data>
   <data name="PluginsModel_XPack" xml:space="preserve">
-    <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation.</value>
+    <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, machine learning, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation.</value>
   </data>
   <data name="PluginType_ApiExtensions" xml:space="preserve">
     <value>API Extensions</value>

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -478,14 +478,14 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This step allows you to specify some settings found in the [b]kibana.yml[/b] located in the [b]config[/b] folder.  We&apos;re only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
+        ///   Looks up a localized string similar to This step allows you to specify some settings found in the [b]kibana.yml[/b] located in the [b]config[/b] folder.  We&apos;re only exposing common settings here that you may commonly want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
         ///
         ///
         ///[b]Host[/b]: This setting specifies the host of the back end server.
         ///
         ///[b]Server name[/b]: A human-readable display name that identifies this Kibana instance.
         ///
-        ///[b]Base Path[/b]: Enables you to specify a p [rest of string was truncated]&quot;;.
+        ///[b]Base Path[/b]: Enables you to specify a pa [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Kibana_Help {
             get {
@@ -1042,7 +1042,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Config[/b]: The directory where Elasticsearch will store its configuration files.
         ///
-        ///It is a best practice to keep your logs, config, and data directories separate from  [rest of string was truncated]&quot;;.
+        ///It is a best practice to keep your logs, config, and data directories separa [rest of string was truncated]&quot;;.
         /// </summary>
         public static string LocationsView_Elasticsearch_Help {
             get {

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -1040,9 +1040,9 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Logs[/b]: The directory where Elasticsearch will write its log files to.
         ///
-        ///[b]Config[/b]: The directory where Elasticsearch will its configuration files.
+        ///[b]Config[/b]: The directory where Elasticsearch will store its configuration files.
         ///
-        ///It is best practice to keep your logs, config, and data directories separate from  [rest of string was truncated]&quot;;.
+        ///It is a best practice to keep your logs, config, and data directories separate from  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string LocationsView_Elasticsearch_Help {
             get {
@@ -1139,7 +1139,7 @@ namespace Elastic.Installer.UI.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Heya! Welcome the {0} Windows intaller.
         ///
-        ///This installer will walk you through various steps to help you conifigure and install {0} on your system.  To make things easier, we&apos;ve gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you&apos;ll definitely want to change..
+        ///This installer will walk you through various steps to help you configure and install {0} on your system.  To make things easier, we&apos;ve gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you may want to change..
         /// </summary>
         public static string MainWindow_Help {
             get {
@@ -1357,7 +1357,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugins are a way to enhance the basic Elasticsearch functionality in a custom manner.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), native scripts, custom discovery and more.
+        ///   Looks up a localized string similar to Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), custom discovery, and more.
         ///
         ///We&apos;ve only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually..
         /// </summary>

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -405,7 +405,7 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
 
 [b]Node name[/b]: The unique name given to this particular Elasticsearch node.
 
-[b]Node role[/b]: The type of role(s) this node should have.  If no roles are assigned, then it will act as a client node, and only route requests to other nodes in your cluster.
+[b]Node role[/b]: The type(s) of role(s) this node should have.  If no roles are assigned, then it will act as a coordinating node, and only route requests to other nodes in your cluster.
 
 [b]Memory[/b]: The amount of memory to allocate to the JVM heap for Elasticsearch.  The standard rule of thumb is to allocate 50% of available memory to the heap, but never exceed 30.5 GB, leaving the remaining 50% free to ensure there is enough for kernel file system caches.  The 30.5 GB limit is recommended in order to prevent the JVM from entering 64-bit address space, which will result in a performance degradation.
 
@@ -429,9 +429,9 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
 
 [b]Logs[/b]: The directory where Elasticsearch will write its log files to.
 
-[b]Config[/b]: The directory where Elasticsearch will its configuration files.
+[b]Config[/b]: The directory where Elasticsearch will store its configuration files.
 
-It is best practice to keep your logs, config, and data directories separate from your home directory.  This keeps your data and configuration safe from overwriting when upgrading to newer versions of Elasticsearch.</value>
+It is a best practice to keep your logs, config, and data directories separate from your home directory.  This keeps your data and configuration safe from overwriting when upgrading to newer versions of Elasticsearch.</value>
   </data>
   <data name="MainWindow_Help_Header" xml:space="preserve">
     <value>Installation Help</value>
@@ -439,14 +439,14 @@ It is best practice to keep your logs, config, and data directories separate fro
   <data name="MainWindow_Help" xml:space="preserve">
     <value>Heya! Welcome the {0} Windows intaller.
 
-This installer will walk you through various steps to help you conifigure and install {0} on your system.  To make things easier, we've gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you'll definitely want to change.</value>
+This installer will walk you through various steps to help you configure and install {0} on your system.  To make things easier, we've gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you may want to change.</value>
     <comment>{0} = Product name</comment>
   </data>
   <data name="PluginsView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Plugin Help</value>
   </data>
   <data name="PluginsView_Elasticsearch_Help" xml:space="preserve">
-    <value>Plugins are a way to enhance the basic Elasticsearch functionality in a custom manner.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), native scripts, custom discovery and more.
+    <value>Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), custom discovery, and more.
 
 We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually.</value>
   </data>
@@ -661,7 +661,7 @@ Alternatively, you may choose to not install Elasticsearch as a service and run 
     <value>Browse</value>
   </data>
   <data name="ConfigurationView_Kibana_Help" xml:space="preserve">
-    <value>This step allows you to specify some settings found in the [b]kibana.yml[/b] located in the [b]config[/b] folder.  We're only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
+    <value>This step allows you to specify some settings found in the [b]kibana.yml[/b] located in the [b]config[/b] folder.  We're only exposing common settings here that you may commonly want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
 
 
 [b]Host[/b]: This setting specifies the host of the back end server.


### PR DESCRIPTION
Updates help boxes mostly to try to use consistent naming (e.g. `elasticsearch` -> `Elasticsearch`) and a few spelling/grammatical errors.  Also makes a few changes for messaging, e.g. moving away from saying "you _definitely_ want to change these defaults" to "you _might_ want to change these defaults"

I think it should be largely agreeable but if there are questions or you want me to break it up, let me know.