### PR TITLE
Use linked_clone for local vagrant boxes

### DIFF
--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
@@ -4,7 +4,7 @@
 # for linked clone support
 Vagrant.require_version ">= 1.8.0"
 
-Vagrant.configure(2) do |config|
+Vagrant.configure("2") do |config|
 
   # when running locally
   config.vm.define "local" do |local|


### PR DESCRIPTION
[Linked Clones](https://www.vagrantup.com/docs/virtualbox/configuration.html#linked-clones) speed up the provisioning of large boxes like the Windows box (~10GB) by differencing disk images from the base box.