### PR TITLE
WIP Feature/duplicate component fix

### DIFF
--- a/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
+++ b/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
@@ -65,5 +65,13 @@ namespace Elastic.Configuration.FileBased.Yaml
 		public string TransportTcpPortString { get; set; }
 		
 		public int? TransportTcpPort => int.TryParse(TransportTcpPortString, out int port) ? port : (int?)null;
+		
+		[YamlMember("xpack.license.self_generated.type")]
+		[DefaultValue(null)]
+		public string XPackLicenseSelfGeneratedType { get; set; }
+		
+		[YamlMember("xpack.security.enabled")]
+		[DefaultValue(null)]
+		public bool? XPackSecurityEnabled { get; set; }
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Elastic.Installer.Domain.csproj
+++ b/src/Installer/Elastic.Installer.Domain/Elastic.Installer.Domain.csproj
@@ -118,6 +118,9 @@
     <Compile Include="Model\Elasticsearch\Notice\NoticeModelValidator.cs" />
     <Compile Include="Model\Elasticsearch\Plugins\PluginsModel.cs" />
     <Compile Include="Model\Elasticsearch\Plugins\PluginsModelValidator.cs" />
+    <Compile Include="Model\Elasticsearch\XPack\XPackModel.cs" />
+    <Compile Include="Model\Elasticsearch\XPack\XPackModelValidator.cs" />
+    <Compile Include="Model\Elasticsearch\XPack\XPackLicenseMode.cs" />
     <Compile Include="Model\Kibana\Closing\ClosingModel.cs" />
     <Compile Include="Model\Kibana\Closing\ClosingModelValidator.cs" />
     <Compile Include="Model\Kibana\Configuration\ConfigurationModel.cs" />

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/InstallationModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/InstallationModelBase.cs
@@ -131,13 +131,19 @@ namespace Elastic.Installer.Domain.Model.Base
 			get => tabSelectedIndex;
 			set => this.RaiseAndSetIfChanged(ref tabSelectedIndex, value);
 		}
-
-		private IList<ValidationFailure> currentValidationFailures = new List<ValidationFailure>();
-
-		public IList<ValidationFailure> CurrentStepValidationFailures
+		
+		int? tabFirstInvalidIndex;
+		public int? TabFirstInvalidIndex
 		{
-			get => currentValidationFailures;
-			protected set => this.RaiseAndSetIfChanged(ref currentValidationFailures, value);
+			get => tabFirstInvalidIndex;
+			set => this.RaiseAndSetIfChanged(ref tabFirstInvalidIndex, value);
+		}
+
+		private IList<ValidationFailure> firstInvalidValidationFailures = new List<ValidationFailure>();
+		public IList<ValidationFailure> FirstInvalidStepValidationFailures
+		{
+			get => firstInvalidValidationFailures;
+			protected set => this.RaiseAndSetIfChanged(ref firstInvalidValidationFailures, value);
 		}
 
 		bool sameVersionAlreadyInstalled;

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/InstallationModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/InstallationModelBase.cs
@@ -27,8 +27,9 @@ namespace Elastic.Installer.Domain.Model.Base
 
 		public ISession Session { get; }
 
-		public ReactiveList<IStep> AllSteps { get; protected set; } = new ReactiveList<IStep>();
-		public IReactiveDerivedList<IStep> Steps { get; protected set; } = new ReactiveList<IStep>().CreateDerivedCollection(x => x, x => true);
+		public ReactiveList<IStep> AllSteps { get; }
+		public IReactiveDerivedList<IStep> Steps { get; } 
+
 		public IStep ActiveStep => this.Steps[this.TabSelectedIndex];
 
 		public ReactiveCommand<object> Next { get; }
@@ -47,9 +48,13 @@ namespace Elastic.Installer.Domain.Model.Base
 			IWixStateProvider wixStateProvider,
 			ISession session,
 			string[] args
-			)
+		)
 		{
 			this.Session = session;
+
+			this.AllSteps = new ReactiveList<IStep> {ChangeTrackingEnabled = true};
+			this.Steps = this.AllSteps.CreateDerivedCollection(x => x, x => x.IsRelevant);
+			this.Steps.Changed.Subscribe(e => this.Steps.RaisePropertyChanged());
 
 			this._wixStateProvider = wixStateProvider ?? throw new ArgumentNullException(nameof(wixStateProvider));
 
@@ -59,17 +64,11 @@ namespace Elastic.Installer.Domain.Model.Base
 				(i, max) => i.GetValue() < max.GetValue());
 
 			this.Next = ReactiveCommand.Create(canMoveForwards);
-			this.Next.Subscribe(i =>
-			{
-				this.TabSelectedIndex = Math.Min(this.Steps.Count - 1, this.TabSelectedIndex + 1);
-			});
+			this.Next.Subscribe(i => { this.TabSelectedIndex = Math.Min(this.Steps.Count - 1, this.TabSelectedIndex + 1); });
 
 			var canMoveBackwards = this.WhenAny(vm => vm.TabSelectedIndex, i => i.GetValue() > 0);
 			this.Back = ReactiveCommand.Create(canMoveBackwards);
-			this.Back.Subscribe(i =>
-			{
-				this.TabSelectedIndex = Math.Max(0, this.TabSelectedIndex - 1);
-			});
+			this.Back.Subscribe(i => { this.TabSelectedIndex = Math.Max(0, this.TabSelectedIndex - 1); });
 
 			this.Help = ReactiveCommand.Create();
 			this.ShowLicenseBlurb = ReactiveCommand.Create();
@@ -79,13 +78,12 @@ namespace Elastic.Installer.Domain.Model.Base
 			this.Exit = ReactiveCommand.Create();
 			this.Proxy = ReactiveCommand.Create();
 
+			this.Steps.Changed.Subscribe((e => UpdateNextButtonText(this.TabSelectedIndex)));
 			this.WhenAny(vm => vm.TabSelectedIndex, v => v.GetValue())
 				.Subscribe(i =>
 				{
+					this.UpdateNextButtonText(i);
 					var c = this.Steps.Count;
-					if (i == (c - 1)) this.NextButtonText = TextResources.SetupView_ExitText;
-					else if (i == (c - 2)) this.NextButtonText = TextResources.SetupView_InstallText;
-					else this.NextButtonText = TextResources.SetupView_NextText;
 					ProxyButtonVisible = c > 0 && ActiveStep is PluginsModel;
 				});
 
@@ -96,6 +94,14 @@ namespace Elastic.Installer.Domain.Model.Base
 						.Where(v => PrerequisiteProperties.Contains(v.PropertyName))
 						.ToList();
 				});
+		}
+
+		private void UpdateNextButtonText(int i)
+		{
+			var c = this.Steps.Count;
+			if (i == (c - 1)) this.NextButtonText = TextResources.SetupView_ExitText;
+			else if (i == (c - 2)) this.NextButtonText = TextResources.SetupView_InstallText;
+			else this.NextButtonText = TextResources.SetupView_NextText;
 		}
 
 		string nextButtonText;
@@ -127,6 +133,7 @@ namespace Elastic.Installer.Domain.Model.Base
 		}
 
 		private IList<ValidationFailure> currentValidationFailures = new List<ValidationFailure>();
+
 		public IList<ValidationFailure> CurrentStepValidationFailures
 		{
 			get => currentValidationFailures;

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
@@ -60,6 +60,12 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 				plugin.Selected = true;
 		}
 
+		public void ChangeXPackSelection(bool selected)
+		{
+			var xpackPlugin = this.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
+			xpackPlugin.Selected = selected;
+		}
+
 		public override string ToString()
 		{
 			var sb = new StringBuilder();

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/StepBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/StepBase.cs
@@ -8,6 +8,8 @@ namespace Elastic.Installer.Domain.Model.Base
 		/// <summary>Whether this model is relevant in the global scheme of things</summary>
 		bool IsRelevant { get; }
 
+		bool IsVisible { get; }
+		
 		bool IsSelected { get; set;  }
 
 		string Header { get; }
@@ -22,6 +24,12 @@ namespace Elastic.Installer.Domain.Model.Base
 		{
 			get => isRelevant;
 			protected set => this.RaiseAndSetIfChanged(ref isRelevant, value);
+		}
+		bool isVisible = true;
+		public bool IsVisible
+		{
+			get => isVisible;
+			protected set => this.RaiseAndSetIfChanged(ref isVisible, value);
 		}
 		bool isSelected = true;
 		public bool IsSelected

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/StepBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/StepBase.cs
@@ -8,8 +8,6 @@ namespace Elastic.Installer.Domain.Model.Base
 		/// <summary>Whether this model is relevant in the global scheme of things</summary>
 		bool IsRelevant { get; }
 
-		bool IsVisible { get; }
-		
 		bool IsSelected { get; set;  }
 
 		string Header { get; }
@@ -24,12 +22,6 @@ namespace Elastic.Installer.Domain.Model.Base
 		{
 			get => isRelevant;
 			protected set => this.RaiseAndSetIfChanged(ref isRelevant, value);
-		}
-		bool isVisible = true;
-		public bool IsVisible
-		{
-			get => isVisible;
-			protected set => this.RaiseAndSetIfChanged(ref isVisible, value);
 		}
 		bool isSelected = true;
 		public bool IsSelected

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
@@ -34,7 +34,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Config
 		public const int PortMaximum = 65535;
 		public const int HttpPortDefault = 9200;
 		public const int TransportPortDefault = 9300;
-
+		
 		public ConfigurationModel(ElasticsearchYamlConfiguration yamlConfiguration, LocalJvmOptionsConfiguration localJvmOptions)
 		{
 			this.Header = "Configuration";
@@ -212,7 +212,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Config
 		}
 
 		int? transportPort;
-
 		[StaticArgument(nameof(TransportPort))]
 		public int? TransportPort
 		{

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchArgumentParser.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchArgumentParser.cs
@@ -8,6 +8,7 @@ using Elastic.Installer.Domain.Model.Elasticsearch.Config;
 using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
 using Elastic.Installer.Domain.Model.Elasticsearch.Notice;
 using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 
 namespace Elastic.Installer.Domain.Model.Elasticsearch
 {
@@ -21,6 +22,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			typeof(ConfigurationModel),
 			typeof(ServiceModel),
 			typeof(PluginsModel),
+			typeof(XPackModel),
 			typeof(ClosingModel)
 		};
 

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -94,7 +94,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			var observeXPackEnabled = this.WhenAnyValue(vm => vm.PluginsModel.XPackEnabled);
 			var canAutomaticallySetup = this.WhenAnyValue(vm => vm.ServiceModel.StartAfterInstall, vm => vm.ServiceModel.InstallAsService)
 				.Select(t => t.Item1 && t.Item2);
-			this.XPackModel = new XPackModel(observeXPackEnabled, canAutomaticallySetup);
+			this.XPackModel = new XPackModel(versionConfig, observeXPackEnabled, canAutomaticallySetup);
 
 //			this.WhenAnyValue(vm => vm.XPackModel.XPackLicense)
 //				.Subscribe(l =>

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -23,6 +23,7 @@ using Elastic.Installer.Domain.Model.Elasticsearch.Config;
 using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
 using Elastic.Installer.Domain.Model.Elasticsearch.Notice;
 using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using FluentValidation.Results;
 using ReactiveUI;
 
@@ -40,6 +41,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 		public LocationsModel LocationsModel { get; }
 		public ConfigurationModel ConfigurationModel { get; }
 		public PluginsModel PluginsModel { get; }
+		public XPackModel XPackModel { get; }
 		public ServiceModel ServiceModel { get; }
 		public ClosingModel ClosingModel { get; }
 
@@ -89,6 +91,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				vm => vm.LocationsModel.ConfigDirectory
 			);
 			this.PluginsModel = new PluginsModel(pluginStateProvider, pluginDependencies);
+			var observeXPackEnabled = this.WhenAnyValue(vm => vm.PluginsModel.XPackEnabled);
+			this.XPackModel = new XPackModel(observeXPackEnabled);
 
 			var isUpgrade = versionConfig.InstallationDirection == InstallationDirection.Up;
 			var observeHost = this.WhenAnyValue(vm => vm.ConfigurationModel.NetworkHost, vm => vm.ConfigurationModel.HttpPort,
@@ -97,32 +101,32 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			var observeElasticsearchLog = this.WhenAnyValue(vm => vm.LocationsModel.ElasticsearchLog);
 
 			var installXPack = this.PluginsModel.DefaultPlugins().Contains("x-pack");
-			var observeInstallXPack = this.PluginsModel.AvailablePlugins.ItemChanged
-				.Where(x => x.PropertyName == nameof(Plugin.Selected) && x.Sender.PluginType == PluginType.XPack)
-				.Select(x => x.Sender.Selected);
 
 			this.ClosingModel = new ClosingModel(wixStateProvider.CurrentVersion, isUpgrade, installXPack, observeHost, observeInstallationLog,
-				observeElasticsearchLog, observeInstallXPack, serviceStateProvider);
-			this.AllSteps = new ReactiveList<IStep>
+				observeElasticsearchLog, observeXPackEnabled, serviceStateProvider);
+			
+			this.AllSteps.AddRange(new List<IStep>
 			{
 				this.NoticeModel,
 				this.LocationsModel,
 				this.ServiceModel,
 				this.ConfigurationModel,
 				this.PluginsModel,
+				this.XPackModel,
 				this.ClosingModel
-			};
-			this.Steps = this.AllSteps.CreateDerivedCollection(x => x, x => x.IsRelevant);
+			});
+			this.AllSteps.ChangeTrackingEnabled = true;
 
 			var observeValidationChanges = this.WhenAny(
 				vm => vm.NoticeModel.ValidationFailures,
 				vm => vm.LocationsModel.ValidationFailures,
 				vm => vm.ConfigurationModel.ValidationFailures,
 				vm => vm.PluginsModel.ValidationFailures,
+				vm => vm.XPackModel.ValidationFailures,
 				vm => vm.ServiceModel.ValidationFailures,
 				vm => vm.ClosingModel.ValidationFailures,
 				vm => vm.TabSelectedIndex,
-				(welcome, locations, configuration, plugins, service, install, index) =>
+				(welcome, locations, configuration, plugins, xpack, service, install, index) =>
 				{
 					var firstInvalidScreen = this.Steps.FirstOrDefault(s => !s.IsValid) ?? this.ClosingModel;
 					return firstInvalidScreen;
@@ -140,15 +144,20 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 					vm => vm.LocationsModel.IsValid,
 					vm => vm.ConfigurationModel.IsValid,
 					vm => vm.PluginsModel.IsValid,
+					vm => vm.XPackModel.IsValid,
 					vm => vm.ServiceModel.IsValid,
 					vm => vm.ClosingModel.IsValid,
-					(welcome, locations, configuration, plugins, service, install) =>
+					(welcome, locations, configuration, plugins, xpack, service, install) =>
 					{
+                        var count = this.Steps.Count;
+						var steps = this.Steps.Select(s => s.GetType().Name).ToList();
 						var firstInvalidScreen = this.Steps.Select((s, i) => new {s, i}).FirstOrDefault(s => !s.s.IsValid);
 						return firstInvalidScreen?.i ?? (this.Steps.Count - 1);
 					})
 				.Subscribe(selected =>
 				{
+					var count = this.Steps.Count;
+					var steps = this.Steps.Select(s => s.GetType().Name).ToList();
 					this.TabSelectionMax = selected;
 					//if one of the steps prior to the current selection is invalid jump back
 					if (this.TabSelectedIndex > this.TabSelectionMax)
@@ -156,6 +165,23 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 
 					this.CurrentStepValidationFailures = this.ActiveStep.ValidationFailures;
 				});
+
+			this.Steps.Changed.Subscribe(e =>
+			{
+				var count = this.Steps.Count;
+				var steps = this.Steps.Select(s => s.GetType().Name).ToList();
+				
+				var firstInvalidScreen = this.Steps.Select((s, i) => new {s, i}).FirstOrDefault(s => !s.s.IsValid);
+				var selectedTabIndex = firstInvalidScreen?.i ?? (this.Steps.Count - 1);
+				this.TabSelectionMax = selectedTabIndex;
+				
+				//if one of the steps prior to the current selection is invalid jump back
+				if (this.TabSelectedIndex > this.TabSelectionMax)
+					this.TabSelectedIndex = this.TabSelectionMax;
+
+				this.CurrentStepValidationFailures = this.ActiveStep.ValidationFailures;
+
+			});
 
 			this.Install = ReactiveCommand.CreateAsyncTask(observeValidationChanges.Select(s => s.IsValid), _ =>
 			{
@@ -282,6 +308,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			sb.AppendLine(nameof(ElasticsearchInstallationModel));
 			sb.AppendLine($"- {nameof(IsValid)} = " + IsValid);
 			sb.AppendLine($"- {nameof(ValidationFailures)} = " + ValidationFailuresString(this.ValidationFailures));
+			sb.AppendLine($"- {nameof(CurrentStepValidationFailures)} = " + ValidationFailuresString(this.CurrentStepValidationFailures));
 			sb.AppendLine($"- {nameof(MsiLogFileLocation)} = " + MsiLogFileLocation);
 			sb.AppendLine($"- {nameof(JavaInstalled)} = " + JavaInstalled);
 			sb.AppendLine($"- {nameof(JavaMisconfigured)} = " + JavaMisconfigured);
@@ -292,6 +319,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			sb.AppendLine(this.ServiceModel.ToString());
 			sb.AppendLine(this.ConfigurationModel.ToString());
 			sb.AppendLine(this.PluginsModel.ToString());
+			sb.AppendLine(this.XPackModel.ToString());
 			return sb.ToString();
 		}
 

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -96,11 +96,11 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				.Select(t => t.Item1 && t.Item2);
 			this.XPackModel = new XPackModel(observeXPackEnabled, canAutomaticallySetup);
 
-			this.WhenAnyValue(vm => vm.XPackModel.XPackLicense)
-				.Subscribe(l =>
-				{
-					this.PluginsModel.ChangeXPackSelection(l.HasValue);
-				});
+//			this.WhenAnyValue(vm => vm.XPackModel.XPackLicense)
+//				.Subscribe(l =>
+//				{
+//					this.PluginsModel.ChangeXPackSelection(l.HasValue);
+//				});
 
 			var isUpgrade = versionConfig.InstallationDirection == InstallationDirection.Up;
 			var observeHost = this.WhenAnyValue(vm => vm.ConfigurationModel.NetworkHost, vm => vm.ConfigurationModel.HttpPort,
@@ -272,7 +272,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 
 		public override void Refresh()
 		{
-			foreach (var step in this.Steps) step.Refresh();
+			foreach (var step in this.AllSteps) step.Refresh();
 
 			this.JavaInstalled = JavaConfiguration.JavaInstalled;
 			this.JavaMisconfigured = JavaConfiguration.JavaMisconfigured;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -96,6 +96,13 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				.Select(t => t.Item1 && t.Item2);
 			this.XPackModel = new XPackModel(observeXPackEnabled, canAutomaticallySetup);
 
+			this.WhenAnyValue(vm => vm.XPackModel.XPackLicense)
+				.Subscribe(l =>
+				{
+					var xPackPlugin = this.PluginsModel.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
+					xPackPlugin.Selected = l.HasValue;
+				});
+
 			var isUpgrade = versionConfig.InstallationDirection == InstallationDirection.Up;
 			var observeHost = this.WhenAnyValue(vm => vm.ConfigurationModel.NetworkHost, vm => vm.ConfigurationModel.HttpPort,
 				(h, p) => $"http://{(string.IsNullOrWhiteSpace(h) ? "localhost" : h)}:{p}");

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -132,11 +132,14 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 					return firstInvalidScreen;
 				});
 			observeValidationChanges
-				.Subscribe(selected =>
+				.Subscribe(firstInvalidStep =>
 				{
-					var step = this.Steps[this.TabSelectedIndex];
-					var failures = step.ValidationFailures;
-					this.CurrentStepValidationFailures = selected.ValidationFailures;
+					this.TabFirstInvalidIndex = this.Steps
+						.Select((s, i) => new {s, i = (int?)i})
+						.Where(t => !t.s.IsValid)
+						.Select(t => t.i)
+						.FirstOrDefault();
+					this.FirstInvalidStepValidationFailures = firstInvalidStep.ValidationFailures;
 				});
 
 			this.WhenAny(
@@ -163,7 +166,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 					if (this.TabSelectedIndex > this.TabSelectionMax)
 						this.TabSelectedIndex = this.TabSelectionMax;
 
-					this.CurrentStepValidationFailures = this.ActiveStep.ValidationFailures;
+					this.FirstInvalidStepValidationFailures = this.ActiveStep.ValidationFailures;
 				});
 
 			this.Steps.Changed.Subscribe(e =>
@@ -179,7 +182,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				if (this.TabSelectedIndex > this.TabSelectionMax)
 					this.TabSelectedIndex = this.TabSelectionMax;
 
-				this.CurrentStepValidationFailures = this.ActiveStep.ValidationFailures;
+				this.FirstInvalidStepValidationFailures = this.ActiveStep.ValidationFailures;
 
 			});
 
@@ -308,7 +311,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			sb.AppendLine(nameof(ElasticsearchInstallationModel));
 			sb.AppendLine($"- {nameof(IsValid)} = " + IsValid);
 			sb.AppendLine($"- {nameof(ValidationFailures)} = " + ValidationFailuresString(this.ValidationFailures));
-			sb.AppendLine($"- {nameof(CurrentStepValidationFailures)} = " + ValidationFailuresString(this.CurrentStepValidationFailures));
+			sb.AppendLine($"- {nameof(FirstInvalidStepValidationFailures)} = " + ValidationFailuresString(this.FirstInvalidStepValidationFailures));
 			sb.AppendLine($"- {nameof(MsiLogFileLocation)} = " + MsiLogFileLocation);
 			sb.AppendLine($"- {nameof(JavaInstalled)} = " + JavaInstalled);
 			sb.AppendLine($"- {nameof(JavaMisconfigured)} = " + JavaMisconfigured);

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -92,7 +92,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			);
 			this.PluginsModel = new PluginsModel(pluginStateProvider, pluginDependencies);
 			var observeXPackEnabled = this.WhenAnyValue(vm => vm.PluginsModel.XPackEnabled);
-			this.XPackModel = new XPackModel(observeXPackEnabled);
+			var canAutomaticallySetup = this.WhenAnyValue(vm => vm.ServiceModel.StartAfterInstall, vm => vm.ServiceModel.InstallAsService)
+				.Select(t => t.Item1 && t.Item2);
+			this.XPackModel = new XPackModel(observeXPackEnabled, canAutomaticallySetup);
 
 			var isUpgrade = versionConfig.InstallationDirection == InstallationDirection.Up;
 			var observeHost = this.WhenAnyValue(vm => vm.ConfigurationModel.NetworkHost, vm => vm.ConfigurationModel.HttpPort,

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -99,8 +99,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			this.WhenAnyValue(vm => vm.XPackModel.XPackLicense)
 				.Subscribe(l =>
 				{
-					var xPackPlugin = this.PluginsModel.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
-					xPackPlugin.Selected = l.HasValue;
+					this.PluginsModel.ChangeXPackSelection(l.HasValue);
 				});
 
 			var isUpgrade = versionConfig.InstallationDirection == InstallationDirection.Up;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModelValidator.cs
@@ -37,12 +37,14 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 
 			RuleFor(vm => vm.Steps)
 				.Must(steps => steps.Where(s => s != null).All(s => s.IsValid))
-				.When(vm => !vm.JavaInstalled
-							&& !vm.JavaMisconfigured
-							&& !vm.Using32BitJava
-							&& !vm.SameVersionAlreadyInstalled
-							&& !vm.HigherVersionAlreadyInstalled
-							&& !vm.BadElasticsearchYamlFile)
+				.When(vm => 
+					vm.Steps != null
+					&& !vm.JavaInstalled
+					&& !vm.JavaMisconfigured
+					&& !vm.Using32BitJava
+					&& !vm.SameVersionAlreadyInstalled
+					&& !vm.HigherVersionAlreadyInstalled
+					&& !vm.BadElasticsearchYamlFile)
 				.WithMessage(NotAllModelsAreValid);
 		}
 	}

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -35,15 +35,16 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				{
 					if (!any) this.HasInternetConnection = true;
 				});
-			
+
 			this.AvailablePlugins.ItemChanged
 				.Where(x => x.PropertyName == nameof(Plugin.Selected) && x.Sender.PluginType == PluginType.XPack)
 				.Select(x => x.Sender.Selected)
 				.Subscribe(selected =>
 				{
 					this.XPackEnabled = selected;
+					this.Validate();
 				});
-			
+
 			Observable.Timer(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(2))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(async _ => await SetInternetConnection());
@@ -81,20 +82,22 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 		private async Task SetInternetConnection()
 		{
 			if (!this.Plugins.Any()) return;
-			
+
 			this.HasInternetConnection = await this.PluginStateProvider.HasInternetConnection();
 			this.Validate();
 		}
-		
+
 		bool xPackEnabled;
+
 		public bool XPackEnabled
 		{
 			get => this.xPackEnabled;
 			private set => this.RaiseAndSetIfChanged(ref this.xPackEnabled, value);
 		}
-		
-		bool hasInternetConnection;
-		public bool HasInternetConnection
+
+		bool? hasInternetConnection;
+
+		public bool? HasInternetConnection
 		{
 			get => this.hasInternetConnection;
 			set => this.RaiseAndSetIfChanged(ref this.hasInternetConnection, value);
@@ -179,7 +182,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				Url = "analysis-kuromoji",
 				DisplayName = "Japanese (kuromoji) Analysis",
 				Description = TextResources.PluginsModel_JapaneseAnalysis
-
 			};
 
 			yield return new Plugin
@@ -188,7 +190,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				Url = "analysis-phonetic",
 				DisplayName = "Phonetic Analysis",
 				Description = TextResources.PluginsModel_Phonetic
-
 			};
 
 			yield return new Plugin
@@ -205,7 +206,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				Url = "analysis-stempel",
 				DisplayName = "Stempel Polish Analysis",
 				Description = TextResources.PluginsModel_StempelPolishAnalysis
-
 			};
 
 			yield return new Plugin

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -77,6 +77,11 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 		{
 			base.Refresh();
 			this.HasInternetConnection = true;
+
+			this.HttpProxyHost = null;
+			this.HttpProxyPort = null;
+			this.HttpsProxyHost = null;
+			this.HttpsProxyPort = null;		
 		}
 
 		private async Task SetInternetConnection()
@@ -297,14 +302,5 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 			};
 		}
 
-		public override void Refresh()
-		{
-			base.Refresh();
-
-			this.HttpProxyHost = null;
-			this.HttpProxyPort = null;
-			this.HttpsProxyHost = null;
-			this.HttpsProxyPort = null;		
-		}
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModelValidator.cs
@@ -19,7 +19,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 		public PluginsModelValidator()
 		{
 			RuleFor(vm => vm.HasInternetConnection)
-				.Must(v => v)
+				.Must(v => !v.HasValue || v.Value)
 				.When(vm => vm.Plugins.Any())
 				.WithMessage(NoInternet);
 

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackLicenseMode.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackLicenseMode.cs
@@ -2,7 +2,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 {
 	public enum XPackLicenseMode
 	{
-		Trial,
-		Basic
+		Basic,
+		Trial
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackLicenseMode.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackLicenseMode.cs
@@ -1,0 +1,8 @@
+namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
+{
+	public enum XPackLicenseMode
+	{
+		Trial,
+		Basic
+	}
+}

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -97,7 +97,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			}
 		}
 
-		public bool NeedsPassword =>
+		public bool NeedsPasswords =>
 			this.IsRelevant 
 			&& this.CanAutomaticallySetupUsers 
 			&& this.XPackLicense == XPackLicenseMode.Trial
@@ -109,8 +109,17 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			var sb = new StringBuilder();
 			sb.AppendLine(nameof(XPackModel));
 			sb.AppendLine($"- {nameof(IsValid)} = " + IsValid);
+			sb.AppendLine($"- {nameof(NeedsPasswords)} = " + NeedsPasswords);
 			if (XPackLicense.HasValue)
 				sb.AppendLine($"- {nameof(XPackLicense)} = " + Enum.GetName(typeof(XPackLicenseMode), XPackLicense.Value));
+			else
+				sb.AppendLine($"- {nameof(XPackLicense)} = null");
+			sb.AppendLine($"- {nameof(this.CanAutomaticallySetupUsers)} = " + CanAutomaticallySetupUsers);
+			sb.AppendLine($"- {nameof(this.SkipSettingPasswords)} = " + SkipSettingPasswords);
+			sb.AppendLine($"- {nameof(this.XPackSecurityEnabled)} = " + SkipSettingPasswords);
+			sb.AppendLine($"- {nameof(this.ElasticUserPassword)} = " + !string.IsNullOrWhiteSpace(ElasticUserPassword));
+			sb.AppendLine($"- {nameof(this.KibanaUserPassword)} = " + !string.IsNullOrWhiteSpace(KibanaUserPassword));
+			sb.AppendLine($"- {nameof(this.LogstashSystemUserPassword)} = " + !string.IsNullOrWhiteSpace(LogstashSystemUserPassword));
 			return sb.ToString();
 		}
 

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -20,7 +20,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			xPackEnabled.Subscribe(t =>
 			{
 				this.IsRelevant = t;
-				this.XPackLicense = !t ? (XPackLicenseMode?)null : _lastSetXpackLicenseMode;
 			});
 			canAutomaticallySetupUsers.Subscribe(b=>
 			{
@@ -40,21 +39,21 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 		}
 		
 		string elasticUserPassword;
-		[StaticArgument(nameof(ElasticUserPassword), IsHidden = true)]
+		[Argument(nameof(ElasticUserPassword), IsHidden = true)]
 		public string ElasticUserPassword
 		{
 			get => this.elasticUserPassword;
 			set => this.RaiseAndSetIfChanged(ref this.elasticUserPassword, value);
 		}
 		string kibanaUserPassword;
-		[StaticArgument(nameof(KibanaUserPassword), IsHidden = true)]
+		[Argument(nameof(KibanaUserPassword), IsHidden = true)]
 		public string KibanaUserPassword
 		{
 			get => this.kibanaUserPassword;
 			set => this.RaiseAndSetIfChanged(ref this.kibanaUserPassword, value);
 		}
 		string logstashSystemUserPassword;
-		[StaticArgument(nameof(LogstashSystemUserPassword), IsHidden = true)]
+		[Argument(nameof(LogstashSystemUserPassword), IsHidden = true)]
 		public string LogstashSystemUserPassword
 		{
 			get => this.logstashSystemUserPassword;
@@ -69,7 +68,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 		}
 		
 		bool xPackSecurityEnabled;
-		[StaticArgument(nameof(XPackSecurityEnabled))]
+		[Argument(nameof(XPackSecurityEnabled))]
 		public bool XPackSecurityEnabled
 		{
 			get => this.xPackSecurityEnabled;
@@ -77,22 +76,20 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 		}
 		
 		bool skipSettingPasswords;
-		[StaticArgument(nameof(SkipSettingPasswords))]
+		[Argument(nameof(SkipSettingPasswords))]
 		public bool SkipSettingPasswords
 		{
 			get => this.skipSettingPasswords;
 			set => this.RaiseAndSetIfChanged(ref this.skipSettingPasswords, value);
 		}
 
-		XPackLicenseMode _lastSetXpackLicenseMode = DefaultXPackLicenseMode;
-		XPackLicenseMode? xPackLicense;
-		[StaticArgument(nameof(XPackLicense))]
-		public XPackLicenseMode? XPackLicense
+		XPackLicenseMode xPackLicense;
+		[Argument(nameof(XPackLicense))]
+		public XPackLicenseMode XPackLicense
 		{
 			get => this.xPackLicense;
 			set
 			{
-				if (value.HasValue) this._lastSetXpackLicenseMode = value.Value;
 				this.RaiseAndSetIfChanged(ref this.xPackLicense, value);
 			}
 		}
@@ -109,11 +106,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			var sb = new StringBuilder();
 			sb.AppendLine(nameof(XPackModel));
 			sb.AppendLine($"- {nameof(IsValid)} = " + IsValid);
+			sb.AppendLine($"- {nameof(IsRelevant)} = " + IsRelevant);
 			sb.AppendLine($"- {nameof(NeedsPasswords)} = " + NeedsPasswords);
-			if (XPackLicense.HasValue)
-				sb.AppendLine($"- {nameof(XPackLicense)} = " + Enum.GetName(typeof(XPackLicenseMode), XPackLicense.Value));
-			else
-				sb.AppendLine($"- {nameof(XPackLicense)} = null");
+			sb.AppendLine($"- {nameof(XPackLicense)} = " + Enum.GetName(typeof(XPackLicenseMode), XPackLicense));
 			sb.AppendLine($"- {nameof(this.CanAutomaticallySetupUsers)} = " + CanAutomaticallySetupUsers);
 			sb.AppendLine($"- {nameof(this.SkipSettingPasswords)} = " + SkipSettingPasswords);
 			sb.AppendLine($"- {nameof(this.XPackSecurityEnabled)} = " + SkipSettingPasswords);

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Elastic.Configuration.FileBased.JvmOpts;
+using Elastic.Configuration.FileBased.Yaml;
+using Elastic.Installer.Domain.Model.Base;
+using Microsoft.VisualBasic.Devices;
+using ReactiveUI;
+
+namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
+{
+	public class XPackModel : StepBase<XPackModel, XPackModelValidator>
+	{
+		public const XPackLicenseMode DefaultXPackLicenseMode = XPackLicenseMode.Trial;
+		
+		public XPackModel(IObservable<bool> xPackEnabled)
+		{
+			xPackEnabled.Subscribe(t =>
+			{
+				this._xPackLicenseDefault = t ? DefaultXPackLicenseMode : (XPackLicenseMode?)null;
+				this.IsRelevant = t;
+				this.IsVisible = t;
+				this.Refresh();
+			});
+			this.Header = "X-Pack";
+			this.Refresh();
+		}
+
+		public sealed override void Refresh()
+		{
+			this.XPackLicense = this._xPackLicenseDefault;
+			this.XPackUsername = "elastic";
+			this.XPackUserPassword = null;
+		}
+		
+		string _xPackUsername;
+		[StaticArgument(nameof(_xPackUsername))]
+		public string XPackUsername
+		{
+			get => this._xPackUsername;
+			set => this.RaiseAndSetIfChanged(ref this._xPackUsername, value);
+		}
+		string xPackUserPassword;
+		[StaticArgument(nameof(xPackUserPassword))]
+		public string XPackUserPassword
+		{
+			get => this.xPackUserPassword;
+			set => this.RaiseAndSetIfChanged(ref this.xPackUserPassword, value);
+		}
+
+		XPackLicenseMode? _xPackLicenseDefault;
+		XPackLicenseMode? xPackLicense;
+		[StaticArgument(nameof(XPackLicense))]
+		public XPackLicenseMode? XPackLicense
+		{
+			get => this.xPackLicense;
+			set => this.RaiseAndSetIfChanged(ref this.xPackLicense, value);
+		}
+		
+		public override string ToString()
+		{
+			var sb = new StringBuilder();
+			sb.AppendLine(nameof(XPackModel));
+			sb.AppendLine($"- {nameof(IsValid)} = " + IsValid);
+			if (XPackLicense.HasValue)
+				sb.AppendLine($"- {nameof(XPackLicense)} = " + Enum.GetName(typeof(XPackLicenseMode), XPackLicense.Value));
+			return sb.ToString();
+		}
+
+	}
+}

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Globalization;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using Elastic.Configuration.FileBased.JvmOpts;
-using Elastic.Configuration.FileBased.Yaml;
 using Elastic.Installer.Domain.Model.Base;
-using Microsoft.VisualBasic.Devices;
 using ReactiveUI;
 
 namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
@@ -35,6 +29,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			this.ElasticUserPassword = null;
 			this.KibanaUserPassword = null;
 			this.LogstashSystemUserPassword = null;
+			this.BootstrapPassword = null;
 			this.XPackSecurityEnabled = true;
 		}
 		
@@ -88,10 +83,15 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 		public XPackLicenseMode XPackLicense
 		{
 			get => this.xPackLicense;
-			set
-			{
-				this.RaiseAndSetIfChanged(ref this.xPackLicense, value);
-			}
+			set => this.RaiseAndSetIfChanged(ref this.xPackLicense, value);
+		}
+
+		private string bootstrapPassword;
+		[Argument(nameof(BootstrapPassword), IsHidden = true)]
+		public string BootstrapPassword
+		{
+			get => this.bootstrapPassword;
+			set => this.RaiseAndSetIfChanged(ref this.bootstrapPassword, value);
 		}
 
 		public bool NeedsPasswords =>
@@ -112,6 +112,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			sb.AppendLine($"- {nameof(this.CanAutomaticallySetupUsers)} = " + CanAutomaticallySetupUsers);
 			sb.AppendLine($"- {nameof(this.SkipSettingPasswords)} = " + SkipSettingPasswords);
 			sb.AppendLine($"- {nameof(this.XPackSecurityEnabled)} = " + SkipSettingPasswords);
+			sb.AppendLine($"- {nameof(this.BootstrapPassword)} = " + !string.IsNullOrWhiteSpace(BootstrapPassword));
 			sb.AppendLine($"- {nameof(this.ElasticUserPassword)} = " + !string.IsNullOrWhiteSpace(ElasticUserPassword));
 			sb.AppendLine($"- {nameof(this.KibanaUserPassword)} = " + !string.IsNullOrWhiteSpace(KibanaUserPassword));
 			sb.AppendLine($"- {nameof(this.LogstashSystemUserPassword)} = " + !string.IsNullOrWhiteSpace(LogstashSystemUserPassword));

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -25,7 +25,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			canAutomaticallySetupUsers.Subscribe(b=>
 			{
 				this.CanAutomaticallySetupUsers = b;
-				this.GenerateUsersLater = !b;
+				this.SkipSettingPasswords = !b;
 			});
 			this.Header = "X-Pack";
 			this.Refresh();
@@ -76,12 +76,12 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			set => this.RaiseAndSetIfChanged(ref this.xPackSecurityEnabled, value);
 		}
 		
-		bool generateUsersLater;
-		[StaticArgument(nameof(GenerateUsersLater))]
-		public bool GenerateUsersLater
+		bool skipSettingPasswords;
+		[StaticArgument(nameof(SkipSettingPasswords))]
+		public bool SkipSettingPasswords
 		{
-			get => this.generateUsersLater;
-			set => this.RaiseAndSetIfChanged(ref this.generateUsersLater, value);
+			get => this.skipSettingPasswords;
+			set => this.RaiseAndSetIfChanged(ref this.skipSettingPasswords, value);
 		}
 
 		XPackLicenseMode _lastSetXpackLicenseMode = DefaultXPackLicenseMode;
@@ -101,7 +101,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			this.IsRelevant 
 			&& this.CanAutomaticallySetupUsers 
 			&& this.XPackLicense == XPackLicenseMode.Trial
-			&& !this.GenerateUsersLater
+			&& !this.SkipSettingPasswords
 			&& this.XPackSecurityEnabled;
 		
 		public override string ToString()

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Text;
+using Elastic.Installer.Domain.Configuration.Wix;
 using Elastic.Installer.Domain.Model.Base;
 using ReactiveUI;
+using Semver;
 
 namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 {
@@ -9,7 +11,10 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 	{
 		public const XPackLicenseMode DefaultXPackLicenseMode = XPackLicenseMode.Basic;
 		
-		public XPackModel(IObservable<bool> xPackEnabled, IObservable<bool> canAutomaticallySetupUsers)
+		public XPackModel(
+			VersionConfiguration versionConfig, 
+			IObservable<bool> xPackEnabled, 
+			IObservable<bool> canAutomaticallySetupUsers)
 		{
 			xPackEnabled.Subscribe(t =>
 			{
@@ -21,6 +26,10 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 				this.SkipSettingPasswords = !b;
 			});
 			this.Header = "X-Pack";
+			this.CurrentVersion = versionConfig.CurrentVersion;
+			this.OpenLicensesAndSubscriptions = ReactiveCommand.Create();
+			this.RegisterBasicLicense = ReactiveCommand.Create();
+			this.OpenManualUserConfiguration = ReactiveCommand.Create();
 			this.Refresh();
 		}
 
@@ -32,6 +41,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			this.BootstrapPassword = null;
 			this.XPackSecurityEnabled = true;
 		}
+
+		public SemVersion CurrentVersion { get; }
 		
 		string elasticUserPassword;
 		[Argument(nameof(ElasticUserPassword), IsHidden = true)]
@@ -100,7 +111,13 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			&& this.XPackLicense == XPackLicenseMode.Trial
 			&& !this.SkipSettingPasswords
 			&& this.XPackSecurityEnabled;
-		
+
+		public ReactiveCommand<object> OpenLicensesAndSubscriptions { get; }
+
+		public ReactiveCommand<object> RegisterBasicLicense { get; }
+
+		public ReactiveCommand<object> OpenManualUserConfiguration { get; }
+
 		public override string ToString()
 		{
 			var sb = new StringBuilder();

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
@@ -1,4 +1,5 @@
-﻿using Elastic.Installer.Domain.Properties;
+﻿using System;
+using Elastic.Installer.Domain.Properties;
 using FluentValidation;
 
 namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
@@ -9,13 +10,20 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 
 		public XPackModelValidator()
 		{
-			RuleFor(c => c.XPackUsername)
-				.NotEmpty().WithMessage("Username is required")
-				.When(m => m.IsRelevant);
-
-			RuleFor(c => c.XPackUserPassword)
-				.NotEmpty().WithMessage("Password is required")
-				.When(m => m.IsRelevant);
+			RuleFor(c => c.ElasticUserPassword)
+				.NotEmpty().WithMessage("`elastic` user's password is required")
+				.When(NeedsPassword);
+			
+			RuleFor(c => c.KibanaUserPassword)
+				.NotEmpty().WithMessage("`kibana` user's password is required")
+				.When(NeedsPassword);
+			
+			RuleFor(c => c.LogstashSystemUserPassword)
+				.NotEmpty().WithMessage("`logstash_system` user's password is required")
+				.When(NeedsPassword);
+			
 		}
+
+		private static bool NeedsPassword(XPackModel m) => m.NeedsPassword;
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
@@ -6,24 +6,38 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 {
 	public class XPackModelValidator : AbstractValidator<XPackModel>
 	{
-		public static readonly string NodeNameNotEmpty = TextResources.ConfigurationModelValidator_NodeName_NotEmpty;
+		public static readonly string ElasticPasswordRequired = TextResources.XPackModelValidator_ElasticPasswordRequired;
+		public static readonly string KibanaPasswordRequired = TextResources.XPackModelValidator_KibanaPasswordRequired;
+		public static readonly string LogstashPasswordRequired = TextResources.XPackModelValidator_LogstashPasswordRequired;
 
 		public XPackModelValidator()
 		{
 			RuleFor(c => c.ElasticUserPassword)
-				.NotEmpty().WithMessage("`elastic` user's password is required")
+				.NotEmpty()
+				.WithMessage(ElasticPasswordRequired)
+				.When(NeedsPassword)
+				.Length(6, int.MaxValue)
+				.WithMessage(ElasticPasswordRequired)
 				.When(NeedsPassword);
 			
 			RuleFor(c => c.KibanaUserPassword)
-				.NotEmpty().WithMessage("`kibana` user's password is required")
+				.NotEmpty()
+				.WithMessage(KibanaPasswordRequired)
+				.When(NeedsPassword)
+				.Length(6, int.MaxValue)
+				.WithMessage(KibanaPasswordRequired)
 				.When(NeedsPassword);
 			
 			RuleFor(c => c.LogstashSystemUserPassword)
-				.NotEmpty().WithMessage("`logstash_system` user's password is required")
+				.NotEmpty()
+				.WithMessage(LogstashPasswordRequired)
+				.When(NeedsPassword)
+				.Length(6, int.MaxValue)
+				.WithMessage(LogstashPasswordRequired)
 				.When(NeedsPassword);
 			
 		}
 
-		private static bool NeedsPassword(XPackModel m) => m.NeedsPassword;
+		private static bool NeedsPassword(XPackModel m) => m.NeedsPasswords;
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
@@ -9,6 +9,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 		public static readonly string ElasticPasswordRequired = TextResources.XPackModelValidator_ElasticPasswordRequired;
 		public static readonly string KibanaPasswordRequired = TextResources.XPackModelValidator_KibanaPasswordRequired;
 		public static readonly string LogstashPasswordRequired = TextResources.XPackModelValidator_LogstashPasswordRequired;
+		public static readonly string ElasticPasswordAtLeast6Characters = TextResources.XPackModelValidator_ElasticPasswordAtLeast6Characters;
+		public static readonly string KibanaPasswordAtLeast6Characters = TextResources.XPackModelValidator_KibanaPasswordAtLeast6Characters;
+		public static readonly string LogstashPasswordAtLeast6Characters = TextResources.XPackModelValidator_LogstashPasswordAtLeast6Characters;
 
 		public XPackModelValidator()
 		{
@@ -17,7 +20,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 				.WithMessage(ElasticPasswordRequired)
 				.When(NeedsPassword)
 				.Length(6, int.MaxValue)
-				.WithMessage(ElasticPasswordRequired)
+				.WithMessage(ElasticPasswordAtLeast6Characters)
 				.When(NeedsPassword);
 			
 			RuleFor(c => c.KibanaUserPassword)
@@ -25,7 +28,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 				.WithMessage(KibanaPasswordRequired)
 				.When(NeedsPassword)
 				.Length(6, int.MaxValue)
-				.WithMessage(KibanaPasswordRequired)
+				.WithMessage(KibanaPasswordAtLeast6Characters)
 				.When(NeedsPassword);
 			
 			RuleFor(c => c.LogstashSystemUserPassword)
@@ -33,9 +36,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 				.WithMessage(LogstashPasswordRequired)
 				.When(NeedsPassword)
 				.Length(6, int.MaxValue)
-				.WithMessage(LogstashPasswordRequired)
-				.When(NeedsPassword);
-			
+				.WithMessage(LogstashPasswordAtLeast6Characters)
+				.When(NeedsPassword);		
 		}
 
 		private static bool NeedsPassword(XPackModel m) => m.NeedsPasswords;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModelValidator.cs
@@ -1,0 +1,21 @@
+﻿using Elastic.Installer.Domain.Properties;
+using FluentValidation;
+
+namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
+{
+	public class XPackModelValidator : AbstractValidator<XPackModel>
+	{
+		public static readonly string NodeNameNotEmpty = TextResources.ConfigurationModelValidator_NodeName_NotEmpty;
+
+		public XPackModelValidator()
+		{
+			RuleFor(c => c.XPackUsername)
+				.NotEmpty().WithMessage("Username is required")
+				.When(m => m.IsRelevant);
+
+			RuleFor(c => c.XPackUserPassword)
+				.NotEmpty().WithMessage("Password is required")
+				.When(m => m.IsRelevant);
+		}
+	}
+}

--- a/src/Installer/Elastic.Installer.Domain/Model/Kibana/KibanaInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Kibana/KibanaInstallationModel.cs
@@ -101,7 +101,7 @@ namespace Elastic.Installer.Domain.Model.Kibana
 				{
 					var step = this.Steps[this.TabSelectedIndex];
 					var failures = step.ValidationFailures;
-					this.CurrentStepValidationFailures = selected.ValidationFailures;
+					this.FirstInvalidStepValidationFailures = selected.ValidationFailures;
 				});
 
 			this.WhenAny(
@@ -124,7 +124,7 @@ namespace Elastic.Installer.Domain.Model.Kibana
 					if (this.TabSelectedIndex > this.TabSelectionMax)
 						this.TabSelectedIndex = this.TabSelectionMax;
 
-					this.CurrentStepValidationFailures = this.ActiveStep.ValidationFailures;
+					this.FirstInvalidStepValidationFailures = this.ActiveStep.ValidationFailures;
 				});
 
 			this.Install = ReactiveCommand.CreateAsyncTask(observeValidationChanges.Select(s => s.IsValid), _ =>

--- a/src/Installer/Elastic.Installer.Domain/Model/Kibana/KibanaInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Kibana/KibanaInstallationModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -70,7 +71,7 @@ namespace Elastic.Installer.Domain.Model.Kibana
 			this.ClosingModel = new ClosingModel(wixStateProvider.CurrentVersion, isUpgrade, observeHost, observeInstallationLog,
 				observeKibanaLog, observeInstallXPack, serviceStateProvider);
 
-			this.AllSteps = new ReactiveList<IStep>
+			this.AllSteps.AddRange(new List<IStep>
 			{
 				this.NoticeModel,
 				this.LocationsModel,
@@ -79,8 +80,7 @@ namespace Elastic.Installer.Domain.Model.Kibana
 				this.ConnectingModel,
 				this.PluginsModel,
 				this.ClosingModel
-			};
-			this.Steps = this.AllSteps.CreateDerivedCollection(x => x, x => x.IsRelevant);
+			});
 
 			var observeValidationChanges = this.WhenAny(
 				vm => vm.NoticeModel.ValidationFailures,

--- a/src/Installer/Elastic.Installer.Domain/Model/ModelArgumentParser.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/ModelArgumentParser.cs
@@ -218,6 +218,13 @@ namespace Elastic.Installer.Domain.Model
 				{
 					((Action<ReactiveList<string>>)setter)(new ReactiveList<string>(a.Value.Split(',').Select(v => v.Trim())));
 				}
+				else if (p == typeof(XPackLicenseMode?))
+				{
+					if (Enum.TryParse<XPackLicenseMode>(a.Value, ignoreCase: true, result: out var licenseMode))
+						((Action<XPackLicenseMode?>)setter)(licenseMode);
+					else 
+						((Action<XPackLicenseMode?>)setter)(null);
+				}
 				else if (p == typeof(bool))
 				{
 					var s = ((Action<bool>)setter);

--- a/src/Installer/Elastic.Installer.Domain/Model/ModelArgumentParser.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/ModelArgumentParser.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Elastic.Installer.Domain.Model.Base;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using FluentValidation.Results;
 using ReactiveUI;
 
@@ -89,6 +90,8 @@ namespace Elastic.Installer.Domain.Model
 			}
 			if (v is bool)
 				return ((bool)v).ToString().ToLowerInvariant();
+			if (v is Enum)
+				return Enum.GetName(v.GetType(), v);
 
 			throw new Exception($"{v.GetType().FullName} has no supported getter");
 		}
@@ -116,6 +119,8 @@ namespace Elastic.Installer.Domain.Model
 					a.Value = MsiString(((Func<ReactiveList<string>>)getter)());
 				else if (p == typeof(bool))
 					a.Value = MsiString(((Func<bool>)getter)());
+				else if (p == typeof(XPackLicenseMode?))
+					a.Value = MsiString(((Func<XPackLicenseMode?>)getter)());
 				else
 					throw new Exception($"{p.FullName} has no supported getter");
 

--- a/src/Installer/Elastic.Installer.Domain/Model/ModelArgumentParser.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/ModelArgumentParser.cs
@@ -119,8 +119,8 @@ namespace Elastic.Installer.Domain.Model
 					a.Value = MsiString(((Func<ReactiveList<string>>)getter)());
 				else if (p == typeof(bool))
 					a.Value = MsiString(((Func<bool>)getter)());
-				else if (p == typeof(XPackLicenseMode?))
-					a.Value = MsiString(((Func<XPackLicenseMode?>)getter)());
+				else if (p == typeof(XPackLicenseMode))
+					a.Value = MsiString(((Func<XPackLicenseMode>)getter)());
 				else
 					throw new Exception($"{p.FullName} has no supported getter");
 
@@ -218,12 +218,12 @@ namespace Elastic.Installer.Domain.Model
 				{
 					((Action<ReactiveList<string>>)setter)(new ReactiveList<string>(a.Value.Split(',').Select(v => v.Trim())));
 				}
-				else if (p == typeof(XPackLicenseMode?))
+				else if (p == typeof(XPackLicenseMode))
 				{
-					if (Enum.TryParse<XPackLicenseMode>(a.Value, ignoreCase: true, result: out var licenseMode))
-						((Action<XPackLicenseMode?>)setter)(licenseMode);
-					else 
-						((Action<XPackLicenseMode?>)setter)(null);
+					if (string.IsNullOrWhiteSpace(a.Value)) 
+						((Action<XPackLicenseMode>)setter)(XPackModel.DefaultXPackLicenseMode);
+					else if (Enum.TryParse<XPackLicenseMode>(a.Value, ignoreCase: true, result: out var licenseMode))
+						((Action<XPackLicenseMode>)setter)(licenseMode);
 				}
 				else if (p == typeof(bool))
 				{

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -217,186 +217,6 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name of the cluster. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_ClusterName {
-            get {
-                return ResourceManager.GetString("InstallOptions_ClusterName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The config directory. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_ConfigDirectory {
-            get {
-                return ResourceManager.GetString("InstallOptions_ConfigDirectory", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The data directory. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_DataDirectory {
-            get {
-                return ResourceManager.GetString("InstallOptions_DataDirectory", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether this node is a Data node. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_DataNode {
-            get {
-                return ResourceManager.GetString("InstallOptions_DataNode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The heap memory that will be allocated to the Elasticsearch Java Process. This should be more than 250mb and ideally less than 32GB (so that Java uses compressed pointers). Defaults to {0}mb for this installation.
-        /// </summary>
-        public static string InstallOptions_HeapSize {
-            get {
-                return ResourceManager.GetString("InstallOptions_HeapSize", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether this node is an Ingest node. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_IngestNode {
-            get {
-                return ResourceManager.GetString("InstallOptions_IngestNode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The installation directory. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_InstallDirectory {
-            get {
-                return ResourceManager.GetString("InstallOptions_InstallDirectory", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether to lock the process address space in RAM, preventing any Elasticsearch memory from being swapped out. This uses VirtualLock on Windows. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_LockMemory {
-            get {
-                return ResourceManager.GetString("InstallOptions_LockMemory", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The logs directory. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_LogsDirectory {
-            get {
-                return ResourceManager.GetString("InstallOptions_LogsDirectory", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether this node is a Master node. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_MasterNode {
-            get {
-                return ResourceManager.GetString("InstallOptions_MasterNode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The name of the node. Defaults to {0} for this installation.
-        /// </summary>
-        public static string InstallOptions_NodeName {
-            get {
-                return ResourceManager.GetString("InstallOptions_NodeName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A comma-separated list of plugins to install as part of the Elasticsearch installation.
-        /// </summary>
-        public static string InstallOptions_Plugins {
-            get {
-                return ResourceManager.GetString("InstallOptions_Plugins", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether to automatically start the service after Windows starts/restarts, if installing as a Windows Service. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_ServiceAutomatic {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServiceAutomatic", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether to install Elasticsearch as a Windows service. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_ServiceInstall {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServiceInstall", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The name of the Windows service, if installing as a Windows Service. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_ServiceName {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServiceName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Password for the specified Username, if installing as a Windows Service.
-        /// </summary>
-        public static string InstallOptions_ServicePassword {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServicePassword", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether to run the service using {0} if installing as a Windows Service. Defaults to {1}. If this value is false and {2} is not specified, the service will be run using {3}.
-        /// </summary>
-        public static string InstallOptions_ServiceRunAsNetworkService {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServiceRunAsNetworkService", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether to start the service after installation, if installing as a Windows Service. Defaults to {0}.
-        /// </summary>
-        public static string InstallOptions_ServiceStart {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServiceStart", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Whether to run the service using a specified Username, if installing as a Windows Service.
-        /// </summary>
-        public static string InstallOptions_ServiceUsername {
-            get {
-                return ResourceManager.GetString("InstallOptions_ServiceUsername", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A comma-separated list of hosts to use for unicast discovery.
-        /// </summary>
-        public static string InstallOptions_UnicastHosts {
-            get {
-                return ResourceManager.GetString("InstallOptions_UnicastHosts", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Configuration.
         /// </summary>
         public static string LocationsModelValidator_Configuration {
@@ -1088,6 +908,33 @@ namespace Elastic.Installer.Domain.Properties {
         public static string SetupView_NextText {
             get {
                 return ResourceManager.GetString("SetupView_NextText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;elastic&apos; password needs to be atleast 6 characters.
+        /// </summary>
+        public static string XPackModelValidator_ElasticPasswordRequired {
+            get {
+                return ResourceManager.GetString("XPackModelValidator_ElasticPasswordRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;kibana&apos; password needs to be atleast 6 characters.
+        /// </summary>
+        public static string XPackModelValidator_KibanaPasswordRequired {
+            get {
+                return ResourceManager.GetString("XPackModelValidator_KibanaPasswordRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;logstash_system&apos; password needs to be atleast 6 characters.
+        /// </summary>
+        public static string XPackModelValidator_LogstashPasswordRequired {
+            get {
+                return ResourceManager.GetString("XPackModelValidator_LogstashPasswordRequired", resourceCulture);
             }
         }
     }

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -676,7 +676,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, machine learning, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation..
+        ///   Looks up a localized string similar to X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, graph and machine learning capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA..
         /// </summary>
         public static string PluginsModel_XPack {
             get {
@@ -912,7 +912,16 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;elastic&apos; password needs to be atleast 6 characters.
+        ///   Looks up a localized string similar to &apos;elastic&apos; password needs to be at least 6 characters.
+        /// </summary>
+        public static string XPackModelValidator_ElasticPasswordAtLeast6Characters {
+            get {
+                return ResourceManager.GetString("XPackModelValidator_ElasticPasswordAtLeast6Characters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;elastic&apos; password is required.
         /// </summary>
         public static string XPackModelValidator_ElasticPasswordRequired {
             get {
@@ -921,7 +930,16 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;kibana&apos; password needs to be atleast 6 characters.
+        ///   Looks up a localized string similar to &apos;kibana&apos; password needs to be at least 6 characters.
+        /// </summary>
+        public static string XPackModelValidator_KibanaPasswordAtLeast6Characters {
+            get {
+                return ResourceManager.GetString("XPackModelValidator_KibanaPasswordAtLeast6Characters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;kibana&apos; password is required.
         /// </summary>
         public static string XPackModelValidator_KibanaPasswordRequired {
             get {
@@ -930,7 +948,16 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;logstash_system&apos; password needs to be atleast 6 characters.
+        ///   Looks up a localized string similar to &apos;logstash_system&apos; password needs to be at least 6 characters.
+        /// </summary>
+        public static string XPackModelValidator_LogstashPasswordAtLeast6Characters {
+            get {
+                return ResourceManager.GetString("XPackModelValidator_LogstashPasswordAtLeast6Characters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;logstash_system&apos; is required.
         /// </summary>
         public static string XPackModelValidator_LogstashPasswordRequired {
             get {

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -351,85 +351,6 @@ in this cluster are empty. To migrate this data back into the downgraded cluster
   <data name="PluginType_XPack" xml:space="preserve">
     <value>X-Pack</value>
   </data>
-  <data name="InstallOptions_ClusterName" xml:space="preserve">
-    <value>The name of the cluster. Defaults to {0}</value>
-    <comment>{0} = Default Cluster Name</comment>
-  </data>
-  <data name="InstallOptions_ConfigDirectory" xml:space="preserve">
-    <value>The config directory. Defaults to {0}</value>
-    <comment>{0} = Default Config Directory</comment>
-  </data>
-  <data name="InstallOptions_DataDirectory" xml:space="preserve">
-    <value>The data directory. Defaults to {0}</value>
-    <comment>{0} = Default Data Directory</comment>
-  </data>
-  <data name="InstallOptions_DataNode" xml:space="preserve">
-    <value>Whether this node is a Data node. Defaults to {0}</value>
-    <comment>{0} = Is this a Data Node</comment>
-  </data>
-  <data name="InstallOptions_HeapSize" xml:space="preserve">
-    <value>The heap memory that will be allocated to the Elasticsearch Java Process. This should be more than 250mb and ideally less than 32GB (so that Java uses compressed pointers). Defaults to {0}mb for this installation</value>
-    <comment>{0} = Default Heap Size</comment>
-  </data>
-  <data name="InstallOptions_IngestNode" xml:space="preserve">
-    <value>Whether this node is an Ingest node. Defaults to {0}</value>
-    <comment>{0} = Is this an Ingest Node</comment>
-  </data>
-  <data name="InstallOptions_InstallDirectory" xml:space="preserve">
-    <value>The installation directory. Defaults to {0}</value>
-    <comment>{0} = Default Install Directory</comment>
-  </data>
-  <data name="InstallOptions_LockMemory" xml:space="preserve">
-    <value>Whether to lock the process address space in RAM, preventing any Elasticsearch memory from being swapped out. This uses VirtualLock on Windows. Defaults to {0}</value>
-    <comment>{0} = Default lock memory value</comment>
-  </data>
-  <data name="InstallOptions_LogsDirectory" xml:space="preserve">
-    <value>The logs directory. Defaults to {0}</value>
-    <comment>{0} = Default Logs Directory</comment>
-  </data>
-  <data name="InstallOptions_MasterNode" xml:space="preserve">
-    <value>Whether this node is a Master node. Defaults to {0}</value>
-    <comment>{0} = Is this a Master Node</comment>
-  </data>
-  <data name="InstallOptions_NodeName" xml:space="preserve">
-    <value>The name of the node. Defaults to {0} for this installation</value>
-    <comment>{0} = Default Node Name</comment>
-  </data>
-  <data name="InstallOptions_Plugins" xml:space="preserve">
-    <value>A comma-separated list of plugins to install as part of the Elasticsearch installation</value>
-  </data>
-  <data name="InstallOptions_ServiceAutomatic" xml:space="preserve">
-    <value>Whether to automatically start the service after Windows starts/restarts, if installing as a Windows Service. Defaults to {0}</value>
-    <comment>{0} = Default Start Service after Windows Starts/Restarts</comment>
-  </data>
-  <data name="InstallOptions_ServiceInstall" xml:space="preserve">
-    <value>Whether to install Elasticsearch as a Windows service. Defaults to {0}</value>
-    <comment>{0} = Default Install as a Service value</comment>
-  </data>
-  <data name="InstallOptions_ServiceName" xml:space="preserve">
-    <value>The name of the Windows service, if installing as a Windows Service. Defaults to {0}</value>
-    <comment>{0} = Default Windows Service name</comment>
-  </data>
-  <data name="InstallOptions_ServicePassword" xml:space="preserve">
-    <value>Password for the specified Username, if installing as a Windows Service</value>
-  </data>
-  <data name="InstallOptions_ServiceRunAsNetworkService" xml:space="preserve">
-    <value>Whether to run the service using {0} if installing as a Windows Service. Defaults to {1}. If this value is false and {2} is not specified, the service will be run using {3}</value>
-    <comment>{0} = Network Service Account
-{1} = Default Network Service Account Name
-{2} = Service Username Install Option Name
-{3} = Local System Service Account</comment>
-  </data>
-  <data name="InstallOptions_ServiceStart" xml:space="preserve">
-    <value>Whether to start the service after installation, if installing as a Windows Service. Defaults to {0}</value>
-    <comment>{0} = Default Start Service after installation</comment>
-  </data>
-  <data name="InstallOptions_ServiceUsername" xml:space="preserve">
-    <value>Whether to run the service using a specified Username, if installing as a Windows Service</value>
-  </data>
-  <data name="InstallOptions_UnicastHosts" xml:space="preserve">
-    <value>A comma-separated list of hosts to use for unicast discovery</value>
-  </data>
   <data name="SetupView_ExitText" xml:space="preserve">
     <value>Exit</value>
   </data>
@@ -475,6 +396,15 @@ PLEASE NOTE: an uninstall will always remove the data folder be sure you move it
     <value>Plugin installation is online, meaning you need a connection to the 
     internet to commence. Either deselect all plugins or connect 
     to the internet and refresh the installer.</value>
+  </data>
+  <data name="XPackModelValidator_ElasticPasswordRequired" xml:space="preserve">
+    <value>'elastic' password needs to be atleast 6 characters</value>
+  </data>
+  <data name="XPackModelValidator_KibanaPasswordRequired" xml:space="preserve">
+    <value>'kibana' password needs to be atleast 6 characters</value>
+  </data>
+  <data name="XPackModelValidator_LogstashPasswordRequired" xml:space="preserve">
+    <value>'logstash_system' password needs to be atleast 6 characters</value>
   </data>
   <data name="PluginsModelValidator_InvalidHttpProxyHost" xml:space="preserve">
     <value>HTTP proxy host is unknown. Enter a valid host name </value>

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -334,7 +334,7 @@ in this cluster are empty. To migrate this data back into the downgraded cluster
     <value>The Store SMB plugin works around a bug in Windows SMB and Java on Windows.</value>
   </data>
   <data name="PluginsModel_XPack" xml:space="preserve">
-    <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, machine learning, and graph capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA. By selecting to install X-Pack, A 30 day fully featured trial license is applied upon installation.</value>
+    <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, graph and machine learning capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
   </data>
   <data name="PluginType_ApiExtensions" xml:space="preserve">
     <value>API Extensions</value>
@@ -398,13 +398,22 @@ PLEASE NOTE: an uninstall will always remove the data folder be sure you move it
     to the internet and refresh the installer.</value>
   </data>
   <data name="XPackModelValidator_ElasticPasswordRequired" xml:space="preserve">
-    <value>'elastic' password needs to be atleast 6 characters</value>
+    <value>'elastic' password is required</value>
   </data>
   <data name="XPackModelValidator_KibanaPasswordRequired" xml:space="preserve">
-    <value>'kibana' password needs to be atleast 6 characters</value>
+    <value>'kibana' password is required</value>
   </data>
   <data name="XPackModelValidator_LogstashPasswordRequired" xml:space="preserve">
-    <value>'logstash_system' password needs to be atleast 6 characters</value>
+    <value>'logstash_system' is required</value>
+  </data>
+  <data name="XPackModelValidator_ElasticPasswordAtLeast6Characters" xml:space="preserve">
+    <value>'elastic' password needs to be at least 6 characters</value>
+  </data>
+  <data name="XPackModelValidator_KibanaPasswordAtLeast6Characters" xml:space="preserve">
+    <value>'kibana' password needs to be at least 6 characters</value>
+  </data>
+  <data name="XPackModelValidator_LogstashPasswordAtLeast6Characters" xml:space="preserve">
+    <value>'logstash_system' password needs to be at least 6 characters</value>
   </data>
   <data name="PluginsModelValidator_InvalidHttpProxyHost" xml:space="preserve">
     <value>HTTP proxy host is unknown. Enter a valid host name </value>

--- a/src/Installer/Elastic.Installer.Msi/Elastic.Installer.Msi.csproj
+++ b/src/Installer/Elastic.Installer.Msi/Elastic.Installer.Msi.csproj
@@ -48,7 +48,9 @@
     <Compile Include="CustomActions\CustomAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Commit\ElasticsearchCleanupAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\ElasticsearchCustomActionOrder.cs" />
+    <Compile Include="Elasticsearch\CustomActions\Immediate\ElasticsearchBootstrapPasswordAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Immediate\ElasticsearchValidateArgumentsAction.cs" />
+    <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchBootstrapPasswordAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchConfigurationAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchDirectoriesAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchEnvironmentAction.cs" />

--- a/src/Installer/Elastic.Installer.Msi/Elastic.Installer.Msi.csproj
+++ b/src/Installer/Elastic.Installer.Msi/Elastic.Installer.Msi.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchServiceInstallAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchServiceStartAction.cs" />
     <Compile Include="CustomActions\RollbackCustomAction.cs" />
+    <Compile Include="Elasticsearch\CustomActions\Install\ElasticsearchSetupXPackPasswordsAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Rollback\ElasticsearchRollbackDirectoriesAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Rollback\ElasticsearchRollbackEnvironmentAction.cs" />
     <Compile Include="Elasticsearch\CustomActions\Rollback\ElasticsearchRollbackServiceStartAction.cs" />

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/ElasticsearchCustomActionOrder.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/ElasticsearchCustomActionOrder.cs
@@ -18,6 +18,7 @@
 		BootstrapPassword = 9,
 		InstallService = 10,
 		InstallStartService = 11,
+		SetupXPackPasswords = 12,
 
 		// Rollback actions are played in reverse order
 		RollbackEnvironment = 1,

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/ElasticsearchCustomActionOrder.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/ElasticsearchCustomActionOrder.cs
@@ -4,6 +4,7 @@
 	{
 		// Immediate actions
 		LogAllTheThings = 1,
+		BootstrapPasswordProperty = 2,
 
 		// Deferred actions
 		SetPreconditions = 2,
@@ -14,8 +15,9 @@
 		InstallConfiguration = 6,
 		InstallJvmOptions = 7,
 		InstallPlugins = 8,
-		InstallService = 9,
-		InstallStartService = 10,
+		BootstrapPassword = 9,
+		InstallService = 10,
+		InstallStartService = 11,
 
 		// Rollback actions are played in reverse order
 		RollbackEnvironment = 1,

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Immediate/ElasticsearchBootstrapPasswordAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Immediate/ElasticsearchBootstrapPasswordAction.cs
@@ -1,0 +1,25 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Msi.CustomActions;
+using Elastic.InstallerHosts;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
+using Microsoft.Deployment.WindowsInstaller;
+using WixSharp;
+
+namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Immediate
+{
+	public class ElasticsearchSetBootstrapPasswordAction : CustomAction<Elasticsearch>
+	{
+		public override string Name => nameof(ElasticsearchSetBootstrapPasswordAction);
+		public override int Order => (int)ElasticsearchCustomActionOrder.BootstrapPasswordProperty;
+		public override Condition Condition => new Condition("(NOT Installed) AND XPACKSECURITYENABLED~=\"true\" AND BOOTSTRAPPASSWORD=\"\"");
+		public override Return Return => Return.check;
+		public override Sequence Sequence => Sequence.InstallExecuteSequence;
+		public override Step Step => new Step(nameof(ElasticsearchValidateArgumentsAction));
+		public override When When => When.After;
+		public override Execute Execute => Execute.immediate;
+
+		[CustomAction]
+		public static ActionResult ElasticsearchSetBootstrapPassword(Session session) =>
+			session.Handle(() => new SetBootstrapPasswordPropertyTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
+	}
+}

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchBootstrapPasswordAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchBootstrapPasswordAction.cs
@@ -1,0 +1,25 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Msi.CustomActions;
+using Elastic.InstallerHosts;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
+using Microsoft.Deployment.WindowsInstaller;
+using WixSharp;
+
+namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
+{
+	public class ElasticsearchBootstrapPasswordAction : CustomAction<Elasticsearch>
+	{
+		public override string Name => nameof(ElasticsearchBootstrapPasswordAction);
+		public override int Order => (int)ElasticsearchCustomActionOrder.BootstrapPassword;
+		public override Condition Condition => new Condition("(NOT Installed) AND XPACKSECURITYENABLED~=\"true\" AND XPACKLICENSE~=\"Trial\"");
+		public override Return Return => Return.check;
+		public override Sequence Sequence => Sequence.InstallExecuteSequence;
+		public override When When => When.After;
+		public override Step Step => new Step(nameof(ElasticsearchPluginsAction));
+		public override Execute Execute => Execute.deferred;
+
+		[CustomAction]
+		public static ActionResult ElasticsearchBootstrapPassword(Session session) =>
+			session.Handle(() => new SetBootstrapPasswordTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
+	}
+}

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchBootstrapPasswordAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchBootstrapPasswordAction.cs
@@ -11,7 +11,7 @@ namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
 	{
 		public override string Name => nameof(ElasticsearchBootstrapPasswordAction);
 		public override int Order => (int)ElasticsearchCustomActionOrder.BootstrapPassword;
-		public override Condition Condition => new Condition("(NOT Installed) AND XPACKSECURITYENABLED~=\"true\" AND XPACKLICENSE~=\"Trial\" AND SKIPSETTINGPASSWORDS~=\"false\"");
+		public override Condition Condition => new Condition("(NOT Installed) AND XPACKSECURITYENABLED~=\"true\" AND XPACKLICENSE~=\"Trial\"");
 		public override Return Return => Return.check;
 		public override Sequence Sequence => Sequence.InstallExecuteSequence;
 		public override When When => When.After;

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchServiceInstallAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchServiceInstallAction.cs
@@ -16,7 +16,7 @@ namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
 		public override Return Return => Return.check;
 		public override Sequence Sequence => Sequence.InstallExecuteSequence;
 		public override When When => When.After;
-		public override Step Step => new Step(nameof(ElasticsearchPluginsAction));
+		public override Step Step => new Step(nameof(ElasticsearchBootstrapPasswordAction));
 		public override Execute Execute => Execute.deferred;
 
 		[CustomAction]

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchSetupXPackPasswordsAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchSetupXPackPasswordsAction.cs
@@ -7,19 +7,19 @@ using WixSharp;
 
 namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
 {
-	public class ElasticsearchBootstrapPasswordAction : CustomAction<Elasticsearch>
+	public class ElasticsearchSetupXPackPasswordsAction : CustomAction<Elasticsearch>
 	{
-		public override string Name => nameof(ElasticsearchBootstrapPasswordAction);
-		public override int Order => (int)ElasticsearchCustomActionOrder.BootstrapPassword;
+		public override string Name => nameof(ElasticsearchSetupXPackPasswordsAction);
+		public override int Order => (int)ElasticsearchCustomActionOrder.SetupXPackPasswords;
 		public override Condition Condition => new Condition("(NOT Installed) AND XPACKSECURITYENABLED~=\"true\" AND XPACKLICENSE~=\"Trial\" AND SKIPSETTINGPASSWORDS~=\"false\"");
 		public override Return Return => Return.check;
 		public override Sequence Sequence => Sequence.InstallExecuteSequence;
 		public override When When => When.After;
-		public override Step Step => new Step(nameof(ElasticsearchPluginsAction));
+		public override Step Step => new Step(nameof(ElasticsearchServiceStartAction));
 		public override Execute Execute => Execute.deferred;
 
 		[CustomAction]
-		public static ActionResult ElasticsearchBootstrapPassword(Session session) =>
-			session.Handle(() => new SetBootstrapPasswordTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
+		public static ActionResult ElasticsearchSetupXPackPasswords(Session session) =>
+			session.Handle(() => new SetupXPackPasswordsTask(session.ToSetupArguments(ElasticsearchArgumentParser.AllArguments), session.ToISession()).Execute());
 	}
 }

--- a/src/Installer/Elastic.Installer.Msi/Program.cs
+++ b/src/Installer/Elastic.Installer.Msi/Program.cs
@@ -148,6 +148,7 @@ namespace Elastic.Installer.Msi
 			const string wixLocation = @"..\..\..\packages\WixSharp.wix.bin\tools\bin";
 			if (!Directory.Exists(wixLocation))
 				throw new Exception($"The directory '{wixLocation}' could not be found");
+			//Compiler.LightOptions = "-sw1076 -sw1079 -sval";
 			Compiler.WixLocation = wixLocation;
 			Compiler.BuildWxs(project, $@"_Generated\{_productName.ToLower()}.wxs", Compiler.OutputType.MSI);
 			Compiler.BuildMsi(project);

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -816,7 +816,7 @@
       <Custom Action="Set_ElasticsearchPluginsAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchPluginsAction" After="ElasticsearchJvmOptionsAction"> (NOT Installed) </Custom>
       <Custom Action="Set_ElasticsearchBootstrapPasswordAction_Props" After="InstallInitialize" />
-      <Custom Action="ElasticsearchBootstrapPasswordAction" After="ElasticsearchPluginsAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND XPACKLICENSE~="Trial" AND SKIPSETTINGPASSWORDS~="false"</Custom>
+      <Custom Action="ElasticsearchBootstrapPasswordAction" After="ElasticsearchPluginsAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND XPACKLICENSE~="Trial"</Custom>
       <Custom Action="Set_ElasticsearchServiceInstallAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchServiceInstallAction" After="ElasticsearchBootstrapPasswordAction">(NOT Installed) AND INSTALLASSERVICE="true"</Custom>
       <Custom Action="Set_ElasticsearchServiceStartAction_Props" After="InstallInitialize" />

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="72029505-94e9-4c29-a604-1da02d9d0402" Name="Elasticsearch 5.6.0" Language="1033" Codepage="Windows-1252" Version="5.6.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="0ce27c5f-af39-4ea8-80d1-d78c97c1cd90" Name="Elasticsearch 6.0.0-rc1" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_5.6.0_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_6.0.0_rc1_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -17,15 +17,15 @@
             </Component>
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-5.6.0\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-5.6.0\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-5.6.0\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -43,20 +43,24 @@
                 <RemoveFolder Id="INSTALLDIR.bin.dir" On="both" />
               </Component>
 
+              <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
+                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-env.bat" />
+              </Component>
+
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-5.6.0\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch.exe" />
 
                 <ServiceControl Id="elasticsearch.exe" Name="Elasticsearch" Stop="both" Wait="yes" />
               </Component>
@@ -71,15 +75,15 @@
               </Component>
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-5.6.0\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-5.6.0\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-5.6.0\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\config\log4j2.properties" />
               </Component>
 
             </Directory>
@@ -91,144 +95,144 @@
                 <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786103da43" Win64="yes">
-                <File Id="elasticsearch_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\elasticsearch-5.6.0.jar" />
+              <Component Id="Component.elasticsearch_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547875a3b5a4" Win64="yes">
+                <File Id="elasticsearch_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\elasticsearch-6.0.0-rc1.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component.java_version_checker_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f8fc2cd" Win64="yes">
-                <File Id="java_version_checker_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\java-version-checker-5.6.0.jar" />
+              <Component Id="Component._..._version_checker_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784a1ec68c" Win64="yes">
+                <File Id="_..._version_checker_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\java-version-checker-6.0.0-rc1.jar" />
               </Component>
 
               <Component Id="Component.jna_4.4.0_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838772020" Win64="yes">
-                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jna-4.4.0-1.jar" />
+                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jna-4.4.0-1.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jts-1.13.jar" />
               </Component>
 
-              <Component Id="Component.log4j_1.2_api_2.9.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e50" Win64="yes">
-                <File Id="log4j_1.2_api_2.9.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\log4j-1.2-api-2.9.0.jar" />
+              <Component Id="Component.log4j_1.2_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e2d" Win64="yes">
+                <File Id="log4j_1.2_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\log4j-1.2-api-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component.log4j_api_2.9.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f03ff" Win64="yes">
-                <File Id="log4j_api_2.9.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\log4j-api-2.9.0.jar" />
+              <Component Id="Component.log4j_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f021e" Win64="yes">
+                <File Id="log4j_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\log4j-api-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component.log4j_core_2.9.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7efb698" Win64="yes">
-                <File Id="log4j_core_2.9.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\log4j-core-2.9.0.jar" />
+              <Component Id="Component.log4j_core_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7d0b698" Win64="yes">
+                <File Id="log4j_core_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\log4j-core-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component._...ene_analyzers_common_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818972dca" Win64="yes">
-                <File Id="_...ene_analyzers_common_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-analyzers-common-6.6.0.jar" />
+              <Component Id="Component._...ene_analyzers_common_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780e3e2dca" Win64="yes">
+                <File Id="_...ene_analyzers_common_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-analyzers-common-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component._...cene_backward_codecs_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478587b7ac6" Win64="yes">
-                <File Id="_...cene_backward_codecs_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-backward-codecs-6.6.0.jar" />
+              <Component Id="Component._...cene_backward_codecs_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850127ac6" Win64="yes">
+                <File Id="_...cene_backward_codecs_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-backward-codecs-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_core_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820309523" Win64="yes">
-                <File Id="lucene_core_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-core-6.6.0.jar" />
+              <Component Id="Component.lucene_core_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478643f640e" Win64="yes">
+                <File Id="lucene_core_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-core-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_grouping_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478200823f6" Win64="yes">
-                <File Id="lucene_grouping_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-grouping-6.6.0.jar" />
+              <Component Id="Component.lucene_grouping_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547825dd2a57" Win64="yes">
+                <File Id="lucene_grouping_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-grouping-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_highlighter_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cf520fdb" Win64="yes">
-                <File Id="lucene_highlighter_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-highlighter-6.6.0.jar" />
+              <Component Id="Component.lucene_highlighter_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb5d0fdb" Win64="yes">
+                <File Id="lucene_highlighter_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-highlighter-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_join_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788bdd052a" Win64="yes">
-                <File Id="lucene_join_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-join-6.6.0.jar" />
+              <Component Id="Component.lucene_join_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cfebd41d" Win64="yes">
+                <File Id="lucene_join_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-join-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_memory_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547821ad2a45" Win64="yes">
-                <File Id="lucene_memory_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-memory-6.6.0.jar" />
+              <Component Id="Component.lucene_memory_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547810d92dbe" Win64="yes">
+                <File Id="lucene_memory_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-memory-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_misc_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868e10357" Win64="yes">
-                <File Id="lucene_misc_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-misc-6.6.0.jar" />
+              <Component Id="Component.lucene_misc_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547823a5cff2" Win64="yes">
+                <File Id="lucene_misc_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-misc-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_queries_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478acaa136d" Win64="yes">
-                <File Id="lucene_queries_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-queries-6.6.0.jar" />
+              <Component Id="Component.lucene_queries_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785b9b136d" Win64="yes">
+                <File Id="lucene_queries_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-queries-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_queryparser_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785a63e130" Win64="yes">
-                <File Id="lucene_queryparser_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-queryparser-6.6.0.jar" />
+              <Component Id="Component.lucene_queryparser_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f0e2e130" Win64="yes">
+                <File Id="lucene_queryparser_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-queryparser-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_sandbox_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547865c0a387" Win64="yes">
-                <File Id="lucene_sandbox_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-sandbox-6.6.0.jar" />
+              <Component Id="Component.lucene_sandbox_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478dc5fa387" Win64="yes">
+                <File Id="lucene_sandbox_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-sandbox-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_spatial_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785099eaf2" Win64="yes">
-                <File Id="lucene_spatial_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-spatial-6.6.0.jar" />
+              <Component Id="Component.lucene_spatial_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ed16eaf2" Win64="yes">
+                <File Id="lucene_spatial_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-spatial-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component._...ucene_spatial_extras_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478101d1172" Win64="yes">
-                <File Id="_...ucene_spatial_extras_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-spatial-extras-6.6.0.jar" />
+              <Component Id="Component._...ucene_spatial_extras_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547817921172" Win64="yes">
+                <File Id="_...ucene_spatial_extras_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-spatial-extras-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_spatial3d_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fe531cc7" Win64="yes">
-                <File Id="lucene_spatial3d_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-spatial3d-6.6.0.jar" />
+              <Component Id="Component.lucene_spatial3d_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547834481cc7" Win64="yes">
+                <File Id="lucene_spatial3d_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-spatial3d-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.lucene_suggest_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c90c821" Win64="yes">
-                <File Id="lucene_suggest_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\lucene-suggest-6.6.0.jar" />
+              <Component Id="Component.lucene_suggest_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784099c821" Win64="yes">
+                <File Id="lucene_suggest_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-suggest-7.0.0.jar" />
               </Component>
 
-              <Component Id="Component.plugin_cli_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781529650f" Win64="yes">
-                <File Id="plugin_cli_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\plugin-cli-5.6.0.jar" />
+              <Component Id="Component.plugin_cli_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478001a880d" Win64="yes">
+                <File Id="plugin_cli_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\plugin-cli-6.0.0-rc1.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -241,103 +245,95 @@
                   <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.aggs_matrix_stats_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547874cd2334" Win64="yes">
-                  <File Id="aggs_matrix_stats_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\aggs-matrix-stats\aggs-matrix-stats-5.6.0.jar" />
+                <Component Id="Component._...ggs_matrix_stats_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f7754b71" Win64="yes">
+                  <File Id="_...ggs_matrix_stats_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                </Component>
+
+              </Directory>
+
+              <Directory Id="INSTALLDIR.modules.analysis_common" Name="analysis-common">
+
+                <Component Id="Component.INSTALLDIR.modules.analysis_common" Guid="daaa2cba-a1ed-4f29-afbf-54787e7f0b5f" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.analysis_common" Name="*" On="both" />
+                  <RemoveFolder Id="INSTALLDIR.modules.analysis_common.dir" On="both" />
+                </Component>
+
+                <Component Id="Component.analysis_common_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478339c7967" Win64="yes">
+                  <File Id="analysis_common_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\analysis-common\analysis-common-6.0.0-rc1.jar" />
+                </Component>
+
+                <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
+                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\analysis-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.ingest_common" Name="ingest-common">
 
-                <Component Id="Component.INSTALLDIR.modules.ingest_common" Guid="daaa2cba-a1ed-4f29-afbf-54787e7f0b5f" Win64="yes">
+                <Component Id="Component.INSTALLDIR.modules.ingest_common" Guid="daaa2cba-a1ed-4f29-afbf-547819d8cae4" Win64="yes">
                   <RemoveFile Id="INSTALLDIR.modules.ingest_common" Name="*" On="both" />
                   <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.ingest_common_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d7e95dd" Win64="yes">
-                  <File Id="ingest_common_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\ingest-common-5.6.0.jar" />
+                <Component Id="Component.ingest_common_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fbc63a5" Win64="yes">
+                  <File Id="ingest_common_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\ingest-common-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\ingest-common\plugin-descriptor.properties" />
+                <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
+                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
 
               <Directory Id="INSTALLDIR.modules.lang_expression" Name="lang-expression">
 
-                <Component Id="Component.INSTALLDIR.modules.lang_expression" Guid="daaa2cba-a1ed-4f29-afbf-547819d8cae4" Win64="yes">
+                <Component Id="Component.INSTALLDIR.modules.lang_expression" Guid="daaa2cba-a1ed-4f29-afbf-5478266128bd" Win64="yes">
                   <RemoveFile Id="INSTALLDIR.modules.lang_expression" Name="*" On="both" />
                   <RemoveFolder Id="INSTALLDIR.modules.lang_expression.dir" On="both" />
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component.lang_expression_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a576270d" Win64="yes">
-                  <File Id="lang_expression_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\lang-expression-5.6.0.jar" />
+                <Component Id="Component.lang_expression_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547896d25411" Win64="yes">
+                  <File Id="lang_expression_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\lang-expression-6.0.0-rc1.jar" />
                 </Component>
 
-                <Component Id="Component.lucene_expressions_6.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bdb326c8" Win64="yes">
-                  <File Id="lucene_expressions_6.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\lucene-expressions-6.6.0.jar" />
-                </Component>
-
-                <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\plugin-descriptor.properties" />
-                </Component>
-
-                <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-expression\plugin-security.policy" />
-                </Component>
-
-              </Directory>
-
-              <Directory Id="INSTALLDIR.modules.lang_groovy" Name="lang-groovy">
-
-                <Component Id="Component.INSTALLDIR.modules.lang_groovy" Guid="daaa2cba-a1ed-4f29-afbf-5478266128bd" Win64="yes">
-                  <RemoveFile Id="INSTALLDIR.modules.lang_groovy" Name="*" On="both" />
-                  <RemoveFolder Id="INSTALLDIR.modules.lang_groovy.dir" On="both" />
-                </Component>
-
-                <Component Id="Component.groovy_2.4.6_indy.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c4b086e8" Win64="yes">
-                  <File Id="groovy_2.4.6_indy.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\groovy-2.4.6-indy.jar" />
-                </Component>
-
-                <Component Id="Component.lang_groovy_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787a5d96af" Win64="yes">
-                  <File Id="lang_groovy_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\lang-groovy-5.6.0.jar" />
+                <Component Id="Component.lucene_expressions_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786e8226c8" Win64="yes">
+                  <File Id="lucene_expressions_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\lucene-expressions-7.0.0.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-groovy\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -350,19 +346,19 @@
                 </Component>
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547829dc94d8" Win64="yes">
-                  <File Id="lang_mustache_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\lang-mustache-5.6.0.jar" />
+                <Component Id="Component.lang_mustache_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b3812d9a" Win64="yes">
+                  <File Id="lang_mustache_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\lang-mustache-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-mustache\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
+                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -375,23 +371,23 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818205544" Win64="yes">
-                  <File Id="lang_painless_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\lang-painless-5.6.0.jar" />
+                <Component Id="Component.lang_painless_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f6c74b7" Win64="yes">
+                  <File Id="lang_painless_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\lang-painless-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\lang-painless\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
+                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -403,12 +399,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.parent_join_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f8598ac1" Win64="yes">
-                  <File Id="parent_join_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\parent-join\parent-join-5.6.0.jar" />
+                <Component Id="Component.parent_join_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818553fd6" Win64="yes">
+                  <File Id="parent_join_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\parent-join\parent-join-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\parent-join\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\parent-join\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -420,12 +416,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.percolator_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786194ddf2" Win64="yes">
-                  <File Id="percolator_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\percolator\percolator-5.6.0.jar" />
+                <Component Id="Component.percolator_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547896a07669" Win64="yes">
+                  <File Id="percolator_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\percolator\percolator-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\percolator\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\percolator\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -438,68 +434,64 @@
                 </Component>
 
                 <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
-                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\commons-codec-1.10.jar" />
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\commons-codec-1.10.jar" />
                 </Component>
 
                 <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
-                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\commons-logging-1.1.3.jar" />
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\commons-logging-1.1.3.jar" />
                 </Component>
 
-                <Component Id="Component._...icsearch_rest_client_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547842d1608f" Win64="yes">
-                  <File Id="_...icsearch_rest_client_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\elasticsearch-rest-client-5.6.0.jar" />
+                <Component Id="Component._...arch_rest_client_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788699de9f" Win64="yes">
+                  <File Id="_...arch_rest_client_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\elasticsearch-rest-client-6.0.0-rc1.jar" />
                 </Component>
 
                 <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
-                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpasyncclient-4.1.2.jar" />
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpasyncclient-4.1.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
-                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpclient-4.5.2.jar" />
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpclient-4.5.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
-                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpcore-4.4.5.jar" />
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpcore-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
-                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\httpcore-nio-4.4.5.jar" />
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
+                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.reindex_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547836012a9a" Win64="yes">
-                  <File Id="reindex_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\reindex\reindex-5.6.0.jar" />
+                <Component Id="Component.reindex_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ad04ddd3" Win64="yes">
+                  <File Id="reindex_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\reindex-6.0.0-rc1.jar" />
                 </Component>
 
               </Directory>
 
-              <Directory Id="INSTALLDIR.modules.transport_netty3" Name="transport-netty3">
+              <Directory Id="INSTALLDIR.modules.repository_url" Name="repository-url">
 
-                <Component Id="Component.INSTALLDIR.modules.transport_netty3" Guid="daaa2cba-a1ed-4f29-afbf-5478f1dfade6" Win64="yes">
-                  <RemoveFile Id="INSTALLDIR.modules.transport_netty3" Name="*" On="both" />
-                  <RemoveFolder Id="INSTALLDIR.modules.transport_netty3.dir" On="both" />
-                </Component>
-
-                <Component Id="Component.netty_3.10.6.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786aa11ed2" Win64="yes">
-                  <File Id="netty_3.10.6.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\netty-3.10.6.Final.jar" />
+                <Component Id="Component.INSTALLDIR.modules.repository_url" Guid="daaa2cba-a1ed-4f29-afbf-5478f1dfade6" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.repository_url" Name="*" On="both" />
+                  <RemoveFolder Id="INSTALLDIR.modules.repository_url.dir" On="both" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\repository-url\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
+                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\repository-url\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty3_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783ec41d4e" Win64="yes">
-                  <File Id="transport_netty3_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty3\transport-netty3-5.6.0.jar" />
+                <Component Id="Component.repository_url_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866cff685" Win64="yes">
+                  <File Id="repository_url_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\repository-url\repository-url-6.0.0-rc1.jar" />
                 </Component>
 
               </Directory>
@@ -512,43 +504,60 @@
                 </Component>
 
                 <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
-                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
+                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_codec_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478677b2eca" Win64="yes">
-                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
+                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...ty_codec_http_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bebaa9fe" Win64="yes">
-                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
+                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_common_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7df66c" Win64="yes">
-                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
+                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_handler_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fda2ab4a" Win64="yes">
-                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
+                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...etty_resolver_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785164d95f" Win64="yes">
-                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
+                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...tty_transport_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbded01b" Win64="yes">
-                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
+                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.10" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae8" Win64="yes">
-                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.6" Guid="daaa2cba-a1ed-4f29-afbf-5478374d00dd" Win64="yes">
-                  <File Id="plugin_security.policy.6" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\plugin-security.policy" />
+                <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
+                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty4_5.6.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850db1d4e" Win64="yes">
-                  <File Id="transport_netty4_5.6.0.jar" Source="..\..\..\build\in\elasticsearch-5.6.0\modules\transport-netty4\transport-netty4-5.6.0.jar" />
+                <Component Id="Component.transport_netty4_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547852ed0ff0" Win64="yes">
+                  <File Id="transport_netty4_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\transport-netty4-6.0.0-rc1.jar" />
+                </Component>
+
+              </Directory>
+
+              <Directory Id="INSTALLDIR.modules.tribe" Name="tribe">
+
+                <Component Id="Component.INSTALLDIR.modules.tribe" Guid="daaa2cba-a1ed-4f29-afbf-5478d0798b49" Win64="yes">
+                  <RemoveFile Id="INSTALLDIR.modules.tribe" Name="*" On="both" />
+                  <RemoveFolder Id="INSTALLDIR.modules.tribe.dir" On="both" />
+                </Component>
+
+                <Component Id="Component.plugin_descriptor.properties.11" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae9" Win64="yes">
+                  <File Id="plugin_descriptor.properties.11" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\tribe\plugin-descriptor.properties" />
+                </Component>
+
+                <Component Id="Component.tribe_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cb39fa31" Win64="yes">
+                  <File Id="tribe_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\tribe\tribe-6.0.0-rc1.jar" />
                 </Component>
 
               </Directory>
@@ -568,8 +577,8 @@
     </UI>
 
     <Upgrade Id="daaa2cba-a1ed-4f29-afbf-5478617b00f6">
-      <UpgradeVersion Minimum="0.0.0.0" Maximum="5.6.0" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
-      <UpgradeVersion Minimum="5.6.0" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
+      <UpgradeVersion Minimum="0.0.0.0" Maximum="6.0.0" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
+      <UpgradeVersion Minimum="6.0.0" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
     </Upgrade>
 
     <Icon Id="app_icon.ico" SourceFile="Resources\elasticsearch.ico" />
@@ -578,47 +587,50 @@
     <CustomAction Id="Action2SetProp_CONFIGDIRECTORY" Property="CONFIGDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\config" Return="check" Execute="immediate" />
     <CustomAction Id="Action3SetProp_LOGSDIRECTORY" Property="LOGSDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\logs" Return="check" Execute="immediate" />
     <CustomAction Id="Action4SetProp_NODENAME" Property="NODENAME" Value="[%COMPUTERNAME]" Return="check" Execute="immediate" />
-    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallService" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackEnvironment" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
     <CustomAction Id="ElasticsearchValidateArgumentsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchValidateArguments" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchCleanupAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchCleanup" Return="ignore" Impersonate="no" Execute="commit" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackDirectories" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchSetBootstrapPasswordAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchSetBootstrapPassword" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackServiceStart" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchPreserveInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPreserveInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackInstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackInstallService" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchConfigurationAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchConfiguration" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchJvmOptionsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchJvmOptions" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchBootstrapPasswordAction_Props" Property="ElasticsearchBootstrapPasswordAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchBootstrapPasswordAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchBootstrapPassword" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceStart" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
     <CustomAction Id="PreventDowngrading" Error="Newer version already installed" />
 
     <Binary Id="ElasticsearchUninstallServiceAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="5.6.0" />
+    <Property Id="CurrentVersion" Value="6.0.0-rc1" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -635,11 +647,11 @@
     <Property Id="LOCKMEMORY" Value="false" />
     <Property Id="HTTPPORT" Value="9200" />
     <Property Id="TRANSPORTPORT" Value="9300" />
-    <Property Id="HTTPPROXYHOST" />
-    <Property Id="HTTPPROXYPORT" />
-    <Property Id="HTTPSPROXYHOST" />
-    <Property Id="HTTPSPROXYPORT" />
     <Property Id="PLUGINS" />
+    <Property Id="ELASTICUSERPASSWORD" Hidden="yes" />
+    <Property Id="KIBANAUSERPASSWORD" Hidden="yes" />
+    <Property Id="LOGSTASHSYSTEMUSERPASSWORD" Hidden="yes" />
+    <Property Id="BOOTSTRAPPASSWORD" Hidden="yes" />
     <Property Id="ARPHELPLINK" Value="https://discuss.elastic.co/c/elasticsearch" />
     <Property Id="ARPPRODUCTICON" Value="app_icon.ico" />
     <Property Id="ARPURLINFOABOUT" Value="https://www.elastic.co/products/elasticsearch" />
@@ -648,6 +660,7 @@
       <ComponentRef Id="Component.LICENSE.txt" />
       <ComponentRef Id="Component.NOTICE.txt" />
       <ComponentRef Id="Component.README.textile" />
+      <ComponentRef Id="Component.elasticsearch_env.bat" />
       <ComponentRef Id="Component.elasticsearch_keystore.bat" />
       <ComponentRef Id="Component.elasticsearch_plugin.bat" />
       <ComponentRef Id="Component.elasticsearch_translog.bat" />
@@ -655,86 +668,83 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_5.6.0.jar" />
+      <ComponentRef Id="Component.elasticsearch_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component.java_version_checker_5.6.0.jar" />
+      <ComponentRef Id="Component._..._version_checker_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.jna_4.4.0_1.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
       <ComponentRef Id="Component.jts_1.13.jar" />
-      <ComponentRef Id="Component.log4j_1.2_api_2.9.0.jar" />
-      <ComponentRef Id="Component.log4j_api_2.9.0.jar" />
-      <ComponentRef Id="Component.log4j_core_2.9.0.jar" />
-      <ComponentRef Id="Component._...ene_analyzers_common_6.6.0.jar" />
-      <ComponentRef Id="Component._...cene_backward_codecs_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_core_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_grouping_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_highlighter_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_join_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_memory_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_misc_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_queries_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_queryparser_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_sandbox_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_spatial_6.6.0.jar" />
-      <ComponentRef Id="Component._...ucene_spatial_extras_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_spatial3d_6.6.0.jar" />
-      <ComponentRef Id="Component.lucene_suggest_6.6.0.jar" />
-      <ComponentRef Id="Component.plugin_cli_5.6.0.jar" />
+      <ComponentRef Id="Component.log4j_1.2_api_2.9.1.jar" />
+      <ComponentRef Id="Component.log4j_api_2.9.1.jar" />
+      <ComponentRef Id="Component.log4j_core_2.9.1.jar" />
+      <ComponentRef Id="Component._...ene_analyzers_common_7.0.0.jar" />
+      <ComponentRef Id="Component._...cene_backward_codecs_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_core_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_grouping_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_highlighter_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_join_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_memory_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_misc_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_queries_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_queryparser_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_sandbox_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_spatial_7.0.0.jar" />
+      <ComponentRef Id="Component._...ucene_spatial_extras_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_spatial3d_7.0.0.jar" />
+      <ComponentRef Id="Component.lucene_suggest_7.0.0.jar" />
+      <ComponentRef Id="Component.plugin_cli_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.securesm_1.1.jar" />
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component.aggs_matrix_stats_5.6.0.jar" />
+      <ComponentRef Id="Component._...ggs_matrix_stats_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.ingest_common_5.6.0.jar" />
+      <ComponentRef Id="Component.analysis_common_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.1" />
+      <ComponentRef Id="Component.ingest_common_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.1" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.2" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar" />
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component.lang_expression_5.6.0.jar" />
-      <ComponentRef Id="Component.lucene_expressions_6.6.0.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.2" />
-      <ComponentRef Id="Component.plugin_security.policy" />
-      <ComponentRef Id="Component.groovy_2.4.6_indy.jar" />
-      <ComponentRef Id="Component.lang_groovy_5.6.0.jar" />
+      <ComponentRef Id="Component.lang_expression_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.lucene_expressions_7.0.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.3" />
-      <ComponentRef Id="Component.plugin_security.policy.1" />
+      <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_5.6.0.jar" />
+      <ComponentRef Id="Component.lang_mustache_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.4" />
-      <ComponentRef Id="Component.plugin_security.policy.2" />
+      <ComponentRef Id="Component.plugin_security.policy.1" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_5.6.0.jar" />
+      <ComponentRef Id="Component.lang_painless_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.5" />
-      <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.parent_join_5.6.0.jar" />
+      <ComponentRef Id="Component.plugin_security.policy.2" />
+      <ComponentRef Id="Component.parent_join_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.6" />
-      <ComponentRef Id="Component.percolator_5.6.0.jar" />
+      <ComponentRef Id="Component.percolator_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.7" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
-      <ComponentRef Id="Component._...icsearch_rest_client_5.6.0.jar" />
+      <ComponentRef Id="Component._...arch_rest_client_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
       <ComponentRef Id="Component.httpclient_4.5.2.jar" />
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.8" />
-      <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.reindex_5.6.0.jar" />
-      <ComponentRef Id="Component.netty_3.10.6.Final.jar" />
+      <ComponentRef Id="Component.plugin_security.policy.3" />
+      <ComponentRef Id="Component.reindex_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.9" />
-      <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component.transport_netty3_5.6.0.jar" />
+      <ComponentRef Id="Component.plugin_security.policy.4" />
+      <ComponentRef Id="Component.repository_url_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.netty_buffer_4.1.13.Final.jar" />
       <ComponentRef Id="Component.netty_codec_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...ty_codec_http_4.1.13.Final.jar" />
@@ -743,24 +753,27 @@
       <ComponentRef Id="Component._...etty_resolver_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...tty_transport_4.1.13.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.10" />
-      <ComponentRef Id="Component.plugin_security.policy.6" />
-      <ComponentRef Id="Component.transport_netty4_5.6.0.jar" />
+      <ComponentRef Id="Component.plugin_security.policy.5" />
+      <ComponentRef Id="Component.transport_netty4_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.plugin_descriptor.properties.11" />
+      <ComponentRef Id="Component.tribe_6.0.0_rc1.jar" />
       <ComponentRef Id="Component.INSTALLDIR" />
       <ComponentRef Id="Component.INSTALLDIR.bin.xpack" />
       <ComponentRef Id="Component.INSTALLDIR.bin" />
       <ComponentRef Id="Component.INSTALLDIR.config" />
       <ComponentRef Id="Component.INSTALLDIR.lib" />
       <ComponentRef Id="Component.INSTALLDIR.modules.aggs_matrix_stats" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.analysis_common" />
       <ComponentRef Id="Component.INSTALLDIR.modules.ingest_common" />
       <ComponentRef Id="Component.INSTALLDIR.modules.lang_expression" />
-      <ComponentRef Id="Component.INSTALLDIR.modules.lang_groovy" />
       <ComponentRef Id="Component.INSTALLDIR.modules.lang_mustache" />
       <ComponentRef Id="Component.INSTALLDIR.modules.lang_painless" />
       <ComponentRef Id="Component.INSTALLDIR.modules.parent_join" />
       <ComponentRef Id="Component.INSTALLDIR.modules.percolator" />
       <ComponentRef Id="Component.INSTALLDIR.modules.reindex" />
-      <ComponentRef Id="Component.INSTALLDIR.modules.transport_netty3" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.repository_url" />
       <ComponentRef Id="Component.INSTALLDIR.modules.transport_netty4" />
+      <ComponentRef Id="Component.INSTALLDIR.modules.tribe" />
     </Feature>
 
     <InstallExecuteSequence>
@@ -779,6 +792,7 @@
       <Custom Action="ElasticsearchUninstallPluginsAction" After="StopServices">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
       <Custom Action="Set_ElasticsearchRollbackDirectoriesAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchRollbackDirectoriesAction" Before="ElasticsearchDirectoriesAction" />
+      <Custom Action="ElasticsearchSetBootstrapPasswordAction" After="ElasticsearchValidateArgumentsAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND BOOTSTRAPPASSWORD=""</Custom>
       <Custom Action="Set_ElasticsearchUninstallDirectoriesAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchUninstallDirectoriesAction" After="ElasticsearchUninstallEnvironmentAction">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
       <Custom Action="Set_ElasticsearchRollbackServiceStartAction_Props" After="InstallInitialize" />
@@ -799,8 +813,10 @@
       <Custom Action="ElasticsearchJvmOptionsAction" After="ElasticsearchConfigurationAction"> (NOT Installed) </Custom>
       <Custom Action="Set_ElasticsearchPluginsAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchPluginsAction" After="ElasticsearchJvmOptionsAction"> (NOT Installed) </Custom>
+      <Custom Action="Set_ElasticsearchBootstrapPasswordAction_Props" After="InstallInitialize" />
+      <Custom Action="ElasticsearchBootstrapPasswordAction" After="ElasticsearchPluginsAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND XPACKLICENSE~="Trial"</Custom>
       <Custom Action="Set_ElasticsearchServiceInstallAction_Props" After="InstallInitialize" />
-      <Custom Action="ElasticsearchServiceInstallAction" After="ElasticsearchPluginsAction">(NOT Installed) AND INSTALLASSERVICE="true"</Custom>
+      <Custom Action="ElasticsearchServiceInstallAction" After="ElasticsearchBootstrapPasswordAction">(NOT Installed) AND INSTALLASSERVICE="true"</Custom>
       <Custom Action="Set_ElasticsearchServiceStartAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchServiceStartAction" After="ElasticsearchServiceInstallAction">(NOT Installed) AND INSTALLASSERVICE="true" AND STARTAFTERINSTALL="true"</Custom>
       <Custom Action="PreventDowngrading" After="FindRelatedProducts">NEWPRODUCTFOUND</Custom>

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="0ce27c5f-af39-4ea8-80d1-d78c97c1cd90" Name="Elasticsearch 6.0.0-rc1" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="50f217e3-97b7-47ba-95f7-685f7db0c8aa" Name="Elasticsearch 6.0.0-beta2" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_6.0.0_rc1_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_6.0.0_beta2_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -17,15 +17,15 @@
             </Component>
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -44,23 +44,23 @@
               </Component>
 
               <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
-                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-env.bat" />
+                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-env.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch.exe" />
 
                 <ServiceControl Id="elasticsearch.exe" Name="Elasticsearch" Stop="both" Wait="yes" />
               </Component>
@@ -75,15 +75,15 @@
               </Component>
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\log4j2.properties" />
               </Component>
 
             </Directory>
@@ -95,144 +95,144 @@
                 <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547875a3b5a4" Win64="yes">
-                <File Id="elasticsearch_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\elasticsearch-6.0.0-rc1.jar" />
+              <Component Id="Component.elasticsearch_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547804f08fa5" Win64="yes">
+                <File Id="elasticsearch_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\elasticsearch-6.0.0-beta2.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component._..._version_checker_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784a1ec68c" Win64="yes">
-                <File Id="_..._version_checker_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\java-version-checker-6.0.0-rc1.jar" />
+              <Component Id="Component._...ersion_checker_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547860ec5a68" Win64="yes">
+                <File Id="_...ersion_checker_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\java-version-checker-6.0.0-beta2.jar" />
               </Component>
 
               <Component Id="Component.jna_4.4.0_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838772020" Win64="yes">
-                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jna-4.4.0-1.jar" />
+                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jna-4.4.0-1.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jts-1.13.jar" />
               </Component>
 
-              <Component Id="Component.log4j_1.2_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e2d" Win64="yes">
-                <File Id="log4j_1.2_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\log4j-1.2-api-2.9.1.jar" />
+              <Component Id="Component.log4j_1.2_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd896f3f" Win64="yes">
+                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-1.2-api-2.8.2.jar" />
               </Component>
 
-              <Component Id="Component.log4j_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f021e" Win64="yes">
-                <File Id="log4j_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\log4j-api-2.9.1.jar" />
+              <Component Id="Component.log4j_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830b6218a" Win64="yes">
+                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-api-2.8.2.jar" />
               </Component>
 
-              <Component Id="Component.log4j_core_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7d0b698" Win64="yes">
-                <File Id="log4j_core_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\log4j-core-2.9.1.jar" />
+              <Component Id="Component.log4j_core_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b3cb698" Win64="yes">
+                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-core-2.8.2.jar" />
               </Component>
 
-              <Component Id="Component._...ene_analyzers_common_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780e3e2dca" Win64="yes">
-                <File Id="_...ene_analyzers_common_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-analyzers-common-7.0.0.jar" />
+              <Component Id="Component._...mon_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780929e8b4" Win64="yes">
+                <File Id="_...mon_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-analyzers-common-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component._...cene_backward_codecs_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850127ac6" Win64="yes">
-                <File Id="_...cene_backward_codecs_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-backward-codecs-7.0.0.jar" />
+              <Component Id="Component._...ecs_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f02cdcc8" Win64="yes">
+                <File Id="_...ecs_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-backward-codecs-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_core_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478643f640e" Win64="yes">
-                <File Id="lucene_core_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-core-7.0.0.jar" />
+              <Component Id="Component._...ore_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866da270f" Win64="yes">
+                <File Id="_...ore_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-core-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_grouping_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547825dd2a57" Win64="yes">
-                <File Id="lucene_grouping_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-grouping-7.0.0.jar" />
+              <Component Id="Component._...ing_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478afc97d45" Win64="yes">
+                <File Id="_...ing_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-grouping-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_highlighter_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb5d0fdb" Win64="yes">
-                <File Id="lucene_highlighter_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-highlighter-7.0.0.jar" />
+              <Component Id="Component._...ter_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788b4151ab" Win64="yes">
+                <File Id="_...ter_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-highlighter-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_join_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cfebd41d" Win64="yes">
-                <File Id="lucene_join_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-join-7.0.0.jar" />
+              <Component Id="Component._...oin_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783e6e1f07" Win64="yes">
+                <File Id="_...oin_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-join-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_memory_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547810d92dbe" Win64="yes">
-                <File Id="lucene_memory_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-memory-7.0.0.jar" />
+              <Component Id="Component._...ory_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781fe9ccc8" Win64="yes">
+                <File Id="_...ory_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-memory-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_misc_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547823a5cff2" Win64="yes">
-                <File Id="lucene_misc_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-misc-7.0.0.jar" />
+              <Component Id="Component._...isc_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788066f951" Win64="yes">
+                <File Id="_...isc_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-misc-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_queries_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785b9b136d" Win64="yes">
-                <File Id="lucene_queries_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-queries-7.0.0.jar" />
+              <Component Id="Component._...ies_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ed2d09d5" Win64="yes">
+                <File Id="_...ies_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-queries-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_queryparser_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f0e2e130" Win64="yes">
-                <File Id="lucene_queryparser_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-queryparser-7.0.0.jar" />
+              <Component Id="Component._...ser_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789366bdba" Win64="yes">
+                <File Id="_...ser_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-queryparser-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_sandbox_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478dc5fa387" Win64="yes">
-                <File Id="lucene_sandbox_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-sandbox-7.0.0.jar" />
+              <Component Id="Component._...box_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fb85033" Win64="yes">
+                <File Id="_...box_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-sandbox-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_spatial_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ed16eaf2" Win64="yes">
-                <File Id="lucene_spatial_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-spatial-7.0.0.jar" />
+              <Component Id="Component._...ial_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838c7d3c2" Win64="yes">
+                <File Id="_...ial_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component._...ucene_spatial_extras_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547817921172" Win64="yes">
-                <File Id="_...ucene_spatial_extras_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-spatial-extras-7.0.0.jar" />
+              <Component Id="Component._...ras_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478473148cb" Win64="yes">
+                <File Id="_...ras_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial-extras-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_spatial3d_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547834481cc7" Win64="yes">
-                <File Id="lucene_spatial3d_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-spatial3d-7.0.0.jar" />
+              <Component Id="Component._...l3d_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478757075b0" Win64="yes">
+                <File Id="_...l3d_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial3d-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.lucene_suggest_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784099c821" Win64="yes">
-                <File Id="lucene_suggest_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\lucene-suggest-7.0.0.jar" />
+              <Component Id="Component._...est_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478780e47de" Win64="yes">
+                <File Id="_...est_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-suggest-7.0.0-snapshot-a128fcb.jar" />
               </Component>
 
-              <Component Id="Component.plugin_cli_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478001a880d" Win64="yes">
-                <File Id="plugin_cli_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\plugin-cli-6.0.0-rc1.jar" />
+              <Component Id="Component.plugin_cli_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f2f1542" Win64="yes">
+                <File Id="plugin_cli_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\plugin-cli-6.0.0-beta2.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -245,12 +245,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...ggs_matrix_stats_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f7754b71" Win64="yes">
-                  <File Id="_...ggs_matrix_stats_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-rc1.jar" />
+                <Component Id="Component._...s_matrix_stats_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547807bf2122" Win64="yes">
+                  <File Id="_...s_matrix_stats_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -262,12 +262,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.analysis_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.analysis_common_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478339c7967" Win64="yes">
-                  <File Id="analysis_common_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\analysis-common\analysis-common-6.0.0-rc1.jar" />
+                <Component Id="Component._...nalysis_common_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b14f4d14" Win64="yes">
+                  <File Id="_...nalysis_common_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\analysis-common\analysis-common-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\analysis-common\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\analysis-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -279,20 +279,20 @@
                   <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.ingest_common_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fbc63a5" Win64="yes">
-                  <File Id="ingest_common_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\ingest-common-6.0.0-rc1.jar" />
+                <Component Id="Component.ingest_common_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478840c9f26" Win64="yes">
+                  <File Id="ingest_common_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\ingest-common-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\ingest-common\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -305,35 +305,35 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component.lang_expression_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547896d25411" Win64="yes">
-                  <File Id="lang_expression_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\lang-expression-6.0.0-rc1.jar" />
+                <Component Id="Component._...ang_expression_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478927f9e5a" Win64="yes">
+                  <File Id="_...ang_expression_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\lang-expression-6.0.0-beta2.jar" />
                 </Component>
 
-                <Component Id="Component.lucene_expressions_7.0.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786e8226c8" Win64="yes">
-                  <File Id="lucene_expressions_7.0.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\lucene-expressions-7.0.0.jar" />
+                <Component Id="Component._...ons_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cc3c0f50" Win64="yes">
+                  <File Id="_...ons_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\lucene-expressions-7.0.0-snapshot-a128fcb.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-expression\plugin-security.policy" />
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -346,19 +346,19 @@
                 </Component>
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b3812d9a" Win64="yes">
-                  <File Id="lang_mustache_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\lang-mustache-6.0.0-rc1.jar" />
+                <Component Id="Component.lang_mustache_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ce3bb6c6" Win64="yes">
+                  <File Id="lang_mustache_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\lang-mustache-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-mustache\plugin-security.policy" />
+                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -371,23 +371,23 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f6c74b7" Win64="yes">
-                  <File Id="lang_painless_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\lang-painless-6.0.0-rc1.jar" />
+                <Component Id="Component.lang_painless_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547839bfb98f" Win64="yes">
+                  <File Id="lang_painless_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\lang-painless-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\lang-painless\plugin-security.policy" />
+                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -399,12 +399,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.parent_join_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547818553fd6" Win64="yes">
-                  <File Id="parent_join_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\parent-join\parent-join-6.0.0-rc1.jar" />
+                <Component Id="Component.parent_join_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789363c25b" Win64="yes">
+                  <File Id="parent_join_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\parent-join\parent-join-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\parent-join\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\parent-join\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -416,12 +416,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.percolator_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547896a07669" Win64="yes">
-                  <File Id="percolator_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\percolator\percolator-6.0.0-rc1.jar" />
+                <Component Id="Component.percolator_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784eca6dcb" Win64="yes">
+                  <File Id="percolator_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\percolator\percolator-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\percolator\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\percolator\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -434,43 +434,43 @@
                 </Component>
 
                 <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
-                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\commons-codec-1.10.jar" />
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\commons-codec-1.10.jar" />
                 </Component>
 
                 <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
-                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\commons-logging-1.1.3.jar" />
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\commons-logging-1.1.3.jar" />
                 </Component>
 
-                <Component Id="Component._...arch_rest_client_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788699de9f" Win64="yes">
-                  <File Id="_...arch_rest_client_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\elasticsearch-rest-client-6.0.0-rc1.jar" />
+                <Component Id="Component._...ch_rest_client_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d0764d61" Win64="yes">
+                  <File Id="_...ch_rest_client_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\elasticsearch-rest-client-6.0.0-beta2.jar" />
                 </Component>
 
                 <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
-                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpasyncclient-4.1.2.jar" />
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpasyncclient-4.1.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
-                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpclient-4.5.2.jar" />
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpclient-4.5.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
-                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpcore-4.4.5.jar" />
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpcore-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
-                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\httpcore-nio-4.4.5.jar" />
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\plugin-security.policy" />
+                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.reindex_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ad04ddd3" Win64="yes">
-                  <File Id="reindex_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\reindex\reindex-6.0.0-rc1.jar" />
+                <Component Id="Component.reindex_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783a09d668" Win64="yes">
+                  <File Id="reindex_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\reindex-6.0.0-beta2.jar" />
                 </Component>
 
               </Directory>
@@ -483,15 +483,15 @@
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\repository-url\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\repository-url\plugin-security.policy" />
+                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.repository_url_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866cff685" Win64="yes">
-                  <File Id="repository_url_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\repository-url\repository-url-6.0.0-rc1.jar" />
+                <Component Id="Component.repository_url_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478349d4525" Win64="yes">
+                  <File Id="repository_url_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\repository-url-6.0.0-beta2.jar" />
                 </Component>
 
               </Directory>
@@ -504,43 +504,43 @@
                 </Component>
 
                 <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
-                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
+                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_codec_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478677b2eca" Win64="yes">
-                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
+                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...ty_codec_http_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bebaa9fe" Win64="yes">
-                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
+                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_common_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7df66c" Win64="yes">
-                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
+                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_handler_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fda2ab4a" Win64="yes">
-                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
+                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...etty_resolver_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785164d95f" Win64="yes">
-                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
+                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...tty_transport_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbded01b" Win64="yes">
-                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
+                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.10" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae8" Win64="yes">
-                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\plugin-descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\plugin-security.policy" />
+                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\plugin-security.policy" />
                 </Component>
 
-                <Component Id="Component.transport_netty4_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547852ed0ff0" Win64="yes">
-                  <File Id="transport_netty4_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\transport-netty4\transport-netty4-6.0.0-rc1.jar" />
+                <Component Id="Component._...ansport_netty4_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d74b642c" Win64="yes">
+                  <File Id="_...ansport_netty4_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\transport-netty4-6.0.0-beta2.jar" />
                 </Component>
 
               </Directory>
@@ -553,11 +553,11 @@
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties.11" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae9" Win64="yes">
-                  <File Id="plugin_descriptor.properties.11" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\tribe\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties.11" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\tribe\plugin-descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.tribe_6.0.0_rc1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cb39fa31" Win64="yes">
-                  <File Id="tribe_6.0.0_rc1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc1\modules\tribe\tribe-6.0.0-rc1.jar" />
+                <Component Id="Component.tribe_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc2204cf" Win64="yes">
+                  <File Id="tribe_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\tribe\tribe-6.0.0-beta2.jar" />
                 </Component>
 
               </Directory>
@@ -625,12 +625,14 @@
     <CustomAction Id="ElasticsearchServiceInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
     <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceStart" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
+    <CustomAction Id="Set_ElasticsearchSetupXPackPasswordsAction_Props" Property="ElasticsearchSetupXPackPasswordsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="ElasticsearchSetupXPackPasswordsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchSetupXPackPasswords" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
     <CustomAction Id="PreventDowngrading" Error="Newer version already installed" />
 
     <Binary Id="ElasticsearchUninstallServiceAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="6.0.0-rc1" />
+    <Property Id="CurrentVersion" Value="6.0.0-beta2" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -668,46 +670,46 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.elasticsearch_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component._..._version_checker_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component._...ersion_checker_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.jna_4.4.0_1.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
       <ComponentRef Id="Component.jts_1.13.jar" />
-      <ComponentRef Id="Component.log4j_1.2_api_2.9.1.jar" />
-      <ComponentRef Id="Component.log4j_api_2.9.1.jar" />
-      <ComponentRef Id="Component.log4j_core_2.9.1.jar" />
-      <ComponentRef Id="Component._...ene_analyzers_common_7.0.0.jar" />
-      <ComponentRef Id="Component._...cene_backward_codecs_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_core_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_grouping_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_highlighter_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_join_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_memory_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_misc_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_queries_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_queryparser_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_sandbox_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_spatial_7.0.0.jar" />
-      <ComponentRef Id="Component._...ucene_spatial_extras_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_spatial3d_7.0.0.jar" />
-      <ComponentRef Id="Component.lucene_suggest_7.0.0.jar" />
-      <ComponentRef Id="Component.plugin_cli_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.log4j_1.2_api_2.8.2.jar" />
+      <ComponentRef Id="Component.log4j_api_2.8.2.jar" />
+      <ComponentRef Id="Component.log4j_core_2.8.2.jar" />
+      <ComponentRef Id="Component._...mon_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ecs_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ore_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ing_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ter_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...oin_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ory_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...isc_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ies_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ser_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...box_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ial_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...ras_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...l3d_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component._...est_7.0.0_snapshot_a128fcb.jar" />
+      <ComponentRef Id="Component.plugin_cli_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.securesm_1.1.jar" />
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component._...ggs_matrix_stats_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component._...s_matrix_stats_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.analysis_common_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component._...nalysis_common_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.1" />
-      <ComponentRef Id="Component.ingest_common_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.ingest_common_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.2" />
@@ -715,36 +717,36 @@
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component.lang_expression_6.0.0_rc1.jar" />
-      <ComponentRef Id="Component.lucene_expressions_7.0.0.jar" />
+      <ComponentRef Id="Component._...ang_expression_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._...ons_7.0.0_snapshot_a128fcb.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.3" />
       <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.lang_mustache_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.4" />
       <ComponentRef Id="Component.plugin_security.policy.1" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.lang_painless_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.5" />
       <ComponentRef Id="Component.plugin_security.policy.2" />
-      <ComponentRef Id="Component.parent_join_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.parent_join_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.6" />
-      <ComponentRef Id="Component.percolator_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.percolator_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.7" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
-      <ComponentRef Id="Component._...arch_rest_client_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component._...ch_rest_client_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
       <ComponentRef Id="Component.httpclient_4.5.2.jar" />
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.8" />
       <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.reindex_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.reindex_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.9" />
       <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.repository_url_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.repository_url_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.netty_buffer_4.1.13.Final.jar" />
       <ComponentRef Id="Component.netty_codec_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...ty_codec_http_4.1.13.Final.jar" />
@@ -754,9 +756,9 @@
       <ComponentRef Id="Component._...tty_transport_4.1.13.Final.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.10" />
       <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component.transport_netty4_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component._...ansport_netty4_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties.11" />
-      <ComponentRef Id="Component.tribe_6.0.0_rc1.jar" />
+      <ComponentRef Id="Component.tribe_6.0.0_beta2.jar" />
       <ComponentRef Id="Component.INSTALLDIR" />
       <ComponentRef Id="Component.INSTALLDIR.bin.xpack" />
       <ComponentRef Id="Component.INSTALLDIR.bin" />
@@ -814,11 +816,13 @@
       <Custom Action="Set_ElasticsearchPluginsAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchPluginsAction" After="ElasticsearchJvmOptionsAction"> (NOT Installed) </Custom>
       <Custom Action="Set_ElasticsearchBootstrapPasswordAction_Props" After="InstallInitialize" />
-      <Custom Action="ElasticsearchBootstrapPasswordAction" After="ElasticsearchPluginsAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND XPACKLICENSE~="Trial"</Custom>
+      <Custom Action="ElasticsearchBootstrapPasswordAction" After="ElasticsearchPluginsAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND XPACKLICENSE~="Trial" AND SKIPSETTINGPASSWORDS~="false"</Custom>
       <Custom Action="Set_ElasticsearchServiceInstallAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchServiceInstallAction" After="ElasticsearchBootstrapPasswordAction">(NOT Installed) AND INSTALLASSERVICE="true"</Custom>
       <Custom Action="Set_ElasticsearchServiceStartAction_Props" After="InstallInitialize" />
       <Custom Action="ElasticsearchServiceStartAction" After="ElasticsearchServiceInstallAction">(NOT Installed) AND INSTALLASSERVICE="true" AND STARTAFTERINSTALL="true"</Custom>
+      <Custom Action="Set_ElasticsearchSetupXPackPasswordsAction_Props" After="InstallInitialize" />
+      <Custom Action="ElasticsearchSetupXPackPasswordsAction" After="ElasticsearchServiceStartAction">(NOT Installed) AND XPACKSECURITYENABLED~="true" AND XPACKLICENSE~="Trial" AND SKIPSETTINGPASSWORDS~="false"</Custom>
       <Custom Action="PreventDowngrading" After="FindRelatedProducts">NEWPRODUCTFOUND</Custom>
 
       <RemoveExistingProducts After="InstallFinalize" />

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="50f217e3-97b7-47ba-95f7-685f7db0c8aa" Name="Elasticsearch 6.0.0-beta2" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="576ef794-b3e3-4640-b717-1ed7d820d06e" Name="Elasticsearch 6.0.0-rc2" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_6.0.0_beta2_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_6.0.0_rc2_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -17,15 +17,15 @@
             </Component>
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -44,23 +44,23 @@
               </Component>
 
               <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
-                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-env.bat" />
+                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-env.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch.exe" />
 
                 <ServiceControl Id="elasticsearch.exe" Name="Elasticsearch" Stop="both" Wait="yes" />
               </Component>
@@ -75,15 +75,15 @@
               </Component>
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\config\log4j2.properties" />
               </Component>
 
             </Directory>
@@ -95,144 +95,144 @@
                 <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547804f08fa5" Win64="yes">
-                <File Id="elasticsearch_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\elasticsearch-6.0.0-beta2.jar" />
+              <Component Id="Component.elasticsearch_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547875a3b5fd" Win64="yes">
+                <File Id="elasticsearch_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\elasticsearch-6.0.0-rc2.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component._...ersion_checker_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547860ec5a68" Win64="yes">
-                <File Id="_...ersion_checker_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\java-version-checker-6.0.0-beta2.jar" />
+              <Component Id="Component._..._version_checker_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547879d9c68c" Win64="yes">
+                <File Id="_..._version_checker_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\java-version-checker-6.0.0-rc2.jar" />
               </Component>
 
               <Component Id="Component.jna_4.4.0_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838772020" Win64="yes">
-                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jna-4.4.0-1.jar" />
+                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jna-4.4.0-1.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jts-1.13.jar" />
               </Component>
 
-              <Component Id="Component.log4j_1.2_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd896f3f" Win64="yes">
-                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-1.2-api-2.8.2.jar" />
+              <Component Id="Component.log4j_1.2_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e2d" Win64="yes">
+                <File Id="log4j_1.2_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\log4j-1.2-api-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component.log4j_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830b6218a" Win64="yes">
-                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-api-2.8.2.jar" />
+              <Component Id="Component.log4j_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f021e" Win64="yes">
+                <File Id="log4j_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\log4j-api-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component.log4j_core_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b3cb698" Win64="yes">
-                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-core-2.8.2.jar" />
+              <Component Id="Component.log4j_core_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7d0b698" Win64="yes">
+                <File Id="log4j_core_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\log4j-core-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component._...mon_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780929e8b4" Win64="yes">
-                <File Id="_...mon_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-analyzers-common-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component._...ene_analyzers_common_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788a792dca" Win64="yes">
+                <File Id="_...ene_analyzers_common_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-analyzers-common-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ecs_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f02cdcc8" Win64="yes">
-                <File Id="_...ecs_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-backward-codecs-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component._...cene_backward_codecs_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841437ac6" Win64="yes">
+                <File Id="_...cene_backward_codecs_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-backward-codecs-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ore_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866da270f" Win64="yes">
-                <File Id="_...ore_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-core-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_core_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a124553f" Win64="yes">
+                <File Id="lucene_core_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-core-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ing_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478afc97d45" Win64="yes">
-                <File Id="_...ing_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-grouping-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_grouping_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788f6cd426" Win64="yes">
+                <File Id="lucene_grouping_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-grouping-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ter_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788b4151ab" Win64="yes">
-                <File Id="_...ter_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-highlighter-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_highlighter_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb3a0fdb" Win64="yes">
+                <File Id="lucene_highlighter_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-highlighter-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...oin_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783e6e1f07" Win64="yes">
-                <File Id="_...oin_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-join-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_join_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c83b3d6" Win64="yes">
+                <File Id="lucene_join_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-join-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ory_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781fe9ccc8" Win64="yes">
-                <File Id="_...ory_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-memory-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_memory_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547810d92d9b" Win64="yes">
+                <File Id="lucene_memory_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-memory-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...isc_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788066f951" Win64="yes">
-                <File Id="_...isc_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-misc-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_misc_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d5eceeb7" Win64="yes">
+                <File Id="lucene_misc_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-misc-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ies_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ed2d09d5" Win64="yes">
-                <File Id="_...ies_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-queries-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_queries_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785b80136d" Win64="yes">
+                <File Id="lucene_queries_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-queries-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ser_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789366bdba" Win64="yes">
-                <File Id="_...ser_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-queryparser-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_queryparser_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f001e130" Win64="yes">
+                <File Id="lucene_queryparser_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-queryparser-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...box_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fb85033" Win64="yes">
-                <File Id="_...box_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-sandbox-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_sandbox_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478dd7ea387" Win64="yes">
+                <File Id="lucene_sandbox_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-sandbox-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ial_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838c7d3c2" Win64="yes">
-                <File Id="_...ial_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_spatial_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478edf7eaf2" Win64="yes">
+                <File Id="lucene_spatial_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-spatial-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ras_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478473148cb" Win64="yes">
-                <File Id="_...ras_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial-extras-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component._...ucene_spatial_extras_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547837d91172" Win64="yes">
+                <File Id="_...ucene_spatial_extras_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-spatial-extras-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...l3d_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478757075b0" Win64="yes">
-                <File Id="_...l3d_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial3d-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_spatial3d_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547825791cc7" Win64="yes">
+                <File Id="lucene_spatial3d_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-spatial3d-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...est_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478780e47de" Win64="yes">
-                <File Id="_...est_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-suggest-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_suggest_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547840b4c821" Win64="yes">
+                <File Id="lucene_suggest_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-suggest-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component.plugin_cli_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f2f1542" Win64="yes">
-                <File Id="plugin_cli_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\plugin-cli-6.0.0-beta2.jar" />
+              <Component Id="Component.plugin_cli_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547800fb880d" Win64="yes">
+                <File Id="plugin_cli_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\plugin-cli-6.0.0-rc2.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -245,12 +245,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...s_matrix_stats_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547807bf2122" Win64="yes">
-                  <File Id="_...s_matrix_stats_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-beta2.jar" />
+                <Component Id="Component._...ggs_matrix_stats_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788b304b71" Win64="yes">
+                  <File Id="_...ggs_matrix_stats_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-rc2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -262,12 +262,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.analysis_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...nalysis_common_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b14f4d14" Win64="yes">
-                  <File Id="_...nalysis_common_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\analysis-common\analysis-common-6.0.0-beta2.jar" />
+                <Component Id="Component.analysis_common_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547880555aa2" Win64="yes">
+                  <File Id="analysis_common_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\analysis-common\analysis-common-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\analysis-common\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478d8242033" Win64="yes" Id="Component.analysis_common.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\analysis-common\plugin-descriptor.properties" Id="analysis_common.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -279,20 +279,20 @@
                   <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.ingest_common_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478840c9f26" Win64="yes">
-                  <File Id="ingest_common_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\ingest-common-6.0.0-beta2.jar" />
+                <Component Id="Component.ingest_common_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fbc6428" Win64="yes">
+                  <File Id="ingest_common_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\ingest-common-6.0.0-rc2.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54787f80fa71" Win64="yes" Id="Component.ingest_common.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\plugin-descriptor.properties" Id="ingest_common.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -305,35 +305,35 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component._...ang_expression_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478927f9e5a" Win64="yes">
-                  <File Id="_...ang_expression_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\lang-expression-6.0.0-beta2.jar" />
+                <Component Id="Component.lang_expression_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ada7b060" Win64="yes">
+                  <File Id="lang_expression_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\lang-expression-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component._...ons_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cc3c0f50" Win64="yes">
-                  <File Id="_...ons_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\lucene-expressions-7.0.0-snapshot-a128fcb.jar" />
+                <Component Id="Component.lucene_expressions_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786da126c8" Win64="yes">
+                  <File Id="lucene_expressions_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\lucene-expressions-7.0.1.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54787452d429" Win64="yes" Id="Component.lang_expression.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\plugin-descriptor.properties" Id="lang_expression.plugin_descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\plugin-security.policy" />
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -346,19 +346,19 @@
                 </Component>
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ce3bb6c6" Win64="yes">
-                  <File Id="lang_mustache_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\lang-mustache-6.0.0-beta2.jar" />
+                <Component Id="Component.lang_mustache_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b3812d77" Win64="yes">
+                  <File Id="lang_mustache_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\lang-mustache-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54781d17feb8" Win64="yes" Id="Component.lang_mustache.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\plugin-descriptor.properties" Id="lang_mustache.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54789821efe2" Win64="yes" Id="Component.lang_mustache.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\plugin-security.policy" Id="lang_mustache.plugin_security.policy" />
                 </Component>
 
               </Directory>
@@ -370,24 +370,24 @@
                   <RemoveFolder Id="INSTALLDIR.modules.lang_painless.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-547876342478" Win64="yes" Id="Component.lang_painless.antlr4_runtime_4.5.1_1.jar">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" Id="lang_painless.antlr4_runtime_4.5.1_1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547839bfb98f" Win64="yes">
-                  <File Id="lang_painless_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\lang-painless-6.0.0-beta2.jar" />
+                <Component Id="Component.lang_painless_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f6c7414" Win64="yes">
+                  <File Id="lang_painless_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\lang-painless-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54783080798c" Win64="yes" Id="Component.lang_painless.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\plugin-descriptor.properties" Id="lang_painless.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54782978c919" Win64="yes" Id="Component.lang_painless.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\plugin-security.policy" Id="lang_painless.plugin_security.policy" />
                 </Component>
 
               </Directory>
@@ -399,12 +399,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.parent_join_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789363c25b" Win64="yes">
-                  <File Id="parent_join_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\parent-join\parent-join-6.0.0-beta2.jar" />
+                <Component Id="Component.parent_join_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782f2a9c25" Win64="yes">
+                  <File Id="parent_join_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\parent-join\parent-join-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\parent-join\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-547800c6720f" Win64="yes" Id="Component.parent_join.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\parent-join\plugin-descriptor.properties" Id="parent_join.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -416,12 +416,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.percolator_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784eca6dcb" Win64="yes">
-                  <File Id="percolator_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\percolator\percolator-6.0.0-beta2.jar" />
+                <Component Id="Component.percolator_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547895fd7669" Win64="yes">
+                  <File Id="percolator_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\percolator\percolator-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\percolator\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54780f787589" Win64="yes" Id="Component.percolator.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\percolator\plugin-descriptor.properties" Id="percolator.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -434,43 +434,43 @@
                 </Component>
 
                 <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
-                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\commons-codec-1.10.jar" />
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\commons-codec-1.10.jar" />
                 </Component>
 
                 <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
-                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\commons-logging-1.1.3.jar" />
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\commons-logging-1.1.3.jar" />
                 </Component>
 
-                <Component Id="Component._...ch_rest_client_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d0764d61" Win64="yes">
-                  <File Id="_...ch_rest_client_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\elasticsearch-rest-client-6.0.0-beta2.jar" />
+                <Component Id="Component._...arch_rest_client_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789468de9f" Win64="yes">
+                  <File Id="_...arch_rest_client_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\elasticsearch-rest-client-6.0.0-rc2.jar" />
                 </Component>
 
                 <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
-                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpasyncclient-4.1.2.jar" />
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpasyncclient-4.1.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
-                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpclient-4.5.2.jar" />
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpclient-4.5.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
-                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpcore-4.4.5.jar" />
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpcore-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
-                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpcore-nio-4.4.5.jar" />
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54781e892253" Win64="yes" Id="Component.reindex.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\plugin-descriptor.properties" Id="reindex.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cf2f45a9" Win64="yes" Id="Component.reindex.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\plugin-security.policy" Id="reindex.plugin_security.policy" />
                 </Component>
 
-                <Component Id="Component.reindex_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783a09d668" Win64="yes">
-                  <File Id="reindex_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\reindex-6.0.0-beta2.jar" />
+                <Component Id="Component.reindex_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785f4bfc98" Win64="yes">
+                  <File Id="reindex_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\reindex-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -482,16 +482,16 @@
                   <RemoveFolder Id="INSTALLDIR.modules.repository_url.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478fa248f9a" Win64="yes" Id="Component.repository_url.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\repository-url\plugin-descriptor.properties" Id="repository_url.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-547898a6f299" Win64="yes" Id="Component.repository_url.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\repository-url\plugin-security.policy" Id="repository_url.plugin_security.policy" />
                 </Component>
 
-                <Component Id="Component.repository_url_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478349d4525" Win64="yes">
-                  <File Id="repository_url_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\repository-url-6.0.0-beta2.jar" />
+                <Component Id="Component.repository_url_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866acf685" Win64="yes">
+                  <File Id="repository_url_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\repository-url\repository-url-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -504,43 +504,43 @@
                 </Component>
 
                 <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
-                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
+                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_codec_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478677b2eca" Win64="yes">
-                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
+                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...ty_codec_http_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bebaa9fe" Win64="yes">
-                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
+                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_common_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7df66c" Win64="yes">
-                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
+                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_handler_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fda2ab4a" Win64="yes">
-                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
+                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...etty_resolver_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785164d95f" Win64="yes">
-                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
+                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...tty_transport_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbded01b" Win64="yes">
-                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
+                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.10" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae8" Win64="yes">
-                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54789fb1b618" Win64="yes" Id="Component.transport_netty4.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\plugin-descriptor.properties" Id="transport_netty4.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478345f9901" Win64="yes" Id="Component.transport_netty4.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\plugin-security.policy" Id="transport_netty4.plugin_security.policy" />
                 </Component>
 
-                <Component Id="Component._...ansport_netty4_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d74b642c" Win64="yes">
-                  <File Id="_...ansport_netty4_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\transport-netty4-6.0.0-beta2.jar" />
+                <Component Id="Component.transport_netty4_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547806940ff0" Win64="yes">
+                  <File Id="transport_netty4_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\transport-netty4-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -552,12 +552,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.tribe.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.11" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae9" Win64="yes">
-                  <File Id="plugin_descriptor.properties.11" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\tribe\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ada2480d" Win64="yes" Id="Component.tribe.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\tribe\plugin-descriptor.properties" Id="tribe.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.tribe_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc2204cf" Win64="yes">
-                  <File Id="tribe_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\tribe\tribe-6.0.0-beta2.jar" />
+                <Component Id="Component.tribe_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cb39fad4" Win64="yes">
+                  <File Id="tribe_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\tribe\tribe-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -587,52 +587,52 @@
     <CustomAction Id="Action2SetProp_CONFIGDIRECTORY" Property="CONFIGDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\config" Return="check" Execute="immediate" />
     <CustomAction Id="Action3SetProp_LOGSDIRECTORY" Property="LOGSDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\logs" Return="check" Execute="immediate" />
     <CustomAction Id="Action4SetProp_NODENAME" Property="NODENAME" Value="[%COMPUTERNAME]" Return="check" Execute="immediate" />
-    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallService" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackEnvironment" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
     <CustomAction Id="ElasticsearchValidateArgumentsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchValidateArguments" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchCleanupAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchCleanup" Return="ignore" Impersonate="no" Execute="commit" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackDirectories" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
     <CustomAction Id="ElasticsearchSetBootstrapPasswordAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchSetBootstrapPassword" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackServiceStart" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchPreserveInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPreserveInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackInstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackInstallService" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchConfigurationAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchConfiguration" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchJvmOptionsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchJvmOptions" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchBootstrapPasswordAction_Props" Property="ElasticsearchBootstrapPasswordAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchBootstrapPasswordAction_Props" Property="ElasticsearchBootstrapPasswordAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchBootstrapPasswordAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchBootstrapPassword" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceStart" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchSetupXPackPasswordsAction_Props" Property="ElasticsearchSetupXPackPasswordsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchSetupXPackPasswordsAction_Props" Property="ElasticsearchSetupXPackPasswordsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchSetupXPackPasswordsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchSetupXPackPasswords" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
     <CustomAction Id="PreventDowngrading" Error="Newer version already installed" />
 
     <Binary Id="ElasticsearchUninstallServiceAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="6.0.0-beta2" />
+    <Property Id="CurrentVersion" Value="6.0.0-rc2" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -649,6 +649,10 @@
     <Property Id="LOCKMEMORY" Value="false" />
     <Property Id="HTTPPORT" Value="9200" />
     <Property Id="TRANSPORTPORT" Value="9300" />
+    <Property Id="HTTPPROXYHOST" />
+    <Property Id="HTTPPROXYPORT" />
+    <Property Id="HTTPSPROXYHOST" />
+    <Property Id="HTTPSPROXYPORT" />
     <Property Id="PLUGINS" />
     <Property Id="ELASTICUSERPASSWORD" Hidden="yes" />
     <Property Id="KIBANAUSERPASSWORD" Hidden="yes" />
@@ -670,83 +674,83 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.elasticsearch_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component._...ersion_checker_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._..._version_checker_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.jna_4.4.0_1.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
       <ComponentRef Id="Component.jts_1.13.jar" />
-      <ComponentRef Id="Component.log4j_1.2_api_2.8.2.jar" />
-      <ComponentRef Id="Component.log4j_api_2.8.2.jar" />
-      <ComponentRef Id="Component.log4j_core_2.8.2.jar" />
-      <ComponentRef Id="Component._...mon_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ecs_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ore_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ing_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ter_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...oin_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ory_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...isc_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ies_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ser_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...box_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ial_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ras_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...l3d_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...est_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component.plugin_cli_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.log4j_1.2_api_2.9.1.jar" />
+      <ComponentRef Id="Component.log4j_api_2.9.1.jar" />
+      <ComponentRef Id="Component.log4j_core_2.9.1.jar" />
+      <ComponentRef Id="Component._...ene_analyzers_common_7.0.1.jar" />
+      <ComponentRef Id="Component._...cene_backward_codecs_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_core_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_grouping_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_highlighter_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_join_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_memory_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_misc_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_queries_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_queryparser_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_sandbox_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_spatial_7.0.1.jar" />
+      <ComponentRef Id="Component._...ucene_spatial_extras_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_spatial3d_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_suggest_7.0.1.jar" />
+      <ComponentRef Id="Component.plugin_cli_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.securesm_1.1.jar" />
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component._...s_matrix_stats_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._...ggs_matrix_stats_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component._...nalysis_common_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.1" />
-      <ComponentRef Id="Component.ingest_common_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.analysis_common_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.analysis_common.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.ingest_common_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.2" />
+      <ComponentRef Id="Component.ingest_common.plugin_descriptor.properties" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar" />
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component._...ang_expression_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component._...ons_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.3" />
+      <ComponentRef Id="Component.lang_expression_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.lucene_expressions_7.0.1.jar" />
+      <ComponentRef Id="Component.lang_expression.plugin_descriptor.properties" />
       <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.4" />
-      <ComponentRef Id="Component.plugin_security.policy.1" />
-      <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
+      <ComponentRef Id="Component.lang_mustache_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.lang_mustache.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.lang_mustache.plugin_security.policy" />
+      <ComponentRef Id="Component.lang_painless.antlr4_runtime_4.5.1_1.jar" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.5" />
-      <ComponentRef Id="Component.plugin_security.policy.2" />
-      <ComponentRef Id="Component.parent_join_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.6" />
-      <ComponentRef Id="Component.percolator_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.7" />
+      <ComponentRef Id="Component.lang_painless_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.lang_painless.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.lang_painless.plugin_security.policy" />
+      <ComponentRef Id="Component.parent_join_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.parent_join.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.percolator_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.percolator.plugin_descriptor.properties" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
-      <ComponentRef Id="Component._...ch_rest_client_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._...arch_rest_client_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
       <ComponentRef Id="Component.httpclient_4.5.2.jar" />
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.8" />
-      <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.reindex_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.9" />
-      <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.repository_url_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.reindex.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.reindex.plugin_security.policy" />
+      <ComponentRef Id="Component.reindex_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.repository_url.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.repository_url.plugin_security.policy" />
+      <ComponentRef Id="Component.repository_url_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.netty_buffer_4.1.13.Final.jar" />
       <ComponentRef Id="Component.netty_codec_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...ty_codec_http_4.1.13.Final.jar" />
@@ -754,11 +758,11 @@
       <ComponentRef Id="Component.netty_handler_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...etty_resolver_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...tty_transport_4.1.13.Final.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.10" />
-      <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component._...ansport_netty4_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.11" />
-      <ComponentRef Id="Component.tribe_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.transport_netty4.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.transport_netty4.plugin_security.policy" />
+      <ComponentRef Id="Component.transport_netty4_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.tribe.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.tribe_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.INSTALLDIR" />
       <ComponentRef Id="Component.INSTALLDIR.bin.xpack" />
       <ComponentRef Id="Component.INSTALLDIR.bin" />

--- a/src/Installer/Elastic.Installer.UI/Controls/StepControl.cs
+++ b/src/Installer/Elastic.Installer.UI/Controls/StepControl.cs
@@ -6,6 +6,7 @@ using ReactiveUI;
 using System;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Windows.Media;
 using Elastic.Installer.Domain.Model.Base;
 
 namespace Elastic.Installer.UI.Controls

--- a/src/Installer/Elastic.Installer.UI/Elastic.Installer.UI.csproj
+++ b/src/Installer/Elastic.Installer.UI/Elastic.Installer.UI.csproj
@@ -102,6 +102,9 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Elasticsearch\Steps\PluginsView.xaml.cs">
+      <DependentUpon>PluginsView.xaml</DependentUpon>
+    </Compile>
     <Content Include="Resources\Entypo-license.txt">
       <Paket>True</Paket>
     </Content>
@@ -158,8 +161,8 @@
     <Compile Include="Elasticsearch\Steps\LocationsView.xaml.cs">
       <DependentUpon>LocationsView.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Elasticsearch\Steps\PluginsView.xaml.cs">
-      <DependentUpon>PluginsView.xaml</DependentUpon>
+    <Compile Include="Elasticsearch\Steps\XPackView.xaml.cs">
+      <DependentUpon>XPackView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\StepControl.cs" />
     <Compile Include="Elasticsearch\Steps\NoticeView.xaml.cs">
@@ -177,6 +180,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="Elasticsearch\Steps\XPackView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Kibana\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml.cs
@@ -134,7 +134,7 @@ namespace Elastic.Installer.UI.Elasticsearch
 			{ typeof(PluginsModel), (m, s) => Step(s, new PluginsView { ViewModel = m as PluginsModel }, 
 				ViewResources.PluginsView_Elasticsearch_Help_Header, ViewResources.PluginsView_Elasticsearch_Help) },
 			{ typeof(XPackModel), (m, s) => Step(s, new XPackView { ViewModel = m as XPackModel }, 
-				ViewResources.PluginsView_Elasticsearch_Help_Header, ViewResources.PluginsView_Elasticsearch_Help) },
+				ViewResources.XPackView_Elasticsearch_Help_Header, ViewResources.XPackView_Elasticsearch_Help) },
 			{ typeof(ClosingModel), (m, s) => Step(s, new ClosingView { ViewModel = m as ClosingModel }, null, null) },
 		};
 		private readonly IDictionary<Type, MetroTabItem> CachedTabs = new Dictionary<Type, MetroTabItem>();

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/MainWindow.xaml.cs
@@ -356,6 +356,7 @@ namespace Elastic.Installer.UI.Elasticsearch
 			SetSessionValues(this.ViewModel.ConfigurationModel);
 			SetSessionValues(this.ViewModel.ServiceModel);
 			SetSessionValues(this.ViewModel.PluginsModel);
+			SetSessionValues(this.ViewModel.XPackModel);
 
 			this._progressCounter = new InstallProgressCounter();
 			this.StepsTab.Visibility = Visibility.Hidden;

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ClosingView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ClosingView.xaml
@@ -33,9 +33,9 @@
 
       <TextBox Grid.Row="1" Grid.Column="0" x:Name="ResultParagraphLabel" 
                Background="Transparent" BorderBrush="Transparent"  Margin="0,0,0,10" 
-               TextWrapping="Wrap"
+               TextWrapping="Wrap" BorderThickness="0"
                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
-               ScrollViewer.VerticalScrollBarVisibility="Visible"/>
+               ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
     </Grid>
     <StackPanel Grid.Row="1" Grid.Column="0">
       <Grid x:Name="GridSuccess" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml.cs
@@ -85,10 +85,10 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 			{
 				switch (e.PropertyName)
 				{
-					case "ClusterName":
+					case nameof(ViewModel.ClusterName):
 						this.ClusterNameTextBox.BorderBrush = b;
 						continue;
-					case "NodeName":
+					case nameof(ViewModel.NodeName):
 						this.NodeNameTextBox.BorderBrush = b;
 						continue;
 				}

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml
@@ -43,7 +43,7 @@
       
       <TextBox x:Name="UpgradeTextBox" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" 
                Background="Transparent" BorderBrush="Transparent"  Margin="0,0,0,10" 
-               TextWrapping="Wrap"
+               TextWrapping="Wrap" BorderThickness="0"
                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
                ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
       

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml
@@ -4,6 +4,7 @@
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:resx="clr-namespace:Elastic.Installer.UI.Properties"
                       xmlns:controls="clr-namespace:Elastic.Installer.UI.Controls"
                       xmlns:steps="clr-namespace:Elastic.Installer.UI.Elasticsearch.Steps"
                       xmlns:plugins="clr-namespace:Elastic.Installer.Domain.Model.Elasticsearch.XPack;assembly=Elastic.Installer.Domain"
@@ -11,5 +12,112 @@
                       d:DataContext="{d:DesignInstance d:Type=plugins:XPackModel }"
                       d:DesignHeight="300" d:DesignWidth="600">
   <Grid>
+    <Grid.Resources>
+      <ResourceDictionary>
+        <ResourceDictionary.MergedDictionaries>
+          <ResourceDictionary Source="pack://application:,,,/Elastic.Installer.UI;component/ResourceDictionary.xaml" />
+        </ResourceDictionary.MergedDictionaries>
+      </ResourceDictionary>
+    </Grid.Resources>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="*"/>
+      <ColumnDefinition Width="20"/>
+      <ColumnDefinition Width="*"/>
+    </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="50" />
+      <RowDefinition Height="95" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <Grid Grid.Column="0" Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="150"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="45" />
+      </Grid.RowDefinitions>
+      <Label Grid.Row="0" Grid.Column="0" x:Name="LicenseLabel" Content="{x:Static resx:ViewResources.XPackView_LicenseLabel}" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
+      <ComboBox Grid.Row="0" Grid.Column="1" x:Name="LicenseDropDown" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
+    </Grid>
+    <Grid Grid.Column="0" x:Name="SecurityGrid" Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="150"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="45" />
+        <RowDefinition Height="45"/>
+      </Grid.RowDefinitions>
+      <Label Grid.Row="0" Grid.Column="0" x:Name="SecurityLabel" Content="{x:Static resx:ViewResources.XPackView_SecurityLabel}" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
+      <CheckBox Grid.Row="0" Grid.Column="1" x:Name="EnableXPackSecurityCheckBox" Content="{x:Static resx:ViewResources.XPackView_EnableXPackSecurity}" HorizontalAlignment="Left" Margin="0,10,0,0" VerticalAlignment="Top"/>
+      <Label Grid.Row="1" Grid.Column="0" x:Name="UserLabel" Content="{x:Static resx:ViewResources.XPackView_UsersLabel}" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
+      <CheckBox Grid.Row="1" Grid.Column="1" x:Name="SkipPasswordGenerationCheckBox" Content="{x:Static resx:ViewResources.XPackView_OverrideGeneratePasswordsLabel}" HorizontalAlignment="Left" Margin="0,10,0,0" VerticalAlignment="Top"/>
+    </Grid> 
+    <Grid Grid.Column="0" x:Name="UserGrid" Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="150"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="45"/>
+        <RowDefinition Height="45"/>
+        <RowDefinition Height="45"/>
+      </Grid.RowDefinitions>
+      <Label Grid.Row="0" Grid.Column="0" x:Name="ElasticUserLabel" Content="{x:Static resx:ViewResources.XPackView_ElasticUserLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
+      <PasswordBox Grid.Row="0" Grid.Column="1" x:Name="ElasticPasswordBox" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="30"  VerticalAlignment="Center" />
+      <Label Grid.Row="1" Grid.Column="0" x:Name="KibanaUserLabel" Content="{x:Static resx:ViewResources.XPackView_KibanaUserLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
+      <PasswordBox Grid.Row="1" Grid.Column="1" x:Name="KibanaUserPasswordBox" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="30"  VerticalAlignment="Center" />
+      <Label Grid.Row="2" Grid.Column="0" x:Name="LogstashSystemLabel" Content="{x:Static resx:ViewResources.XPackView_LogstashSystemUserLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
+      <PasswordBox Grid.Row="2" Grid.Column="1" x:Name="LogstashSystemPasswordBox" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="30"  VerticalAlignment="Center" />
+    </Grid>
+    <Grid Grid.Column="0" x:Name="ManualSetupGrid" Grid.Row="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Height="Auto">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <TextBox x:Name="ManualConfigurationNeededTextBox" Grid.Row="0" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_ManualUserConfigurationNeeded}"
+               Background="Transparent" BorderBrush="Transparent"  Margin="0,20,0,10" Foreground="{DynamicResource AccentColorBrush2}"
+               TextWrapping="Wrap" 
+               HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
+               ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
+       <Button Grid.Row="1" Grid.Column="0" x:Name="OpenManualUserConfigurationLink"  Style="{DynamicResource Link}" 
+             FontWeight="Bold" 
+             Margin="6, 12, 0,0"
+             Content="{x:Static resx:ViewResources.XPackView_ManualUserConfigurationLink}" 
+             HorizontalAlignment="Left" VerticalAlignment="Top" />
+    </Grid>
+    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="0" Grid.Column="2" Grid.RowSpan="4">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="45"/>
+        <RowDefinition Height="30"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="30"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="40"/>
+      </Grid.RowDefinitions>
+      <Label Grid.Row="0" Grid.Column="0" x:Name="ChooseYourLicenseLabel" Content="{x:Static resx:ViewResources.XPackView_ChooseYourLicense}" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{DynamicResource DescriptionHeaderStyle}" />
+      <Label Grid.Row="1" Grid.Column="0" FontWeight="Bold" Foreground="{DynamicResource AccentColorBrush}" x:Name="BasicLicenseLabel" Content="{x:Static resx:ViewResources.XPackView_BasicLicense}" HorizontalAlignment="Left" VerticalAlignment="Top" />
+      <TextBox x:Name="BasicDescriptionTextBox" Grid.Row="2" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_BasicDescription}"
+               Background="Transparent" BorderBrush="Transparent"  Margin="0,0,0,10" Foreground="{DynamicResource AccentColorBrush}"
+               TextWrapping="Wrap" 
+               HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
+               ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
+      <Label Grid.Row="3" Grid.Column="0" FontWeight="Bold" Foreground="{DynamicResource AccentColorBrush}" x:Name="TrialLicenseLabel" Content="{x:Static resx:ViewResources.XPackView_TrialLicense}" HorizontalAlignment="Left" VerticalAlignment="Top" />
+      <TextBox x:Name="TrialDescriptionTextBox" Grid.Row="4" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_TrialDescription}"
+               Background="Transparent" BorderBrush="Transparent"  Margin="0,0,0,10" Foreground="{DynamicResource AccentColorBrush}"
+               TextWrapping="Wrap" 
+               HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
+               ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
+        <Button Grid.Row="5" Grid.Column="0" x:Name="OpenSupscriptionsLink"  Style="{DynamicResource Link}" 
+             FontWeight="Bold" 
+             Margin="6, 12, 0,0"
+             Content="{x:Static resx:ViewResources.XPackView_SubscriptionsLink}" 
+             HorizontalAlignment="Left" VerticalAlignment="Top" />
+
+    </Grid>
   </Grid>
 </controls:StepControl>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml
@@ -78,7 +78,7 @@
       </Grid.RowDefinitions>
       <TextBox x:Name="ManualConfigurationNeededTextBox" Grid.Row="0" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_ManualUserConfigurationNeeded}"
                Background="Transparent" BorderBrush="Transparent"  Margin="0,20,0,10" Foreground="{DynamicResource AccentColorBrush2}"
-               TextWrapping="Wrap" 
+               TextWrapping="Wrap" BorderThickness="0"
                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
                ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
        <Button Grid.Row="1" Grid.Column="0" x:Name="OpenManualUserConfigurationLink"  Style="{DynamicResource Link}" 
@@ -95,6 +95,7 @@
         <RowDefinition Height="45"/>
         <RowDefinition Height="30"/>
         <RowDefinition Height="Auto"/>
+        <RowDefinition Height="40"/>
         <RowDefinition Height="30"/>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="40"/>
@@ -103,21 +104,25 @@
       <Label Grid.Row="1" Grid.Column="0" FontWeight="Bold" Foreground="{DynamicResource AccentColorBrush}" x:Name="BasicLicenseLabel" Content="{x:Static resx:ViewResources.XPackView_BasicLicense}" HorizontalAlignment="Left" VerticalAlignment="Top" />
       <TextBox x:Name="BasicDescriptionTextBox" Grid.Row="2" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_BasicDescription}"
                Background="Transparent" BorderBrush="Transparent"  Margin="0,0,0,10" Foreground="{DynamicResource AccentColorBrush}"
-               TextWrapping="Wrap" 
+               TextWrapping="Wrap" BorderThickness="0"
                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
                ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
-      <Label Grid.Row="3" Grid.Column="0" FontWeight="Bold" Foreground="{DynamicResource AccentColorBrush}" x:Name="TrialLicenseLabel" Content="{x:Static resx:ViewResources.XPackView_TrialLicense}" HorizontalAlignment="Left" VerticalAlignment="Top" />
-      <TextBox x:Name="TrialDescriptionTextBox" Grid.Row="4" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_TrialDescription}"
+      <Button Grid.Row="3" Grid.Column="0" x:Name="RegisterBasicLicenseLink"  Style="{DynamicResource Link}" 
+              FontWeight="Bold" 
+              Margin="6, 12, 0,0"
+              Content="{x:Static resx:ViewResources.XPackView_RegisterBasicLicenseLink}" 
+              HorizontalAlignment="Left" VerticalAlignment="Top" />
+      <Label Grid.Row="4" Grid.Column="0" FontWeight="Bold" Foreground="{DynamicResource AccentColorBrush}" x:Name="TrialLicenseLabel" Content="{x:Static resx:ViewResources.XPackView_TrialLicense}" HorizontalAlignment="Left" VerticalAlignment="Top" />
+      <TextBox x:Name="TrialDescriptionTextBox" Grid.Row="5" Grid.Column="0" Text="{x:Static resx:ViewResources.XPackView_TrialDescription}"
                Background="Transparent" BorderBrush="Transparent"  Margin="0,0,0,10" Foreground="{DynamicResource AccentColorBrush}"
-               TextWrapping="Wrap" 
+               TextWrapping="Wrap" BorderThickness="0"
                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsReadOnly="True"
                ScrollViewer.VerticalScrollBarVisibility="Hidden"/>
-        <Button Grid.Row="5" Grid.Column="0" x:Name="OpenSupscriptionsLink"  Style="{DynamicResource Link}" 
-             FontWeight="Bold" 
-             Margin="6, 12, 0,0"
-             Content="{x:Static resx:ViewResources.XPackView_SubscriptionsLink}" 
-             HorizontalAlignment="Left" VerticalAlignment="Top" />
-
+      <Button Grid.Row="6" Grid.Column="0" x:Name="OpenSubscriptionsLink"  Style="{DynamicResource Link}" 
+            FontWeight="Bold" 
+            Margin="6, 12, 0,0"
+            Content="{x:Static resx:ViewResources.XPackView_SubscriptionsLink}" 
+            HorizontalAlignment="Left" VerticalAlignment="Top" />
     </Grid>
   </Grid>
 </controls:StepControl>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml
@@ -1,0 +1,15 @@
+﻿<controls:StepControl x:Class="Elastic.Installer.UI.Elasticsearch.Steps.XPackView"
+                      x:TypeArguments="plugins:XPackModel, steps:XPackView"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:controls="clr-namespace:Elastic.Installer.UI.Controls"
+                      xmlns:steps="clr-namespace:Elastic.Installer.UI.Elasticsearch.Steps"
+                      xmlns:plugins="clr-namespace:Elastic.Installer.Domain.Model.Elasticsearch.XPack;assembly=Elastic.Installer.Domain"
+                      mc:Ignorable="d"
+                      d:DataContext="{d:DesignInstance d:Type=plugins:XPackModel }"
+                      d:DesignHeight="300" d:DesignWidth="600">
+  <Grid>
+  </Grid>
+</controls:StepControl>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using Elastic.Installer.UI.Controls;
+using Elastic.Installer.UI.Properties;
 using FluentValidation.Results;
 using ReactiveUI;
 using static System.Windows.Visibility;
@@ -43,6 +45,15 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 
 			this.Bind(ViewModel, vm => vm.SkipSettingPasswords, v => v.SkipPasswordGenerationCheckBox.IsChecked);
 			this.Bind(ViewModel, vm => vm.XPackSecurityEnabled, v => v.EnableXPackSecurityCheckBox.IsChecked);
+			this.BindCommand(ViewModel, vm => vm.OpenLicensesAndSubscriptions, v => v.OpenSubscriptionsLink, nameof(OpenSubscriptionsLink.Click));
+			this.BindCommand(ViewModel, vm => vm.RegisterBasicLicense, v => v.RegisterBasicLicenseLink, nameof(RegisterBasicLicenseLink.Click));
+			this.BindCommand(ViewModel, vm => vm.OpenManualUserConfiguration, v => v.OpenManualUserConfigurationLink, nameof(OpenManualUserConfigurationLink.Click));
+
+			this.ViewModel.OpenLicensesAndSubscriptions.Subscribe(x => Process.Start(ViewResources.XPackView_OpenLicensesAndSubscriptions));
+			this.ViewModel.RegisterBasicLicense.Subscribe(x => Process.Start(ViewResources.XPackView_RegisterBasicLicense));
+
+			var majorMinor = $"{this.ViewModel.CurrentVersion.Major}.{this.ViewModel.CurrentVersion.Minor}";
+			this.ViewModel.OpenManualUserConfiguration.Subscribe(x => Process.Start(string.Format(ViewResources.XPackView_ManualUserConfiguration, majorMinor)));
 
 			foreach (var name in Enum.GetNames(typeof(XPackLicenseMode)))
 				this.LicenseDropDown.Items.Add(new ComboBoxItem {Content = name});

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
@@ -41,7 +41,7 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 			this.LogstashSystemPasswordBox.Events().PasswordChanged
 				.Subscribe(a => this.ViewModel.LogstashSystemUserPassword = this.LogstashSystemPasswordBox.Password);
 
-			this.Bind(ViewModel, vm => vm.GenerateUsersLater, v => v.SkipPasswordGenerationCheckBox.IsChecked);
+			this.Bind(ViewModel, vm => vm.SkipSettingPasswords, v => v.SkipPasswordGenerationCheckBox.IsChecked);
 			this.Bind(ViewModel, vm => vm.XPackSecurityEnabled, v => v.EnableXPackSecurityCheckBox.IsChecked);
 
 			foreach (var name in Enum.GetNames(typeof(XPackLicenseMode)))
@@ -53,7 +53,7 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 
 			this.ViewModel.WhenAnyValue(
 					vm => vm.XPackLicense,
-					vm => vm.GenerateUsersLater,
+					vm => vm.SkipSettingPasswords,
 					vm => vm.XPackSecurityEnabled,
 					vm => vm.CanAutomaticallySetupUsers,
 					vm => vm.IsRelevant

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using System.Reactive.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using Elastic.Installer.Domain.Model.Base.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using Elastic.Installer.UI.Controls;
+using ReactiveUI;
+
+namespace Elastic.Installer.UI.Elasticsearch.Steps
+{
+	public partial class XPackView : StepControl<XPackModel, XPackView>
+	{
+		public static readonly DependencyProperty ViewModelProperty =
+			DependencyProperty.Register(nameof(ViewModel), typeof(XPackModel), typeof(XPackView), new PropertyMetadata(null, ViewModelPassed));
+
+		public override XPackModel ViewModel
+		{
+			get => (XPackModel)GetValue(ViewModelProperty);
+			set => SetValue(ViewModelProperty, value);
+		}
+
+		public XPackView()
+		{
+			InitializeComponent();
+		}
+
+		protected override void InitializeBindings()
+		{
+			//this.OneWayBind(ViewModel, vm => vm.AvailablePlugins, v => v.PluginsListBox.ItemsSource);
+		}
+	}
+}

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
@@ -1,12 +1,14 @@
-﻿using System.Linq;
-using System.Reactive.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using Elastic.Installer.Domain.Model.Base.Plugins;
-using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using System.Windows.Media;
 using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using Elastic.Installer.UI.Controls;
+using FluentValidation.Results;
 using ReactiveUI;
+using static System.Windows.Visibility;
 
 namespace Elastic.Installer.UI.Elasticsearch.Steps
 {
@@ -17,18 +19,132 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 
 		public override XPackModel ViewModel
 		{
-			get => (XPackModel)GetValue(ViewModelProperty);
+			get => (XPackModel) GetValue(ViewModelProperty);
 			set => SetValue(ViewModelProperty, value);
 		}
+
+		private readonly Brush _defaultBrush;
 
 		public XPackView()
 		{
 			InitializeComponent();
+			this._defaultBrush = this.ElasticPasswordBox.BorderBrush;
 		}
 
 		protected override void InitializeBindings()
 		{
-			//this.OneWayBind(ViewModel, vm => vm.AvailablePlugins, v => v.PluginsListBox.ItemsSource);
+			// cannot bind to the Password property directly as it does not expose a DP
+			this.ElasticPasswordBox.Events().PasswordChanged
+				.Subscribe(a => this.ViewModel.ElasticUserPassword = this.ElasticPasswordBox.Password);
+			this.KibanaUserPasswordBox.Events().PasswordChanged
+				.Subscribe(a => this.ViewModel.KibanaUserPassword = this.KibanaUserPasswordBox.Password);
+			this.LogstashSystemPasswordBox.Events().PasswordChanged
+				.Subscribe(a => this.ViewModel.LogstashSystemUserPassword = this.LogstashSystemPasswordBox.Password);
+
+			this.Bind(ViewModel, vm => vm.GenerateUsersLater, v => v.SkipPasswordGenerationCheckBox.IsChecked);
+			this.Bind(ViewModel, vm => vm.XPackSecurityEnabled, v => v.EnableXPackSecurityCheckBox.IsChecked);
+
+			foreach (var name in Enum.GetNames(typeof(XPackLicenseMode)))
+				this.LicenseDropDown.Items.Add(new ComboBoxItem {Content = name});
+
+			this.Bind(ViewModel, vm => vm.XPackLicense, x => x.LicenseDropDown.SelectedIndex
+				, null, vmToViewConverterOverride: new LicenseToSelectedIndexConverter()
+				, viewToVMConverterOverride: new SelectedIndexToLicenseConverter());
+
+			this.ViewModel.WhenAnyValue(
+					vm => vm.XPackLicense,
+					vm => vm.GenerateUsersLater,
+					vm => vm.XPackSecurityEnabled,
+					vm => vm.CanAutomaticallySetupUsers,
+					vm => vm.IsRelevant
+				)
+				.Subscribe(t =>
+				{
+					var isTrialLicense = t.Item1 == XPackLicenseMode.Trial;
+					var generateUsersLater = t.Item2;
+					var securityEnabled = t.Item3;
+					var canGenerateUsers = t.Item4;
+					var isRelevant = t.Item5;
+
+					this.SecurityGrid.Visibility = isTrialLicense ? Visible : Hidden;
+					
+					if (!isTrialLicense || !securityEnabled)
+						this.UserGrid.Visibility = Collapsed;
+					else if (!this.ViewModel.NeedsPassword)
+						this.UserGrid.Visibility = Collapsed;
+					else this.UserGrid.Visibility = Visible;
+					
+					this.ManualSetupGrid.Visibility =
+						!isTrialLicense || !securityEnabled
+							? Collapsed : (!this.ViewModel.NeedsPassword ? Visible : Collapsed);
+
+					this.UserLabel.Visibility = isTrialLicense && securityEnabled ? Visible : Collapsed;
+					this.SkipPasswordGenerationCheckBox.Visibility = isTrialLicense && securityEnabled ? Visible : Collapsed;
+					this.SkipPasswordGenerationCheckBox.IsEnabled = securityEnabled && canGenerateUsers;
+					
+				});
+		}
+
+		protected override void UpdateValidState(bool isValid, IList<ValidationFailure> failures)
+		{
+			var b = isValid ? this._defaultBrush : new SolidColorBrush(Color.FromRgb(233, 73, 152));
+			this.ElasticPasswordBox.BorderBrush = _defaultBrush;
+			this.KibanaUserPasswordBox.BorderBrush = _defaultBrush;
+			this.LogstashSystemPasswordBox.BorderBrush = _defaultBrush;
+			if (isValid) return;
+			foreach (var e in this.ViewModel.ValidationFailures)
+			{
+				switch (e.PropertyName)
+				{
+					case nameof(ViewModel.ElasticUserPassword):
+						this.ElasticPasswordBox.BorderBrush = b;
+						continue;
+					case nameof(ViewModel.KibanaUserPassword):
+						this.KibanaUserPasswordBox.BorderBrush = b;
+						continue;
+					case nameof(ViewModel.LogstashSystemUserPassword):
+						this.LogstashSystemPasswordBox.BorderBrush = b;
+						continue;
+				}
+			}
+		}
+
+
+		protected class LicenseToSelectedIndexConverter : IBindingTypeConverter
+		{
+			private static readonly List<XPackLicenseMode> XPackLicenseModes =
+				Enum.GetValues(typeof(XPackLicenseMode)).Cast<XPackLicenseMode>().ToList();
+
+			public int GetAffinityForObjects(Type fromType, Type toType) => 1;
+
+			public bool TryConvert(object @from, Type toType, object conversionHint, out object result)
+			{
+				result = -1;
+				if (!(@from is XPackLicenseMode)) return true;
+				var e = (XPackLicenseMode) @from;
+				var i = XPackLicenseModes.TakeWhile(v => v != e).Count();
+				result = i;
+				return true;
+			}
+		}
+
+		protected class SelectedIndexToLicenseConverter : IBindingTypeConverter
+		{
+			private static readonly List<XPackLicenseMode> XPackLicenseModes =
+				Enum.GetValues(typeof(XPackLicenseMode)).Cast<XPackLicenseMode>().ToList();
+
+			public int GetAffinityForObjects(Type fromType, Type toType) => 1;
+
+			public bool TryConvert(object @from, Type toType, object conversionHint, out object result)
+			{
+				result = null;
+				if (!(@from is int)) return true;
+				var i = (int) @from;
+				if (i >= 0 && i < XPackLicenseModes.Count)
+					result = XPackLicenseModes[i];
+				;
+				return true;
+			}
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
@@ -70,13 +70,13 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 					
 					if (!isTrialLicense || !securityEnabled)
 						this.UserGrid.Visibility = Collapsed;
-					else if (!this.ViewModel.NeedsPassword)
+					else if (!this.ViewModel.NeedsPasswords)
 						this.UserGrid.Visibility = Collapsed;
 					else this.UserGrid.Visibility = Visible;
 					
 					this.ManualSetupGrid.Visibility =
 						!isTrialLicense || !securityEnabled
-							? Collapsed : (!this.ViewModel.NeedsPassword ? Visible : Collapsed);
+							? Collapsed : (!this.ViewModel.NeedsPasswords ? Visible : Collapsed);
 
 					this.UserLabel.Visibility = isTrialLicense && securityEnabled ? Visible : Collapsed;
 					this.SkipPasswordGenerationCheckBox.Visibility = isTrialLicense && securityEnabled ? Visible : Collapsed;

--- a/src/Installer/Elastic.Installer.UI/Kibana/MainWindow.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Kibana/MainWindow.xaml.cs
@@ -73,7 +73,7 @@ namespace Elastic.Installer.UI.Kibana
 
 			this.Bind(ViewModel, vm => vm.NextButtonText, view => view.NextButton.Content);
 
-			this.WhenAny(view => view.ViewModel.CurrentStepValidationFailures, v => v.GetValue().Count)
+			this.WhenAny(view => view.ViewModel.FirstInvalidStepValidationFailures, v => v.GetValue().Count)
 				.Subscribe(errorCount =>
 				{
 					if (errorCount == 0) this.ValidationErrorLink.Text = null;
@@ -250,7 +250,7 @@ namespace Elastic.Installer.UI.Kibana
 
 			this.ViewModel.ShowCurrentStepErrors.Subscribe(async x =>
 			{
-				var message = string.Join("\r\n", this.ViewModel.CurrentStepValidationFailures.Select(v => v.ErrorMessage.ValidationMessage()));
+				var message = string.Join("\r\n", this.ViewModel.FirstInvalidStepValidationFailures.Select(v => v.ErrorMessage.ValidationMessage()));
 				await this.ShowMessageAsync(
 					ViewResources.MainWindow_ValidationErrors,
 					message,

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -97,7 +97,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Elasticsearch in the browser (User name: elastic, Password: changeme).
+        ///   Looks up a localized string similar to Open Elasticsearch in the browser.
         /// </summary>
         public static string ClosingView_ElasticsearchRunningAtHeaderWithCredentials {
             get {
@@ -169,7 +169,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Kibana in the browser (User name: elastic, Password: changeme).
+        ///   Looks up a localized string similar to Open Kibana in the browser.
         /// </summary>
         public static string ClosingView_KibanaRunningAtHeaderWithCredentials {
             get {
@@ -433,7 +433,7 @@ namespace Elastic.Installer.UI.Properties {
         ///   Looks up a localized string similar to This step allows you to specify some settings found in the [b]elasticsearch.yml[/b] and [b]jvm.options[/b] files located in the [b]config[/b] folder.  We&apos;re only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
         ///
         ///
-        ///[b]Cluster name[/b]: The name of the cluster this Elasticsearch node should be a part of.  The cluster name is used to discover and auto-join other nodes.  It is important no [rest of string was truncated]&quot;;.
+        ///[b]Cluster name[/b]: The name of the cluster this Elasticsearch node should be a part of.  The cluster name is used to discover and auto-join other nodes.  It is important [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Elasticsearch_Help {
             get {
@@ -485,7 +485,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Server name[/b]: A human-readable display name that identifies this Kibana instance.
         ///
-        ///[b]Base Path[/b]: Enables you to specify a path to  [rest of string was truncated]&quot;;.
+        ///[b]Base Path[/b]: Enables you to specify a p [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Kibana_Help {
             get {
@@ -762,7 +762,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Index Name[/b]: Kibana uses an index in Elasticsearch to store saved searches, visualizations and dashboards. Kibana creates a new index if the index doesn’t already exist.
         ///
-        ///[b]Username[/b] and [b]Password[/b]: If your Elasticsearch is protected with basic authentication, these settings provide the username and password that the Kiba [rest of string was truncated]&quot;;.
+        ///[b]Username[/b] and [b]Password[/b]: If your Elasticsearch is protected with basic authentication, these settings provide the username and password that t [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConnectingView_Kibana_Help {
             get {
@@ -1042,7 +1042,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Config[/b]: The directory where Elasticsearch will store its configuration files.
         ///
-        ///It is best practice to keep your logs, config, and data directories separate from your home  [rest of string was truncated]&quot;;.
+        ///It is best practice to keep your logs, config, and data directories separate from  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string LocationsView_Elasticsearch_Help {
             get {
@@ -1765,7 +1765,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only access to the basic (free) license for 30 days. 
+        ///   Looks up a localized string similar to Only access to the Basic (free) license for 30 days. 
         ///    .
         /// </summary>
         public static string XPackView_BasicDescription {
@@ -1793,7 +1793,15 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO.
+        ///   Looks up a localized string similar to This step allows you to specify how X-Pack is configured.
+        ///
+        ///[b]License[/b]: This setting specifies the type of license to apply to X-Pack. 
+        ///
+        ///    A [b]Basic license[/b] is free and provides access only to a subset of X-Pack features. 
+        ///
+        ///    A [b]Trial license[/b] provides access to all of the X-Pack Enterprise features, including Machine Learning, Graph, Alerting, Security, amongst others.
+        ///
+        ///    Both Basic and Trial licenses applied are valid for 30 days. You can register to receive a free 1 year Basic  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string XPackView_Elasticsearch_Help {
             get {
@@ -1856,6 +1864,15 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to https://www.elastic.co/guide/en/x-pack/{0}/setting-up-authentication.html#set-built-in-user-passwords.
+        /// </summary>
+        public static string XPackView_ManualUserConfiguration {
+            get {
+                return ResourceManager.GetString("XPackView_ManualUserConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to How to setup users manually.
         /// </summary>
         public static string XPackView_ManualUserConfigurationLink {
@@ -1865,7 +1882,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Elasticsearch system users need to be setup manually. Either we are not installing as a service that gets started after installation or you&apos;ve manually opted out..
+        ///   Looks up a localized string similar to Elasticsearch system users need to be setup manually. Either you are not installing as a service that gets started after installation, or you&apos;ve opted to start Elasticsearch manually when needed..
         /// </summary>
         public static string XPackView_ManualUserConfigurationNeeded {
             get {
@@ -1874,11 +1891,38 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Defer setting up users till later.
+        ///   Looks up a localized string similar to https://www.elastic.co/subscriptions.
+        /// </summary>
+        public static string XPackView_OpenLicensesAndSubscriptions {
+            get {
+                return ResourceManager.GetString("XPackView_OpenLicensesAndSubscriptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Defer setting up users until later.
         /// </summary>
         public static string XPackView_OverrideGeneratePasswordsLabel {
             get {
                 return ResourceManager.GetString("XPackView_OverrideGeneratePasswordsLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://register.elastic.co/.
+        /// </summary>
+        public static string XPackView_RegisterBasicLicense {
+            get {
+                return ResourceManager.GetString("XPackView_RegisterBasicLicense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Register for a free Basic license .
+        /// </summary>
+        public static string XPackView_RegisterBasicLicenseLink {
+            get {
+                return ResourceManager.GetString("XPackView_RegisterBasicLicenseLink", resourceCulture);
             }
         }
         
@@ -1901,7 +1945,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access to all X-Pack enterprise features for 30 days, including machine learning, graph, watcher and others.
+        ///   Looks up a localized string similar to Access to all X-Pack Enterprise features for 30 days, including Machine Learning, Graph, Alerting, Security, and others.
         ///    .
         /// </summary>
         public static string XPackView_TrialDescription {

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -433,7 +433,7 @@ namespace Elastic.Installer.UI.Properties {
         ///   Looks up a localized string similar to This step allows you to specify some settings found in the [b]elasticsearch.yml[/b] and [b]jvm.options[/b] files located in the [b]config[/b] folder.  We&apos;re only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
         ///
         ///
-        ///[b]Cluster name[/b]: The name of the cluster this Elasticsearch node should be a part of.  The cluster name is used to discover and auto-join other nodes.  It is important [rest of string was truncated]&quot;;.
+        ///[b]Cluster name[/b]: The name of the cluster this Elasticsearch node should be a part of.  The cluster name is used to discover and auto-join other nodes.  It is important no [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Elasticsearch_Help {
             get {
@@ -485,7 +485,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Server name[/b]: A human-readable display name that identifies this Kibana instance.
         ///
-        ///[b]Base Path[/b]: Enables you to specify a pa [rest of string was truncated]&quot;;.
+        ///[b]Base Path[/b]: Enables you to specify a path to  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Kibana_Help {
             get {
@@ -762,7 +762,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Index Name[/b]: Kibana uses an index in Elasticsearch to store saved searches, visualizations and dashboards. Kibana creates a new index if the index doesn’t already exist.
         ///
-        ///[b]Username[/b] and [b]Password[/b]: If your Elasticsearch is protected with basic authentication, these settings provide the username and password that t [rest of string was truncated]&quot;;.
+        ///[b]Username[/b] and [b]Password[/b]: If your Elasticsearch is protected with basic authentication, these settings provide the username and password that the Kiba [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConnectingView_Kibana_Help {
             get {
@@ -1042,7 +1042,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Config[/b]: The directory where Elasticsearch will store its configuration files.
         ///
-        ///It is a best practice to keep your logs, config, and data directories separa [rest of string was truncated]&quot;;.
+        ///It is best practice to keep your logs, config, and data directories separate from your home  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string LocationsView_Elasticsearch_Help {
             get {
@@ -1263,6 +1263,15 @@ namespace Elastic.Installer.UI.Properties {
         public static string MainWindow_TabItemWelcome {
             get {
                 return ResourceManager.GetString("MainWindow_TabItemWelcome", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to X-Pack.
+        /// </summary>
+        public static string MainWindow_TabItemXPack {
+            get {
+                return ResourceManager.GetString("MainWindow_TabItemXPack", resourceCulture);
             }
         }
         
@@ -1752,6 +1761,170 @@ namespace Elastic.Installer.UI.Properties {
         public static string SilentSetup_UninstallVariables {
             get {
                 return ResourceManager.GetString("SilentSetup_UninstallVariables", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only access to the basic (free) license for 30 days. 
+        ///    .
+        /// </summary>
+        public static string XPackView_BasicDescription {
+            get {
+                return ResourceManager.GetString("XPackView_BasicDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Basic License.
+        /// </summary>
+        public static string XPackView_BasicLicense {
+            get {
+                return ResourceManager.GetString("XPackView_BasicLicense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Which license is for me?.
+        /// </summary>
+        public static string XPackView_ChooseYourLicense {
+            get {
+                return ResourceManager.GetString("XPackView_ChooseYourLicense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO.
+        /// </summary>
+        public static string XPackView_Elasticsearch_Help {
+            get {
+                return ResourceManager.GetString("XPackView_Elasticsearch_Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to X-Pack Help.
+        /// </summary>
+        public static string XPackView_Elasticsearch_Help_Header {
+            get {
+                return ResourceManager.GetString("XPackView_Elasticsearch_Help_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to elastic.
+        /// </summary>
+        public static string XPackView_ElasticUserLabel {
+            get {
+                return ResourceManager.GetString("XPackView_ElasticUserLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable X-Pack Security.
+        /// </summary>
+        public static string XPackView_EnableXPackSecurity {
+            get {
+                return ResourceManager.GetString("XPackView_EnableXPackSecurity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to kibana.
+        /// </summary>
+        public static string XPackView_KibanaUserLabel {
+            get {
+                return ResourceManager.GetString("XPackView_KibanaUserLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to License.
+        /// </summary>
+        public static string XPackView_LicenseLabel {
+            get {
+                return ResourceManager.GetString("XPackView_LicenseLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to logstash system.
+        /// </summary>
+        public static string XPackView_LogstashSystemUserLabel {
+            get {
+                return ResourceManager.GetString("XPackView_LogstashSystemUserLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How to setup users manually.
+        /// </summary>
+        public static string XPackView_ManualUserConfigurationLink {
+            get {
+                return ResourceManager.GetString("XPackView_ManualUserConfigurationLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Elasticsearch system users need to be setup manually. Either we are not installing as a service that gets started after installation or you&apos;ve manually opted out..
+        /// </summary>
+        public static string XPackView_ManualUserConfigurationNeeded {
+            get {
+                return ResourceManager.GetString("XPackView_ManualUserConfigurationNeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Defer setting up users till later.
+        /// </summary>
+        public static string XPackView_OverrideGeneratePasswordsLabel {
+            get {
+                return ResourceManager.GetString("XPackView_OverrideGeneratePasswordsLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Security.
+        /// </summary>
+        public static string XPackView_SecurityLabel {
+            get {
+                return ResourceManager.GetString("XPackView_SecurityLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Full overview of licences and subscriptions.
+        /// </summary>
+        public static string XPackView_SubscriptionsLink {
+            get {
+                return ResourceManager.GetString("XPackView_SubscriptionsLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Access to all X-Pack enterprise features for 30 days, including machine learning, graph, watcher and others.
+        ///    .
+        /// </summary>
+        public static string XPackView_TrialDescription {
+            get {
+                return ResourceManager.GetString("XPackView_TrialDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trial License.
+        /// </summary>
+        public static string XPackView_TrialLicense {
+            get {
+                return ResourceManager.GetString("XPackView_TrialLicense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Users.
+        /// </summary>
+        public static string XPackView_UsersLabel {
+            get {
+                return ResourceManager.GetString("XPackView_UsersLabel", resourceCulture);
             }
         }
     }

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -271,6 +271,61 @@
     <value>Installing Elasticsearch {0}</value>
     <comment>{0} = Elasticsearch Version</comment>
   </data>
+  
+  
+  
+  <data name="XPackView_LicenseLabel" xml:space="preserve">
+    <value>License</value>
+  </data>
+  
+  <data name="XPackView_UsersLabel" xml:space="preserve">
+    <value>Users</value>
+  </data>
+  <data name="XPackView_ElasticUserLabel" xml:space="preserve">
+    <value>elastic</value>
+  </data>
+  <data name="XPackView_KibanaUserLabel" xml:space="preserve">
+    <value>kibana</value>
+  </data>
+  <data name="XPackView_LogstashSystemUserLabel" xml:space="preserve">
+    <value>logstash system</value>
+  </data>
+  <data name="XPackView_OverrideGeneratePasswordsLabel" xml:space="preserve">
+    <value>Defer setting up users till later</value>
+  </data>
+  <data name="XPackView_EnableXPackSecurity" xml:space="preserve">
+    <value>Enable X-Pack Security</value>
+  </data>
+  <data name="XPackView_SecurityLabel" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="XPackView_ChooseYourLicense" xml:space="preserve">
+    <value>Which license is for me?</value>
+  </data>
+  <data name="XPackView_TrialLicense" xml:space="preserve">
+    <value>Trial License</value>
+  </data>
+  <data name="XPackView_BasicLicense" xml:space="preserve">
+    <value>Basic License</value>
+  </data>
+  <data name="XPackView_TrialDescription" xml:space="preserve">
+    <value>Access to all X-Pack enterprise features for 30 days, including machine learning, graph, watcher and others.
+    </value>
+  </data>
+  <data name="XPackView_BasicDescription" xml:space="preserve">
+    <value>Only access to the basic (free) license for 30 days. 
+    </value>
+  </data>
+  <data name="XPackView_SubscriptionsLink" xml:space="preserve">
+    <value>Full overview of licences and subscriptions</value>
+  </data>
+  <data name="XPackView_ManualUserConfigurationNeeded" xml:space="preserve">
+    <value>Elasticsearch system users need to be setup manually. Either we are not installing as a service that gets started after installation or you've manually opted out.</value>
+  </data>
+  <data name="XPackView_ManualUserConfigurationLink" xml:space="preserve">
+    <value>How to setup users manually</value>
+  </data>
+
   <data name="MainWindow_InstallingTitle" xml:space="preserve">
     <value>Installing...</value>
   </data>
@@ -282,6 +337,9 @@
   </data>
   <data name="MainWindow_TabItemPlugins" xml:space="preserve">
     <value>Plugins</value>
+  </data>
+  <data name="MainWindow_TabItemXPack" xml:space="preserve">
+    <value>X-Pack</value>
   </data>
   <data name="MainWindow_TabItemService" xml:space="preserve">
     <value>Service</value>
@@ -452,6 +510,12 @@ We've only listed the official Elasticsearch plugins here, but there are many mo
 
 It is common for many companies to set up a proxy through which resources will be downloaded from the internet. As such, you may need to specify the host name and port of a corporate proxy to allow the installer to successfully install plugins. Since official Elasticsearch plugins are installed from 
 https://artifacts.elastic.co, a HTTPS proxy can be specified.</value>
+  </data>
+  <data name="XPackView_Elasticsearch_Help_Header" xml:space="preserve">
+    <value>X-Pack Help</value>
+  </data>
+  <data name="XPackView_Elasticsearch_Help" xml:space="preserve">
+    <value>TODO</value>
   </data>
   <data name="ServiceView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Service Help</value>

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -190,7 +190,7 @@
     <value>What's Next?</value>
   </data>
   <data name="ClosingView_ElasticsearchRunningAtHeaderWithCredentials" xml:space="preserve">
-    <value>Open Elasticsearch in the browser (User name: elastic, Password: changeme)</value>
+    <value>Open Elasticsearch in the browser</value>
   </data>
   <data name="ClosingView_FindYourClient" xml:space="preserve">
     <value>Find a client for your favorite language</value>
@@ -271,13 +271,9 @@
     <value>Installing Elasticsearch {0}</value>
     <comment>{0} = Elasticsearch Version</comment>
   </data>
-  
-  
-  
   <data name="XPackView_LicenseLabel" xml:space="preserve">
     <value>License</value>
   </data>
-  
   <data name="XPackView_UsersLabel" xml:space="preserve">
     <value>Users</value>
   </data>
@@ -291,7 +287,7 @@
     <value>logstash system</value>
   </data>
   <data name="XPackView_OverrideGeneratePasswordsLabel" xml:space="preserve">
-    <value>Defer setting up users till later</value>
+    <value>Defer setting up users until later</value>
   </data>
   <data name="XPackView_EnableXPackSecurity" xml:space="preserve">
     <value>Enable X-Pack Security</value>
@@ -309,23 +305,22 @@
     <value>Basic License</value>
   </data>
   <data name="XPackView_TrialDescription" xml:space="preserve">
-    <value>Access to all X-Pack enterprise features for 30 days, including machine learning, graph, watcher and others.
+    <value>Access to all X-Pack Enterprise features for 30 days, including Machine Learning, Graph, Alerting, Security, and others.
     </value>
   </data>
   <data name="XPackView_BasicDescription" xml:space="preserve">
-    <value>Only access to the basic (free) license for 30 days. 
+    <value>Only access to the Basic (free) license for 30 days. 
     </value>
   </data>
   <data name="XPackView_SubscriptionsLink" xml:space="preserve">
     <value>Full overview of licences and subscriptions</value>
   </data>
   <data name="XPackView_ManualUserConfigurationNeeded" xml:space="preserve">
-    <value>Elasticsearch system users need to be setup manually. Either we are not installing as a service that gets started after installation or you've manually opted out.</value>
+    <value>Elasticsearch system users need to be setup manually. Either you are not installing as a service that gets started after installation, or you've opted to start Elasticsearch manually when needed.</value>
   </data>
   <data name="XPackView_ManualUserConfigurationLink" xml:space="preserve">
     <value>How to setup users manually</value>
   </data>
-
   <data name="MainWindow_InstallingTitle" xml:space="preserve">
     <value>Installing...</value>
   </data>
@@ -515,7 +510,25 @@ https://artifacts.elastic.co, a HTTPS proxy can be specified.</value>
     <value>X-Pack Help</value>
   </data>
   <data name="XPackView_Elasticsearch_Help" xml:space="preserve">
-    <value>TODO</value>
+    <value>This step allows you to specify how X-Pack is configured.
+
+[b]License[/b]: This setting specifies the type of license to apply to X-Pack. 
+
+    A [b]Basic license[/b] is free and provides access only to a subset of X-Pack features. 
+
+    A [b]Trial license[/b] provides access to all of the X-Pack Enterprise features, including Machine Learning, Graph, Alerting, Security, amongst others.
+
+    Both Basic and Trial licenses applied are valid for 30 days. You can register to receive a free 1 year Basic license at https://register.elastic.co/ and get in touch if you'd like to request information on other license types at https://www.elastic.co/subscriptions.
+
+[b]Enable X-Pack Security[/b]: Whether X-Pack Security should be enabled on the node. Enabling X-Pack Security will require authentication credentials to communicate with the cluster.
+
+[b]Defer setting up users until later[/b]: Whether the built-in user roles should be set up as part of installation. Setting these users up requires a running cluster as the credentials are stored within an index in the cluster.
+
+[b]elastic[/b]: The password for the built-in 'elastic' user account.
+
+[b]kibana[/b]: The password for the built-in 'kibana' user account.
+
+[b]logstash system[/b]: The password for the built-in 'logstash_system' user account.</value>
   </data>
   <data name="ServiceView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Service Help</value>
@@ -822,7 +835,20 @@ Alternatively, you may choose to not install Kibana as a service and run it manu
     <value>https://www.elastic.co/guide/index.html</value>
   </data>
   <data name="ClosingView_KibanaRunningAtHeaderWithCredentials" xml:space="preserve">
-    <value>Open Kibana in the browser (User name: elastic, Password: changeme)</value>
+    <value>Open Kibana in the browser</value>
+  </data>
+  <data name="XPackView_ManualUserConfiguration" xml:space="preserve">
+    <value>https://www.elastic.co/guide/en/x-pack/{0}/setting-up-authentication.html#set-built-in-user-passwords</value>
+    <comment>{0} = major minor version</comment>
+  </data>
+  <data name="XPackView_OpenLicensesAndSubscriptions" xml:space="preserve">
+    <value>https://www.elastic.co/subscriptions</value>
+  </data>
+  <data name="XPackView_RegisterBasicLicense" xml:space="preserve">
+    <value>https://register.elastic.co/</value>
+  </data>
+  <data name="XPackView_RegisterBasicLicenseLink" xml:space="preserve">
+    <value>Register for a free Basic license </value>
   </data>
   <data name="PluginsView_SetHttpsProxy_Message" xml:space="preserve">
     <value>Configure a HTTPS proxy through which to download plugins as part of installation. A proxy can be specified in the form of host or host:port. If no port is specified, defaults to using port 443.</value>

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elastic.InstallerHosts.csproj
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elastic.InstallerHosts.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Elasticsearch\Tasks\Install\InstallServiceTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\PreserveInstallTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\SetEnvironmentVariablesTask.cs" />
+    <Compile Include="Elasticsearch\Tasks\Install\SetupXPackPasswordsTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\StartServiceTask.cs" />
     <Compile Include="Elasticsearch\Tasks\RemoveEnvironmentVariablesTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Rollback\RollbackServiceTask.cs" />

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elastic.InstallerHosts.csproj
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elastic.InstallerHosts.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
@@ -50,6 +51,8 @@
     <Compile Include="Elasticsearch\Tasks\Install\InstallPluginsTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\InstallServiceTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\PreserveInstallTask.cs" />
+    <Compile Include="Elasticsearch\Tasks\Install\SetBootstrapPasswordPropertyTask.cs" />
+    <Compile Include="Elasticsearch\Tasks\Install\SetBootstrapPasswordTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\SetEnvironmentVariablesTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\SetupXPackPasswordsTask.cs" />
     <Compile Include="Elasticsearch\Tasks\Install\StartServiceTask.cs" />

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/EditElasticsearchYamlTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/EditElasticsearchYamlTask.cs
@@ -52,9 +52,7 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 			}
 			else
 			{
-				settings.XPackLicenseSelfGeneratedType = xPack.XPackLicense.HasValue
-					? Enum.GetName(typeof(XPackLicenseMode), xPack.XPackLicense.Value)?.ToLowerInvariant()
-					: null;
+				settings.XPackLicenseSelfGeneratedType = Enum.GetName(typeof(XPackLicenseMode), xPack.XPackLicense)?.ToLowerInvariant();
 				settings.XPackSecurityEnabled = !xPack.XPackSecurityEnabled ? false : (bool?) null;
 			}
 		}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/EditElasticsearchYamlTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/EditElasticsearchYamlTask.cs
@@ -1,38 +1,87 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
 using Elastic.Configuration.FileBased.Yaml;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Domain.Model.Elasticsearch.Config;
+using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 
 namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 {
 	public class EditElasticsearchYamlTask : ElasticsearchInstallationTaskBase
 	{
 		public EditElasticsearchYamlTask(string[] args, ISession session) : base(args, session) { }
-		public EditElasticsearchYamlTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
+
+		public EditElasticsearchYamlTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem)
 			: base(model, session, fileSystem) { }
 
-		private const int TotalTicks = 3000;
+		private const int TotalTicks = 6000;
 
 		protected override bool ExecuteTask()
 		{
 			this.Session.SendActionStart(TotalTicks, ActionName, "Configuring Elasticsearch", "Configuring Elasticsearch: [1]");
 			var locations = this.InstallationModel.LocationsModel;
-			var config = this.InstallationModel.ConfigurationModel;
 			this.Session.SendProgress(1000, "reading elasticsearch.yml from " + locations.ConfigDirectory);
 			var yaml = ElasticsearchYamlConfiguration.FromFolder(locations.ConfigDirectory, this.FileSystem);
-			this.Session.SendProgress(1000, "updating elasticsearch.yml");
+
 			var settings = yaml.Settings;
+			this.ApplyConfigurationModel(settings);
+			this.ApplyLocationsModel(settings, locations);
+			this.ApplyServiceModel(settings);
+			this.ApplyXPackModel(settings);
+			yaml.Save();
+			this.Session.SendProgress(1000, "elasticsearch.yml updated");
+			return true;
+		}
+
+		private void ApplyXPackModel(ElasticsearchYamlSettings settings)
+		{
+			this.Session.SendProgress(1000, "updating elasticsearch.yml with values from x-pack model if needed");
+			var xPack = this.InstallationModel.XPackModel;
+			if (!xPack.IsRelevant)
+			{
+				//make sure we unset all xpack related settings because they might prevent a node from starting
+				settings.XPackLicenseSelfGeneratedType = null;
+				settings.XPackSecurityEnabled = null;
+				var xPackKeys = settings.Keys.Where(k => k.StartsWith("xpack.")).ToList();
+				foreach (var key in xPackKeys)
+					settings.Remove(key);
+			}
+			else
+			{
+				settings.XPackLicenseSelfGeneratedType = xPack.XPackLicense.HasValue
+					? Enum.GetName(typeof(XPackLicenseMode), xPack.XPackLicense.Value)?.ToLowerInvariant()
+					: null;
+				settings.XPackSecurityEnabled = !xPack.XPackSecurityEnabled ? false : (bool?) null;
+			}
+		}
+
+		private void ApplyServiceModel(ElasticsearchYamlSettings settings)
+		{
+			this.Session.SendProgress(1000, "updating elasticsearch.yml with values from locations model");
+			settings.MaxLocalStorageNodes = this.InstallationModel.ServiceModel.InstallAsService ? (int?) 1 : null;
+		}
+
+		private void ApplyLocationsModel(ElasticsearchYamlSettings settings, LocationsModel locations)
+		{
+			this.Session.SendProgress(1000, "updating elasticsearch.yml with values from locations model");
+			settings.LogsPath = locations.LogsDirectory;
+			settings.DataPath = locations.DataDirectory;
+		}
+
+		private void ApplyConfigurationModel(ElasticsearchYamlSettings settings)
+		{
+			this.Session.SendProgress(1000, "updating elasticsearch.yml with values from configuration model");
+			var config = this.InstallationModel.ConfigurationModel;
 			settings.ClusterName = config.ClusterName;
 			settings.NodeName = config.NodeName;
 			settings.MasterNode = config.MasterNode;
 			settings.DataNode = config.DataNode;
 			settings.IngestNode = config.IngestNode;
 			settings.MemoryLock = config.LockMemory;
-			settings.LogsPath = locations.LogsDirectory;
-			settings.DataPath = locations.DataDirectory;
-			settings.MaxLocalStorageNodes = this.InstallationModel.ServiceModel.InstallAsService ? (int?)1 : null;
 			settings.NetworkHost = !string.IsNullOrEmpty(config.NetworkHost) ? config.NetworkHost : null;
 			if (config.HttpPort.HasValue)
 				settings.HttpPortString = config.HttpPort.Value.ToString(CultureInfo.InvariantCulture);
@@ -40,9 +89,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 				settings.TransportTcpPortString = config.TransportPort.Value.ToString(CultureInfo.InvariantCulture);
 			var hosts = config.UnicastNodes;
 			settings.UnicastHosts = hosts.Any() ? hosts.ToList() : null;
-			yaml.Save();
-			this.Session.SendProgress(1000, "elasticsearch.yml updated");
-			return true;
 		}
 	}
 }

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordPropertyTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordPropertyTask.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO.Abstractions;
+using System.Security.Cryptography;
+using System.Text;
+using Elastic.Installer.Domain.Configuration.Wix.Session;
+using Elastic.Installer.Domain.Model.Elasticsearch;
+
+namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
+{
+	public class SetBootstrapPasswordPropertyTask : ElasticsearchInstallationTaskBase
+	{
+		private static readonly char[] BootstrapChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*-_=+?".ToCharArray();
+
+		public SetBootstrapPasswordPropertyTask(string[] args, ISession session) 
+			: base(args, session) { }
+
+		public SetBootstrapPasswordPropertyTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
+			: base(model, session, fileSystem) { }
+
+		protected override bool ExecuteTask()
+		{
+			var length = 20;
+			var password = new StringBuilder();
+
+			int GetValidIndex(RandomNumberGenerator rng, int max)
+			{
+				var randomBytes = new byte[4];
+				int value;
+				do
+				{
+					rng.GetBytes(randomBytes);
+					value = BitConverter.ToInt32(randomBytes, 0) & int.MaxValue;
+				} while (value >= max * (int.MaxValue / max));
+
+				return value % max;
+			}
+
+			using (var rng = new RNGCryptoServiceProvider())
+			{
+				for (var i = 0; i < 20; i++)
+					password.Append(BootstrapChars[GetValidIndex(rng, BootstrapChars.Length)]);
+			}
+		
+			Session.Set("BOOTSTRAPPASSWORD", password.ToString());
+			return true;
+		}
+	}
+}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordPropertyTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordPropertyTask.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 
 namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 {
@@ -21,6 +22,7 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 		{
 			var length = 20;
 			var password = new StringBuilder();
+			var property = nameof(XPackModel.BootstrapPassword).ToUpperInvariant();
 
 			int GetValidIndex(RandomNumberGenerator rng, int max)
 			{
@@ -30,18 +32,19 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 				{
 					rng.GetBytes(randomBytes);
 					value = BitConverter.ToInt32(randomBytes, 0) & int.MaxValue;
-				} while (value >= max * (int.MaxValue / max));
-
+				}
+				while (value >= max * (int.MaxValue / max));
 				return value % max;
 			}
 
 			using (var rng = new RNGCryptoServiceProvider())
 			{
-				for (var i = 0; i < 20; i++)
+				for (var i = 0; i < length; i++)
 					password.Append(BootstrapChars[GetValidIndex(rng, BootstrapChars.Length)]);
 			}
 		
-			Session.Set("BOOTSTRAPPASSWORD", password.ToString());
+			Session.Log($"Setting {property} to a randomly generated {length} character string");
+			Session.Set(property, password.ToString());
 			return true;
 		}
 	}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordTask.cs
@@ -1,0 +1,69 @@
+﻿using System.Diagnostics;
+using System.IO.Abstractions;
+using Elastic.Configuration.EnvironmentBased;
+using Elastic.Installer.Domain.Configuration.Wix.Session;
+using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+
+namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
+{
+	public class SetBootstrapPasswordTask : ElasticsearchInstallationTaskBase
+	{
+		public SetBootstrapPasswordTask(string[] args, ISession session) 
+			: base(args, session) {}
+
+		public SetBootstrapPasswordTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
+			: base(model, session, fileSystem) {}
+
+		protected override bool ExecuteTask()
+		{
+			var xPackModel = this.InstallationModel.XPackModel;
+			if (!xPackModel.IsRelevant || !xPackModel.XPackSecurityEnabled || xPackModel.XPackLicense != XPackLicenseMode.Trial) return true;
+
+			var installationDir = this.InstallationModel.LocationsModel.InstallDir;
+			var password = this.InstallationModel.XPackModel.BootstrapPassword;
+			var binary = this.FileSystem.Path.Combine(installationDir, "bin", "elasticsearch-keystore.bat");
+
+			var p = new Process
+			{
+				EnableRaisingEvents = true,
+				StartInfo =
+				{
+					FileName = binary,
+					Arguments = "add -x -f",
+					CreateNoWindow = true,
+					UseShellExecute = false,
+					RedirectStandardOutput = true,
+					RedirectStandardError = true,
+					RedirectStandardInput = true,
+					EnvironmentVariables =
+					{
+						{ ElasticsearchEnvironmentStateProvider.ConfDir, this.InstallationModel.LocationsModel.ConfigDirectory }
+					}
+				}
+			};
+
+			void OnDataReceived(object sender, DataReceivedEventArgs a)
+			{
+				var message = a.Data;
+				if (message != null)
+					this.Session.Log(message);
+			}
+
+			p.ErrorDataReceived += OnDataReceived;
+			p.OutputDataReceived += OnDataReceived;
+			p.Start();
+
+			p.BeginOutputReadLine();
+			p.BeginErrorReadLine();
+			p.StandardInput.WriteLine(password);
+			p.WaitForExit();
+
+			p.ErrorDataReceived -= OnDataReceived;
+			p.OutputDataReceived -= OnDataReceived;
+			p.Close();
+
+			return true;
+		}
+	}
+}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetupXPackPasswordsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetupXPackPasswordsTask.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using Elastic.Installer.Domain.Configuration.Wix.Session;
+using Elastic.Installer.Domain.Model.Elasticsearch;
+
+namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
+{
+	public class SetupXPackPasswordsTask : ElasticsearchInstallationTaskBase
+	{
+		public SetupXPackPasswordsTask(string[] args, ISession session) 
+			: base(args, session) { }
+		public SetupXPackPasswordsTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
+			: base(model, session, fileSystem) { }
+
+		protected override bool ExecuteTask()
+		{
+			var installationFolder = this.InstallationModel.LocationsModel.InstallDir;
+			installationFolder = @"c:\Data\elasticsearch-6.0.0-beta2";
+			var binary = this.FileSystem.Path.Combine(installationFolder, "bin", "x-pack", "setup-passwords") + ".bat";
+			//if (!this.FileSystem.File.Exists(binary)) return false;
+
+			var xPackModel = this.InstallationModel.XPackModel;
+			if (!xPackModel.IsRelevant || !xPackModel.NeedsPasswords) return true;
+			var p = new Process
+			{
+				EnableRaisingEvents = true,
+				StartInfo =
+				{
+					FileName = binary,
+					Arguments = "interactive",
+					CreateNoWindow = true,
+					UseShellExecute = false,
+					RedirectStandardOutput = true,
+					RedirectStandardError = true,
+					RedirectStandardInput = true,
+				}
+			};
+			
+			ApproachOne(p);
+			//ApproacheTwo(p);
+
+			p.WaitForExit();
+
+			var exitCode = p.ExitCode;
+			p.Close();
+			return true;
+		}
+
+		private void ApproacheTwo(Process p)
+		{
+			//p.StandardInput.BaseStream
+			p.Start();
+			
+			var bufferSize = 1024;
+			var read = 0;
+			do
+			{
+				var buffer = new byte[bufferSize];
+				for (read = 0; read < bufferSize; read++)
+				{
+					var eof = p.StandardOutput.EndOfStream;
+					var exited = p.HasExited;
+					
+					var readByte = p.StandardOutput.BaseStream.ReadByte();
+					if (readByte == -1)
+						break;
+					var c = (byte) readByte;
+					if (c == '\n' || c == ']' || c == ':')
+					{
+						break;
+					}
+					
+					buffer[read] = c;
+				}
+				var s = Encoding.UTF8.GetString(buffer, 0, read);
+			} while (read > 0);
+		}
+
+		private void ApproachOne(Process p)
+		{
+			var errors = false;
+			var steps = 0;
+			
+			p.ErrorDataReceived += (s, a) => errors = true;
+			p.OutputDataReceived += (sender, a) =>
+			{
+				var message = a.Data;
+				if (message == null) return;
+				if (message.StartsWith("Exception")) errors = true;
+				if (message.Trim().EndsWith("[y/N]"))
+				{
+					p.StandardInput.WriteLine("y");
+				}
+				if (string.IsNullOrEmpty(message.Trim()) && steps == 3)
+				{
+					p.StandardInput.WriteLine(this.InstallationModel.XPackModel.ElasticUserPassword);
+				}
+				steps++;
+			};
+			p.Start();
+			p.BeginOutputReadLine();
+			p.BeginErrorReadLine();
+//			p.StandardInput.WriteLine(this.InstallationModel.XPackModel.ElasticUserPassword);
+//			p.StandardInput.WriteLine(this.InstallationModel.XPackModel.KibanaUserPassword);
+//			p.StandardInput.WriteLine(this.InstallationModel.XPackModel.KibanaUserPassword);
+//			p.StandardInput.WriteLine(this.InstallationModel.XPackModel.LogstashSystemUserPassword);
+//			p.StandardInput.WriteLine(this.InstallationModel.XPackModel.LogstashSystemUserPassword);
+		}
+	}
+}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetupXPackPasswordsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetupXPackPasswordsTask.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.IO.Abstractions;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Elasticsearch;
 
@@ -15,50 +18,91 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 		public SetupXPackPasswordsTask(ElasticsearchInstallationModel model, ISession session, IFileSystem fileSystem) 
 			: base(model, session, fileSystem) { }
 
+		private const int TotalTicks = 1200;
+
 		protected override bool ExecuteTask()
 		{
 			var xPackModel = this.InstallationModel.XPackModel;
 			if (!xPackModel.IsRelevant || !xPackModel.NeedsPasswords) return true;
 
+			this.Session.SendActionStart(TotalTicks, ActionName, "Setting up X-Pack passwords", "Setting up X-Pack passwords: [1]");
+
 			var password = this.InstallationModel.XPackModel.BootstrapPassword;
+			var host = !string.IsNullOrEmpty(this.InstallationModel.ConfigurationModel.NetworkHost)
+				? this.InstallationModel.ConfigurationModel.NetworkHost
+				: "localhost";
+			var port = this.InstallationModel.ConfigurationModel.HttpPort;
+			var baseAddess = $"http://{host}:{port}/";
 
-			using (var client = new HttpClient())
+			using (var client = new HttpClient { BaseAddress = new Uri(baseAddess) })
 			{
+				WaitForNodeToAcceptRequests(client, password);
 				var elasticUserPassword = this.InstallationModel.XPackModel.ElasticUserPassword;
-
-				if (!string.IsNullOrEmpty(elasticUserPassword))
-				{
-					SetPassword(client, password, "elastic", elasticUserPassword);
-					this.Session.Log("Changed password for user [elastic]");
-				}
-
-				// change the elastic user password to use for subsequent users after updating it for elastic user
-				password = !string.IsNullOrEmpty(elasticUserPassword)
-					? elasticUserPassword
-					: password;
-
-				if (!string.IsNullOrEmpty(this.InstallationModel.XPackModel.KibanaUserPassword))
-				{
-					SetPassword(client, password, "kibana",  this.InstallationModel.XPackModel.KibanaUserPassword);
-					this.Session.Log("Changed password for user [kibana]");
-				}
-
-				if (!string.IsNullOrEmpty(this.InstallationModel.XPackModel.LogstashSystemUserPassword))
-				{
-					SetPassword(client, password, "logstash_system", this.InstallationModel.XPackModel.LogstashSystemUserPassword);
-					this.Session.Log("Changed password for user [logstash_system]");
-				}
+				SetPassword(client, password, "elastic", elasticUserPassword);
+				// change the elastic user password used for subsequent users, after updating it for elastic user
+				password = elasticUserPassword;
+				SetPassword(client, password, "kibana", this.InstallationModel.XPackModel.KibanaUserPassword);
+				SetPassword(client, password, "logstash_system", this.InstallationModel.XPackModel.LogstashSystemUserPassword);
 			}
 			
 			return true;
 		}
 
+		private void WaitForNodeToAcceptRequests(HttpClient client, string elasticUserPassword)
+		{
+			var statusCode = 500;
+			var times = 0;
+			var totalTimes = 30;
+			var sleepyTime = 1000;
+			var totalTicks = 300;
+			var tickIncrement = totalTicks / totalTimes;
+
+			do
+			{
+				if (times > 0) Thread.Sleep(sleepyTime);
+				HttpResponseMessage response = null;
+				try
+				{
+					this.Session.SendProgress(tickIncrement, "Checking Elasticsearch is up and running");
+
+					using (var message = new HttpRequestMessage(HttpMethod.Head, string.Empty))
+					{
+						var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"elastic:{elasticUserPassword}"));
+						message.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+						response = client.SendAsync(message).Result;
+						statusCode = (int)response.StatusCode;
+					}
+				}
+				catch (AggregateException ae)
+				{
+					if (response != null)
+						statusCode = (int) response.StatusCode;
+
+					var httpRequestException = ae.InnerException as HttpRequestException;
+					if (httpRequestException == null) throw;
+
+					var webException = httpRequestException.InnerException as WebException;
+					if (webException == null) throw;
+
+					var socketException = webException.InnerException as SocketException;
+					if (socketException == null) throw;
+
+					if (socketException.SocketErrorCode != SocketError.ConnectionRefused) throw;
+				}
+
+				++times;
+			} while (statusCode >= 500 && times < totalTimes);
+
+			if (statusCode >= 500)
+				throw new TimeoutException($"Elasticsearch not seen running after trying for {TimeSpan.FromMilliseconds(totalTimes * sleepyTime)}");
+
+			this.Session.SendProgress(totalTicks - (tickIncrement * times), "Elasticsearch is up and running");
+		}
+
 		private void SetPassword(HttpClient client, string elasticUserPassword, string user, string password)
 		{
-			var host = this.InstallationModel.ConfigurationModel.NetworkHost ?? "localhost";
-			var port = this.InstallationModel.ConfigurationModel.HttpPort;
-
-			using (var message = new HttpRequestMessage(HttpMethod.Put, $"http://{host}:{port}/_xpack/security/user/{user}/_password"))
+			this.Session.SendProgress(100, $"Changing password for '{user}'");
+			using (var message = new HttpRequestMessage(HttpMethod.Put, $"_xpack/security/user/{user}/_password"))
 			{
 				var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"elastic:{elasticUserPassword}"));
 
@@ -67,6 +111,7 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 				var response = client.SendAsync(message).Result;
 				response.EnsureSuccessStatusCode();
 			}
+			this.Session.SendProgress(200, $"Changed password for user '{user}'");
 		}
 	}
 }

--- a/src/InstallerHosts/Elastic.InstallerHosts/SessionWrapper.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/SessionWrapper.cs
@@ -12,13 +12,9 @@ namespace Elastic.InstallerHosts
 
 		public SessionWrapper(Session session) => this._session = session;
 
-		public T Get<T>(string property)
-		{
-			string value;
-			if (this._session.TryGetValue(property, out value))
-				return (T)Convert.ChangeType(value, typeof(T));
-			return default(T);
-		}
+		public T Get<T>(string property) => this._session.TryGetValue(property, out var value) 
+			? (T)Convert.ChangeType(value, typeof(T)) 
+			: default(T);
 
 		public void Set(string property, string value) => this._session.Set(property, value);
 

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","74d918")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","ea7bab")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
 [assembly: AssemblyVersionAttribute("6.0.0")]
 [assembly: AssemblyFileVersionAttribute("6.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("6.0.0-beta2")]
+[assembly: AssemblyInformationalVersionAttribute("6.0.0-rc2")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "74d918";
+        internal const System.String AssemblyMetadata_GitBuildHash = "ea7bab";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
         internal const System.String AssemblyVersion = "6.0.0";
         internal const System.String AssemblyFileVersion = "6.0.0";
-        internal const System.String AssemblyInformationalVersion = "6.0.0-beta2";
+        internal const System.String AssemblyInformationalVersion = "6.0.0-rc2";
     }
 }

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","e2249a")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","74d918")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
@@ -19,7 +19,7 @@ namespace System {
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "e2249a";
+        internal const System.String AssemblyMetadata_GitBuildHash = "74d918";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","9ab6a1")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","e2249a")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
 [assembly: AssemblyVersionAttribute("6.0.0")]
 [assembly: AssemblyFileVersionAttribute("6.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("6.0.0-rc1")]
+[assembly: AssemblyInformationalVersionAttribute("6.0.0-beta2")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "9ab6a1";
+        internal const System.String AssemblyMetadata_GitBuildHash = "e2249a";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
         internal const System.String AssemblyVersion = "6.0.0";
         internal const System.String AssemblyFileVersion = "6.0.0";
-        internal const System.String AssemblyInformationalVersion = "6.0.0-rc1";
+        internal const System.String AssemblyInformationalVersion = "6.0.0-beta2";
     }
 }

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","787c93")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","9ab6a1")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
-[assembly: AssemblyVersionAttribute("5.6.0")]
-[assembly: AssemblyFileVersionAttribute("5.6.0")]
-[assembly: AssemblyInformationalVersionAttribute("5.6.0")]
+[assembly: AssemblyVersionAttribute("6.0.0")]
+[assembly: AssemblyFileVersionAttribute("6.0.0")]
+[assembly: AssemblyInformationalVersionAttribute("6.0.0-rc1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "787c93";
+        internal const System.String AssemblyMetadata_GitBuildHash = "9ab6a1";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
-        internal const System.String AssemblyVersion = "5.6.0";
-        internal const System.String AssemblyFileVersion = "5.6.0";
-        internal const System.String AssemblyInformationalVersion = "5.6.0";
+        internal const System.String AssemblyVersion = "6.0.0";
+        internal const System.String AssemblyFileVersion = "6.0.0";
+        internal const System.String AssemblyInformationalVersion = "6.0.0-rc1";
     }
 }

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Elasticsearch\Models\Tasks\UninstallServiceTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Uninstall\UninstallDeleteDirectoriesTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Uninstall\UninstallRemoveEnvironmentVariablesTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\XPack\XPackArgumentsTests.cs" />
     <Compile Include="Elasticsearch\Process\ConsoleSession.cs" />
     <Compile Include="Elasticsearch\Process\ElasticsearchProcessTester.cs" />
     <Compile Include="Elasticsearch\Process\ElasticsearchProcessTesterStateProvider.cs" />

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -109,6 +109,8 @@
     <Compile Include="Elasticsearch\Models\Tasks\UninstallServiceTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Uninstall\UninstallDeleteDirectoriesTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Uninstall\UninstallRemoveEnvironmentVariablesTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\XPack\BasicLicenseArgumentsTests.cs" />
+    <Compile Include="Elasticsearch\Models\XPack\TrialLicenseArgumentsTests.cs" />
     <Compile Include="Elasticsearch\Models\XPack\XPackArgumentsTests.cs" />
     <Compile Include="Elasticsearch\Process\ConsoleSession.cs" />
     <Compile Include="Elasticsearch\Process\ElasticsearchProcessTester.cs" />

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -98,7 +98,10 @@
     <Compile Include="Elasticsearch\Models\InstallationModelArgumentsTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Commit\CleanUpInstallTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Install\CreateDirectoriesTaskTests.cs" />
-    <Compile Include="Elasticsearch\Models\Tasks\Install\EditElasticsearchYamlTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\Tasks\Install\EditElasticsearchYaml\EditElasticsearchYamlConfigurationModelTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\Tasks\Install\EditElasticsearchYaml\EditElasticsearchYamlServiceModelTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\Tasks\Install\EditElasticsearchYaml\EditElasticsearchYamlTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\Tasks\Install\EditElasticsearchYaml\EditElasticsearchYamlXPackModelTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Install\EditJvmOptionTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Install\InstallPluginsTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Install\InstallServiceTaskTests.cs" />

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Elasticsearch\Models\Tasks\Install\InstallServiceTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Install\PreserveInstallTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Install\SetEnvironmentVariablesTaskTests.cs" />
+    <Compile Include="Elasticsearch\Models\Tasks\Install\SetupXPackPasswordsTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Rollback\RollbackDeleteDirectoriesTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Rollback\RollbackRemoveEnvironmentVariablesTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\UninstallServiceTaskTests.cs" />

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -110,7 +110,9 @@
     <Compile Include="Elasticsearch\Models\Tasks\Uninstall\UninstallDeleteDirectoriesTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\Tasks\Uninstall\UninstallRemoveEnvironmentVariablesTaskTests.cs" />
     <Compile Include="Elasticsearch\Models\XPack\BasicLicenseArgumentsTests.cs" />
+    <Compile Include="Elasticsearch\Models\XPack\BasicLicenseModelTests.cs" />
     <Compile Include="Elasticsearch\Models\XPack\TrialLicenseArgumentsTests.cs" />
+    <Compile Include="Elasticsearch\Models\XPack\TrialLicenseModelTests.cs" />
     <Compile Include="Elasticsearch\Models\XPack\XPackArgumentsTests.cs" />
     <Compile Include="Elasticsearch\Process\ConsoleSession.cs" />
     <Compile Include="Elasticsearch\Process\ElasticsearchProcessTester.cs" />

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/ElasticsearchYamlFileTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/ElasticsearchYamlFileTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using Elastic.Configuration.FileBased.Yaml;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using FluentAssertions;
 using Xunit;
 
@@ -26,6 +28,9 @@ node.max_local_storage_nodes: 1
 node.name: {nodeName}
 path.data: {folder}data
 path.logs: {folder}logs
+xpack.license.self_generated.type: trial
+xpack.security.enabled: false
+xpack.random_setting: something
 ";
 			var fs = FakeElasticsearchYaml(yaml);
 			var optsFile = new ElasticsearchYamlConfiguration(_path, fs);
@@ -39,6 +44,9 @@ path.logs: {folder}logs
 			settings.DataPath.Should().Be(folder + "data");
 			settings.LogsPath.Should().Be(folder + "logs");
 			settings.MaxLocalStorageNodes.Should().Be(1);
+			settings.XPackSecurityEnabled.Should().BeFalse();
+			settings.XPackLicenseSelfGeneratedType.Should().Be(nameof(XPackLicenseMode.Trial).ToLowerInvariant());
+			settings.Keys.Where(k => k.StartsWith("xpack")).Should().HaveCount(1);
 			optsFile.Save();
 
 			var fileContentsAfterSave = fs.File.ReadAllText(_path);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelArgumentsTestsBase.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelArgumentsTestsBase.cs
@@ -34,7 +34,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		{
 			var args = new[] {$"{key.Split('.').Last()}={value}"};
 			var models = model.AllSteps.Cast<IValidatableReactiveObject>().Concat(new[] {model}).ToList();
-			var viewModelArgumentParser = new ModelArgumentParser(models, args);
+			var viewModelArgumentParser = new ElasticsearchArgumentParser(models, args);
 			assert(model, value);
 
 			var msiParams = model.ToMsiParamsString();
@@ -80,7 +80,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			{
 				var args = this.Arguments.Select(t => $"{t.Item1.Split('.').Last()}={t.Item3}").ToArray();
 				var models = this._model.AllSteps.Cast<IValidatableReactiveObject>().Concat(new[] {this._model}).ToList();
-				var viewModelArgumentParser = new ModelArgumentParser(models, args);
+				var viewModelArgumentParser = new ElasticsearchArgumentParser(models, args);
 				assert(this._model);
 
 				var msiParams = this._model.ToMsiParamsString();

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelArgumentsTestsBase.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelArgumentsTestsBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Elastic.Installer.Domain.Model;
 using Elastic.Installer.Domain.Model.Base;
@@ -19,7 +20,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			var msiParamString = model.ParsedArguments.MsiString(value);
 
 			msiParams.Should().Contain($"{key.ToUpperInvariant()}=\"{msiParamString}\"");
-
 		}
 
 		protected void Argument<T>(string key, T value, string msiParam, Action<ElasticsearchInstallationModel, T> assert)
@@ -27,19 +27,68 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			var model = WithValidPreflightChecks().InstallationModel;
 			string msiParams = AssertParser(model, key, value, assert);
 			msiParams.Should().Contain($"{key.ToUpperInvariant()}=\"{msiParam}\"");
-
 		}
 
-		private string AssertParser<T>(ElasticsearchInstallationModel model, string key, T value, Action<ElasticsearchInstallationModel, T> assert)
+		private string AssertParser<T>(ElasticsearchInstallationModel model, string key, T value,
+			Action<ElasticsearchInstallationModel, T> assert)
 		{
-			var args = new[] { $"{key.Split('.').Last()}={value}" };
-			var models = model.Steps.Cast<IValidatableReactiveObject>().Concat(new[] { model }).ToList();
+			var args = new[] {$"{key.Split('.').Last()}={value}"};
+			var models = model.AllSteps.Cast<IValidatableReactiveObject>().Concat(new[] {model}).ToList();
 			var viewModelArgumentParser = new ModelArgumentParser(models, args);
 			assert(model, value);
 
 			var msiParams = model.ToMsiParamsString();
 			msiParams.Should().NotBeEmpty();
 			return msiParams;
+		}
+
+		protected MultipleArgumentsTester Argument<T>(string key, T value)
+		{
+			var model = WithValidPreflightChecks().InstallationModel;
+			return new MultipleArgumentsTester(model).Argument(key, value);
+		}
+
+		protected MultipleArgumentsTester Argument<T>(string key, T value, string msiParam)
+		{
+			var model = WithValidPreflightChecks().InstallationModel;
+			return new MultipleArgumentsTester(model).Argument(key, value, msiParam);
+		}
+
+		public class MultipleArgumentsTester
+		{
+			private readonly ElasticsearchInstallationModel _model;
+			private List<Tuple<string, string, string>> Arguments { get; } = new List<Tuple<string, string, string>>();
+
+			public MultipleArgumentsTester(ElasticsearchInstallationModel model)
+			{
+				this._model = model;
+			}
+
+			public MultipleArgumentsTester Argument<T>(string key, T value)
+			{
+				this.Arguments.Add(Tuple.Create(key, value.ToString(), value.ToString()));
+				return this;
+			}
+
+			public MultipleArgumentsTester Argument<T>(string key, T value, string msiParam)
+			{
+				this.Arguments.Add(Tuple.Create(key, value.ToString(), msiParam));
+				return this;
+			}
+
+			public string Assert(Action<ElasticsearchInstallationModel> assert)
+			{
+				var args = this.Arguments.Select(t => $"{t.Item1.Split('.').Last()}={t.Item3}").ToArray();
+				var models = this._model.AllSteps.Cast<IValidatableReactiveObject>().Concat(new[] {this._model}).ToList();
+				var viewModelArgumentParser = new ModelArgumentParser(models, args);
+				assert(this._model);
+
+				var msiParams = this._model.ToMsiParamsString();
+				msiParams.Should().NotBeEmpty();
+				foreach(var t in this.Arguments)
+					msiParams.Should().Contain($"{t.Item1.ToUpperInvariant()}=\"{t.Item3}\"");
+				return msiParams;
+			}
 		}
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
@@ -125,7 +125,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			var firstStep = this.InstallationModel.Steps.First();
 			return IsValidOnStep(firstStep);
 		}
-
+		
 		public InstallationModelTester IsNotified(Action<NoticeModel> assert)
 		{
 			var step = this.InstallationModel.NoticeModel;
@@ -150,6 +150,13 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			return IsValidOnStep(step);
 		}
 
+		public InstallationModelTester IsOnStep(Func<ElasticsearchInstallationModel, IValidatableReactiveObject> selector)
+		{
+			var step = selector(this.InstallationModel);
+			this.InstallationModel.ActiveStep.Should().Be(step);
+			return this;
+		}
+
 		public InstallationModelTester IsValidOnStep(IValidatableReactiveObject step)
 		{
 			this.InstallationModel.ActiveStep.Should().Be(step);
@@ -165,7 +172,14 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		{
 			var c = false;
 			this.InstallationModel.Next.CanExecuteObservable.Subscribe(cc => c = cc);
-			c.Should().Be(canClick, "errors {0}", this.InstallationModel);
+			c.Should().Be(canClick, "expected to be able to click next {0} model: {1}", canClick, this.InstallationModel);
+			return this;
+		}
+		public InstallationModelTester CanInstall(bool canInstall = true)
+		{
+			var c = false;
+			this.InstallationModel.Install.CanExecuteObservable.Subscribe(cc => c = cc);
+			c.Should().Be(canInstall, "expected to be able to click install {0} model: {1}", canInstall, this.InstallationModel);
 			return this;
 		}
 
@@ -186,7 +200,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 		public InstallationModelTester ClickBack()
 		{
-			CanClickNext();
+			CanClickBack();
 			this.InstallationModel.Back.Execute(null);
 			return this;
 		}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
@@ -111,9 +111,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			this.InstallationModel.ActiveStep.Should().Be(step);
 			step.IsValid.Should().BeFalse("{0} should be invalid", step.GetType().Name);
 
-			this.InstallationModel.CurrentStepValidationFailures.Should().NotBeEmpty();
+			this.InstallationModel.FirstInvalidStepValidationFailures.Should().NotBeEmpty();
 			step.ValidationFailures.Should().NotBeEmpty()
-				.And.HaveCount(this.InstallationModel.CurrentStepValidationFailures.Count);
+				.And.HaveCount(this.InstallationModel.FirstInvalidStepValidationFailures.Count);
 
 			validateErrors?.Invoke(step.ValidationFailures);
 
@@ -153,9 +153,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		public InstallationModelTester IsValidOnStep(IValidatableReactiveObject step)
 		{
 			this.InstallationModel.ActiveStep.Should().Be(step);
-			step.IsValid.Should().BeTrue("error messages: {0}", this.InstallationModel.CurrentStepValidationFailures.ToUnitTestMessage());
+			step.IsValid.Should().BeTrue("error messages: {0}", this.InstallationModel.FirstInvalidStepValidationFailures.ToUnitTestMessage());
 
-			this.InstallationModel.CurrentStepValidationFailures.Should().BeEmpty();
+			this.InstallationModel.FirstInvalidStepValidationFailures.Should().BeEmpty();
 			step.ValidationFailures.Should().BeEmpty();
 
 			return this;

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
@@ -165,7 +165,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		{
 			var c = false;
 			this.InstallationModel.Next.CanExecuteObservable.Subscribe(cc => c = cc);
-			c.Should().Be(canClick);
+			c.Should().Be(canClick, "errors {0}", this.InstallationModel);
 			return this;
 		}
 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
@@ -99,12 +99,8 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			tester.InstallationModel.XPackModel.IsRelevant.Should().BeTrue();
 			
 			tester.ClickNext();
-			tester.IsInvalidOnStep(m => m.XPackModel, errors => errors.ShouldHaveErrors(
-				"Password is required"
-			));
-
-			tester.InstallationModel.XPackModel.ElasticUserPassword = Guid.NewGuid().ToString();
-
+			//Basic license selected by default
+			tester.IsValidOnStep(m => m.XPackModel);
 			tester.CanClickNext();
 		
 			tester.InstallationModel.NextButtonText.Should().Be(TextResources.SetupView_InstallText);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
@@ -103,7 +103,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 				"Password is required"
 			));
 
-			tester.InstallationModel.XPackModel.XPackUserPassword = Guid.NewGuid().ToString();
+			tester.InstallationModel.XPackModel.ElasticUserPassword = Guid.NewGuid().ToString();
 
 			tester.CanClickNext();
 		

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
@@ -94,8 +94,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			tester.IsValidOnStep(m => m.PluginsModel);
 			tester.InstallationModel.XPackModel.IsRelevant.Should().BeFalse();
 			var step = tester.InstallationModel.PluginsModel;
-			var xpackPlugin = step.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
-			xpackPlugin.Selected = true;
+			step.ChangeXPackSelection(true);
 			tester.InstallationModel.XPackModel.IsRelevant.Should().BeTrue();
 			
 			tester.ClickNext();

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsArgumentsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using FluentAssertions;
 using Xunit;
 
@@ -33,6 +34,13 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 		{
 			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.Contain("analysis-phonetic");
 			m.PluginsModel.AvailablePlugins.Count(p => p.Selected).Should().Be(2);
+		});
+		
+		[Fact] void XPackSetsBasicLicenseAutomatically() => Argument(nameof(PluginsModel.Plugins), "x-pack", (m, v) =>
+		{
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+			m.XPackModel.IsRelevant.Should().BeTrue();
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
 		});
 
 		[Fact] void PluginsHttpProxyHost() => Argument(

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -1,4 +1,6 @@
-﻿using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using System.Linq;
+using Elastic.Installer.Domain.Model.Base.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
 using FluentAssertions;
 using Xunit;
 
@@ -24,6 +26,17 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 			})
 			.CanClickNext();
 
+		[Fact] void SelectingXPackIsPropagated() => this._model
+			.OnStep(m => m.PluginsModel, step =>
+			{
+				step.XPackEnabled.Should().BeFalse();
+				var xpackPlugin = step.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
+				xpackPlugin.Selected = true;
+
+				step.XPackEnabled.Should().BeTrue();
+
+			})
+			.CanClickNext();
 
 		[Fact] void IngestPluginsNotSelectedByDefault() => this._model
 			.OnStep(m => m.PluginsModel, step =>

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -30,9 +30,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 			.OnStep(m => m.PluginsModel, step =>
 			{
 				step.XPackEnabled.Should().BeFalse();
-				var xpackPlugin = step.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
-				xpackPlugin.Selected = true;
-
+				step.ChangeXPackSelection(true);
 				step.XPackEnabled.Should().BeTrue();
 
 			})

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlConfigurationModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlConfigurationModelTaskTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Configuration.FileBased.Yaml;
+using Elastic.Installer.Domain.Model.Elasticsearch.Config;
+using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.EditElasticsearchYaml
+{
+	public class EditElasticsearchYamlConfigurationModelTaskTests : InstallationModelTestBase
+	{
+		[Fact] void CustomConfigValues() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.ConfigurationModel, s =>
+			{
+				s.ClusterName = "x";
+				s.NodeName = "x";
+				s.MasterNode = false;
+				s.DataNode = false;
+				s.IngestNode = false;
+				s.LockMemory = false;
+				s.NetworkHost = "xyz";
+				s.HttpPort = 80;
+				s.TransportPort = 9300;
+				s.UnicastNodes = new ReactiveUI.ReactiveList<string>
+				{
+					"localhost", "192.2.3.1:9301"
+				};
+			})
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					s.ClusterName.Should().Be("x");
+					s.NodeName.Should().Be("x");
+					s.MasterNode.Should().BeFalse();
+					s.IngestNode.Should().BeFalse();
+					s.MemoryLock.Should().BeFalse();
+					s.NetworkHost.Should().Be("xyz");
+					s.HttpPort.Should().Be(80);
+					s.HttpPortString.Should().Be("80");
+					s.TransportTcpPort.Should().Be(9300);
+					s.TransportTcpPortString.Should().Be("9300");
+					s.UnicastHosts.Should().BeEquivalentTo(new List<string>
+					{
+						"localhost", "192.2.3.1:9301"
+					});
+				}
+			);
+
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlServiceModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlServiceModelTaskTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Configuration.FileBased.Yaml;
+using Elastic.Installer.Domain.Model.Elasticsearch.Config;
+using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.EditElasticsearchYaml
+{
+	public class EditElasticsearchYamlServiceModelTaskTests : InstallationModelTestBase
+	{
+		[Fact] void DefaultMaxLocalStorageNodesNotService() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.ServiceModel, s => s.InstallAsService = false)
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					//because we do not install as service
+					s.MaxLocalStorageNodes.Should().NotHaveValue();
+				}
+			);
+
+		[Fact] void MaxLocalStorageNodesShouldBeSetWhenInstallingAsService() => WithValidPreflightChecks(s => s
+				.Elasticsearch(es => es
+					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+				)
+				.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.ServiceModel, s => s.InstallAsService = true)
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					//because we do not install as service
+					s.MaxLocalStorageNodes.Should().Be(1);
+				});
+
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlTaskTests.cs
@@ -8,12 +8,11 @@ using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
 using FluentAssertions;
 using Xunit;
 
-namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.EditElasticsearchYaml
 {
 	public class EditElasticsearchYamlTaskTests : InstallationModelTestBase
 	{
-		[Fact]
-		void PicksUpExistingConfiguration() => WithValidPreflightChecks(s => s
+		[Fact] void PicksUpExistingConfiguration() => WithValidPreflightChecks(s => s
 				.Elasticsearch(e => e
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)
@@ -40,8 +39,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 				}
 			);
 
-		[Fact]
-		void WritesExpectedDefauts() => WithValidPreflightChecks(s => s
+		[Fact] void WritesExpectedDefauts() => WithValidPreflightChecks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -78,8 +76,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 				}
 			);
 
-		[Fact]
-		void DefaultMaxLocalStorageNodesNotService() => WithValidPreflightChecks(s => s
+		[Fact] void DefaultMaxLocalStorageNodesNotService() => WithValidPreflightChecks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -105,8 +102,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 				}
 			);
 
-		[Fact]
-		void CustomConfigValues() => WithValidPreflightChecks(s => s
+		[Fact] void CustomConfigValues() => WithValidPreflightChecks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlXPackModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlXPackModelTaskTests.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using Elastic.Configuration.FileBased.Yaml;
+using Elastic.Installer.Domain.Model.Elasticsearch.Config;
+using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.EditElasticsearchYaml
+{
+	public class EditElasticsearchYamlXPackModelTaskTests : InstallationModelTestBase
+	{
+		[Fact] void WritesExpectedDefauts() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					s.XPackLicenseSelfGeneratedType.Should().BeNull();
+					s.XPackSecurityEnabled.Should().BeNull();
+				}
+			);
+
+		[Fact] void SelectingXPackPluginDefaultsToWritingLicenseType() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.PluginsModel, s => s.ChangeXPackSelection(true))
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					s.XPackLicenseSelfGeneratedType.Should().Be(nameof(XPackLicenseMode.Basic).ToLowerInvariant());
+					s.XPackSecurityEnabled.Should().BeNull();
+				}
+			);
+		
+		[Fact] void SelectingTrialDoesNotWriteSecurityEnabled() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.PluginsModel, s => s.ChangeXPackSelection(true))
+			.OnStep(m => m.XPackModel, s => s.XPackLicense = XPackLicenseMode.Trial)
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					s.XPackLicenseSelfGeneratedType.Should().Be(nameof(XPackLicenseMode.Trial).ToLowerInvariant());
+					s.XPackSecurityEnabled.Should().BeNull();
+				}
+			);
+		
+		[Fact] void DeselectingSecurityWritesFalseToYamlFile() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.PluginsModel, s => s.ChangeXPackSelection(true))
+			.OnStep(m => m.XPackModel, s =>
+			{
+				s.XPackLicense = XPackLicenseMode.Trial;
+				s.XPackSecurityEnabled = false;
+			})
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					s.XPackLicenseSelfGeneratedType.Should().Be(nameof(XPackLicenseMode.Trial).ToLowerInvariant());
+					s.XPackSecurityEnabled.Should().BeFalse();
+				}
+			);
+		
+		[Fact] void RemovesXPackSettingsIfXPackIsNotBeingInstalled() => WithValidPreflightChecks(s => s
+			.Elasticsearch(es => es
+				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+			)
+			.FileSystem(fs =>
+				{
+					var yaml = $@"bootstrap.memory_lock: true
+xpack.security.enabled = false
+xpack.license.self_generated.type = trial
+xpack.random_setting = something
+";
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@""));
+					return fs;
+				})
+			)
+			.OnStep(m => m.PluginsModel, s => s.ChangeXPackSelection(false))
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					s.XPackLicenseSelfGeneratedType.Should().BeNull();
+					s.XPackSecurityEnabled.Should().BeNull();
+					s.Keys.Where(k => k.StartsWith("xpack")).Should().HaveCount(0);
+				}
+			);
+
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/SetupXPackPasswordsTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/SetupXPackPasswordsTaskTests.cs
@@ -1,0 +1,28 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Install;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
+{
+	public class SetupXPackPasswordsTaskTests : InstallationModelTestBase
+	{
+		[Fact] void InstallByDefault() => WithValidPreflightChecks()
+			.OnStep(m=>m.PluginsModel, step=>step.ChangeXPackSelection(true))
+			.OnStep(m=>m.XPackModel, step =>
+			{
+				step.XPackLicense = XPackLicenseMode.Trial;
+
+				step.ElasticUserPassword = "somepass";
+				step.KibanaUserPassword = "somepass";
+				step.LogstashSystemUserPassword = "somepass";
+
+			})
+			.AssertTask(
+				(m, s, fs) => new SetupXPackPasswordsTask(m, s, fs), 
+				(m, t) =>
+				{
+				}
+			);
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/SetupXPackPasswordsTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/SetupXPackPasswordsTaskTests.cs
@@ -7,7 +7,8 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 {
 	public class SetupXPackPasswordsTaskTests : InstallationModelTestBase
 	{
-		[Fact] void InstallByDefault() => WithValidPreflightChecks()
+		[Fact(Skip = "need an integration test for this")]
+		void InstallByDefault() => WithValidPreflightChecks()
 			.OnStep(m=>m.PluginsModel, step=>step.ChangeXPackSelection(true))
 			.OnStep(m=>m.XPackModel, step =>
 			{

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseArgumentsTests.cs
@@ -1,0 +1,16 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
+{
+	public class BasicLicenseArgumentsTests : InstallationModelArgumentsTestsBase
+	{
+		[Fact] void CanPassBasicLicense() => Argument(nameof(XPackModel.XPackLicense), "basic", "Basic", (m, v) =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
+			m.XPackModel.IsValid.Should().BeTrue("{0}", m);
+		});
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseModelTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using Elastic.Installer.Domain.Model.Base.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
+{
+	public class BasicLicenseModelTester : InstallationModelTestBase
+	{
+		private readonly InstallationModelTester _model;
+		
+		public BasicLicenseModelTester()
+		{
+			this._model = WithValidPreflightChecks()
+				.ClickNext()
+				.ClickNext()
+				.ClickNext()
+				.IsValidOnStep(m => m.PluginsModel)
+				.OnStep(m => m.PluginsModel, m =>
+				{
+					var xPackPlugin = m.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
+					xPackPlugin.Selected = true;
+				})
+				.IsValidOnStep(m => m.PluginsModel)
+				.ClickNext();
+		}
+
+		[Fact] void DefaultLicenseIsBasic() => this._model
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Basic);
+			})
+			.CanClickNext();
+			
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseModelTests.cs
@@ -17,10 +17,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.PluginsModel)
-				.OnStep(m => m.PluginsModel, m =>
+				.OnStep(m => m.PluginsModel, step =>
 				{
-					var xPackPlugin = m.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
-					xPackPlugin.Selected = true;
+					step.ChangeXPackSelection(true);
 				})
 				.IsValidOnStep(m => m.PluginsModel)
 				.ClickNext();

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseArgumentsTests.cs
@@ -1,0 +1,52 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
+{
+	public class TrialLicenseArgumentsTests : InstallationModelArgumentsTestsBase
+	{
+		[Fact] void CanPassTrialLicense() => Argument(nameof(XPackModel.XPackLicense), "trIal", "Trial", (m, v) =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.XPackModel.IsValid.Should().BeFalse("{0}", m);
+		});
+		
+		[Fact] void SignalUsersWillBeGeneratedLater() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial))
+			.Argument(nameof(XPackModel.SkipSettingPasswords), "1", "true")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.XPackModel.SkipSettingPasswords.Should().BeTrue();
+			m.XPackModel.IsValid.Should().BeTrue("{0}", m);
+		});
+		
+		[Fact] void InstallTrialButWithoutSecurity() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial))
+			.Argument(nameof(XPackModel.XPackSecurityEnabled), "0", "false")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.XPackModel.XPackSecurityEnabled.Should().BeFalse();
+			m.XPackModel.IsValid.Should().BeTrue("{0}", m);
+		});
+		
+		[Fact] void CanPassSystemUserPasswords() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial))
+			.Argument(nameof(XPackModel.ElasticUserPassword), "es-pass")
+			.Argument(nameof(XPackModel.KibanaUserPassword), "ki-pass")
+			.Argument(nameof(XPackModel.LogstashSystemUserPassword), "ls-pass")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.XPackModel.IsValid.Should().BeTrue("{0}", m);
+			m.XPackModel.XPackSecurityEnabled.Should().BeTrue();
+			m.XPackModel.SkipSettingPasswords.Should().BeFalse();
+			m.XPackModel.ElasticUserPassword.Should().Be("es-pass");
+			m.XPackModel.KibanaUserPassword.Should().Be("ki-pass");
+			m.XPackModel.LogstashSystemUserPassword.Should().Be("ls-pass");
+		});
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseArgumentsTests.cs
@@ -10,7 +10,8 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 		[Fact] void CanPassTrialLicense() => Argument(nameof(XPackModel.XPackLicense), "trIal", "Trial", (m, v) =>
 		{
 			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
-			m.XPackModel.IsValid.Should().BeFalse("{0}", m);
+			m.XPackModel.IsValid.Should().BeTrue("{0}", m);
+			m.PluginsModel.XPackEnabled.Should().BeFalse();
 		});
 		
 		[Fact] void SignalUsersWillBeGeneratedLater() => 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Linq;
+using Elastic.Installer.Domain.Model.Base.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
+{
+	public class TrialLicenseModelTester : InstallationModelTestBase
+	{
+		private readonly InstallationModelTester _model;
+		
+		public TrialLicenseModelTester()
+		{
+			this._model = WithValidPreflightChecks()
+				.ClickNext()
+				.ClickNext()
+				.ClickNext()
+				.IsValidOnStep(m => m.PluginsModel)
+				.OnStep(m => m.PluginsModel, m =>
+				{
+					var xPackPlugin = m.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
+					xPackPlugin.Selected = true;
+				})
+				.IsValidOnStep(m => m.PluginsModel)
+				.ClickNext()
+				.OnStep(m => m.XPackModel, step =>
+				{
+					step.XPackLicense = XPackLicenseMode.Trial;
+				})
+				.IsInvalidOnStep(m => m.XPackModel,errors => errors
+					.ShouldHaveErrors(
+						XPackModelValidator.ElasticPasswordRequired,
+						XPackModelValidator.KibanaPasswordRequired,
+						XPackModelValidator.LogstashPasswordRequired
+					)
+				);
+		}
+
+		[Fact] void SettingShortPasswordsStillAnError() => this._model
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+				step.ElasticUserPassword = Guid.NewGuid().ToString().Substring(0, 4);
+				step.KibanaUserPassword = Guid.NewGuid().ToString().Substring(0, 4);
+				step.LogstashSystemUserPassword = Guid.NewGuid().ToString().Substring(0, 4);
+			})
+			.IsInvalidOnStep(m => m.XPackModel,errors => errors
+				.ShouldHaveErrors(
+					XPackModelValidator.ElasticPasswordRequired,
+					XPackModelValidator.KibanaPasswordRequired,
+					XPackModelValidator.LogstashPasswordRequired
+				)
+			)
+			.CanClickNext(canClick: false);
+		
+		[Fact] void SettingPasswordsMakesTheModelValid() => this._model
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+				step.ElasticUserPassword = Guid.NewGuid().ToString().Substring(0, 6);
+				step.KibanaUserPassword = Guid.NewGuid().ToString().Substring(0, 6);
+				step.LogstashSystemUserPassword = Guid.NewGuid().ToString().Substring(0, 6);
+			})
+			.IsValidOnStep(m => m.XPackModel)
+			.CanClickNext();
+		
+		[Fact] void CanForceManualPasswordGeneration() => this._model
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+				step.SkipSettingPasswords = true;
+			})
+			.IsValidOnStep(m => m.XPackModel)
+			.CanClickNext();
+		
+		[Fact] void CanDisableXPackSecurity() => this._model
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+				step.XPackSecurityEnabled.Should().BeTrue();
+				step.XPackSecurityEnabled = false;
+			})
+			.IsValidOnStep(m => m.XPackModel)
+			.CanClickNext();
+		
+		[Fact] void UpdatingServiceToNotInstallShouldNoLongerAskForPasswords() => this._model
+			.ClickBack()
+			.ClickBack()
+			.ClickBack()
+			.IsOnStep(m => m.ServiceModel)
+			.OnStep(m => m.ServiceModel, step =>
+			{
+				step.InstallAsService = false;
+			})
+			.ClickNext()
+			.ClickNext()
+			.ClickNext()
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+				step.SkipSettingPasswords.Should().BeTrue();
+			})
+			.IsValidOnStep(m => m.XPackModel)
+			.CanInstall();
+		
+		[Fact] void UpdatingServiceToNotStartAfterInstallShouldNoLongerAskForPasswords() => this._model
+			.ClickBack()
+			.ClickBack()
+			.ClickBack()
+			.IsOnStep(m => m.ServiceModel)
+			.OnStep(m => m.ServiceModel, step =>
+			{
+				step.StartAfterInstall = false;
+			})
+			.ClickNext()
+			.ClickNext()
+			.ClickNext()
+			.OnStep(m => m.XPackModel, step => 
+			{
+				step.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+				step.SkipSettingPasswords.Should().BeTrue();
+			})
+			.IsValidOnStep(m => m.XPackModel)
+			.CanInstall();
+		
+			
+	}
+}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using Elastic.Installer.Domain.Model.Base.Plugins;
 using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using FluentAssertions;
 using Xunit;
@@ -47,9 +45,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 			})
 			.IsInvalidOnStep(m => m.XPackModel,errors => errors
 				.ShouldHaveErrors(
-					XPackModelValidator.ElasticPasswordRequired,
-					XPackModelValidator.KibanaPasswordRequired,
-					XPackModelValidator.LogstashPasswordRequired
+					XPackModelValidator.ElasticPasswordAtLeast6Characters,
+					XPackModelValidator.KibanaPasswordAtLeast6Characters,
+					XPackModelValidator.LogstashPasswordAtLeast6Characters
 				)
 			)
 			.CanClickNext(canClick: false);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
@@ -18,10 +18,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.PluginsModel)
-				.OnStep(m => m.PluginsModel, m =>
+				.OnStep(m => m.PluginsModel, step =>
 				{
-					var xPackPlugin = m.AvailablePlugins.First(p => p.PluginType == PluginType.XPack);
-					xPackPlugin.Selected = true;
+					step.ChangeXPackSelection(true);
 				})
 				.IsValidOnStep(m => m.PluginsModel)
 				.ClickNext()

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/XPackArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/XPackArgumentsTests.cs
@@ -10,18 +10,18 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 		[Fact] void CanPassTrialLicense() => Argument(nameof(XPackModel.XPackLicense), "Trial", (m, v) =>
 		{
 			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
-			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+			m.PluginsModel.XPackEnabled.Should().BeFalse();
 		});
 		
 		[Fact] void CanPassBasicLicense() => Argument(nameof(XPackModel.XPackLicense), "Basic", (m, v) =>
 		{
 			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
-			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+			m.PluginsModel.XPackEnabled.Should().BeFalse();
 		});
 		
-		[Fact] void CanPassEmptyLicense() => Argument(nameof(XPackModel.XPackLicense), "", (m, v) =>
+		[Fact] void CanPassEmptyLicense() => Argument(nameof(XPackModel.XPackLicense), "", "Basic", (m, v) =>
 		{
-			m.XPackModel.XPackLicense.Should().Be(null);
+			m.XPackModel.XPackLicense.Should().Be(XPackModel.DefaultXPackLicenseMode);
 			m.PluginsModel.Plugins.Should().BeEmpty();
 		});
 		
@@ -44,26 +44,35 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 		});
 		
 		[Fact] void BasicWithMultiplePluginsNotContainingXPack() => 
-			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Basic), "")
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Basic), "Basic")
 			.Argument(nameof(PluginsModel.Plugins), "analysis-icu, analysis-phonetic")
 			.Assert(m =>
 		{
-			m.XPackModel.XPackLicense.Should().Be(null);
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
 			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.NotContain("x-pack");
 		});
 		
 		[Fact] void TrialWithMultiplePluginsNotContainingXPack() => 
-			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial), "")
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial), "Trial")
 			.Argument(nameof(PluginsModel.Plugins), "analysis-icu, analysis-phonetic")
 			.Assert(m =>
 		{
-			m.XPackModel.XPackLicense.Should().Be(null);
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
 			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.NotContain("x-pack");
 		});
 		
 		[Fact] void EmptyLicenseWithXpackInPluginsAutoSelectsBasicLicense() => 
 			Argument(nameof(XPackModel.XPackLicense), "", nameof(XPackLicenseMode.Basic))
 			.Argument(nameof(PluginsModel.Plugins), "x-pack")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+		});
+		
+		[Fact] void EmptyLicenseWithXpackInPluginsAutoSelectsBasicLicenseReverse() => 
+			Argument(nameof(PluginsModel.Plugins), "x-pack")
+			.Argument(nameof(XPackModel.XPackLicense), "", nameof(XPackLicenseMode.Basic))
 			.Assert(m =>
 		{
 			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/XPackArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/XPackArgumentsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 {
-	public class XPackArgumentsTests : InstallationModelArgumentsTestsBase
+	public class XPackLicenseArgumentsTests : InstallationModelArgumentsTestsBase
 	{
 		[Fact] void CanPassTrialLicense() => Argument(nameof(XPackModel.XPackLicense), "Trial", (m, v) =>
 		{

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/XPackArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/XPackArgumentsTests.cs
@@ -1,0 +1,82 @@
+﻿using Elastic.Installer.Domain.Model.Elasticsearch.Plugins;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
+{
+	public class XPackArgumentsTests : InstallationModelArgumentsTestsBase
+	{
+		[Fact] void CanPassTrialLicense() => Argument(nameof(XPackModel.XPackLicense), "Trial", (m, v) =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+		});
+		
+		[Fact] void CanPassBasicLicense() => Argument(nameof(XPackModel.XPackLicense), "Basic", (m, v) =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+		});
+		
+		[Fact] void CanPassEmptyLicense() => Argument(nameof(XPackModel.XPackLicense), "", (m, v) =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(null);
+			m.PluginsModel.Plugins.Should().BeEmpty();
+		});
+		
+		[Fact] void BasicWithMultiplePluginsContainingXPack() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Basic))
+			.Argument(nameof(PluginsModel.Plugins), "x-pack, analysis-icu")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.Contain("x-pack");
+		});
+		
+		[Fact] void TrialWithMultiplePluginsContainingXPack() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial))
+			.Argument(nameof(PluginsModel.Plugins), "x-pack, analysis-icu")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.Contain("x-pack");
+		});
+		
+		[Fact] void BasicWithMultiplePluginsNotContainingXPack() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Basic), "")
+			.Argument(nameof(PluginsModel.Plugins), "analysis-icu, analysis-phonetic")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(null);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.NotContain("x-pack");
+		});
+		
+		[Fact] void TrialWithMultiplePluginsNotContainingXPack() => 
+			Argument(nameof(XPackModel.XPackLicense), nameof(XPackLicenseMode.Trial), "")
+			.Argument(nameof(PluginsModel.Plugins), "analysis-icu, analysis-phonetic")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(null);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(2).And.NotContain("x-pack");
+		});
+		
+		[Fact] void EmptyLicenseWithXpackInPluginsAutoSelectsBasicLicense() => 
+			Argument(nameof(XPackModel.XPackLicense), "", nameof(XPackLicenseMode.Basic))
+			.Argument(nameof(PluginsModel.Plugins), "x-pack")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Basic);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+		});
+		
+		[Fact] void EmptyPluginsStillInjectsXpackWhenXPackLicenseIsPassed() => 
+			Argument(nameof(XPackModel.XPackLicense), "trial" , nameof(XPackLicenseMode.Trial))
+			.Argument(nameof(PluginsModel.Plugins), "", "x-pack")
+			.Assert(m =>
+		{
+			m.XPackModel.XPackLicense.Should().Be(XPackLicenseMode.Trial);
+			m.PluginsModel.Plugins.Should().NotBeEmpty().And.HaveCount(1).And.Contain("x-pack");
+		});
+	}
+}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
       azure.subscription_id = ENV['AZURE_SUBSCRIPTION_ID']
 
       azure.vm_name = "msiintegration"
+	  # swapped out for a random DNS name when running the test
       azure.dns_name = "AZURE_DNS_NAME"
       azure.vm_image_urn = 'MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter-smalldisk:latest'
       azure.vm_password = ENV['AZURE_VM_PASSWORD']
@@ -45,6 +46,7 @@ Vagrant.configure("2") do |config|
 	  azure.instance_ready_timeout = 600
 	  azure.instance_check_interval = 60
 	  azure.wait_for_destroy = true
+	  # swapped out for a random resource group name when running the test
 	  azure.resource_group_name = "AZURE_RESOURCE_GROUP_NAME"
 	  azure.location = "WestEurope"
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPassword/SilentInstall-XPackBootstrapPassword.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPassword/SilentInstall-XPackBootstrapPassword.Tests.ps1
@@ -1,0 +1,48 @@
+$currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
+Set-Location $currentDir
+
+# mapped sync folder for common scripts
+. $currentDir\..\common\Utils.ps1
+. $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
+
+Get-Version
+Get-PreviousVersions
+
+Describe "Silent Install with setting up bootstrap password" {
+
+	$exeArgs = @(
+		"PLUGINS=x-pack", 
+		"XPACKSECURITYENABLED=true", 
+		"XPACKLICENSE=Trial", 
+		"SKIPSETTINGPASSWORDS=true",
+		"BOOTSTRAPPASSWORD=elastic")
+
+    Invoke-SilentInstall -Exeargs $exeArgs
+
+    Context-PingNode -XPackSecurityInstalled $true
+
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack") }
+
+    Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:elastic" }
+}
+
+Describe "Silent Uninstall with setting up bootstrap password" {
+
+    Invoke-SilentUninstall
+
+	Context-NodeNotRunning
+
+	Context-EsConfigEnvironmentVariableNull
+
+	Context-EsHomeEnvironmentVariableNull
+
+	Context-MsiNotRegistered
+
+	Context-ElasticsearchServiceNotInstalled
+
+	$ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+	Context-EmptyInstallDirectory -Path $ExpectedHomeFolder
+}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPasswordAndXPackUsers/SilentInstall-XPackBootstrapPasswordAndXPackUsers.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPasswordAndXPackUsers/SilentInstall-XPackBootstrapPasswordAndXPackUsers.Tests.ps1
@@ -1,0 +1,51 @@
+$currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
+Set-Location $currentDir
+
+# mapped sync folder for common scripts
+. $currentDir\..\common\Utils.ps1
+. $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
+
+Get-Version
+Get-PreviousVersions
+
+Describe "Silent Install with setting up bootstrap password and x-pack users" {
+
+	$exeArgs = @(
+		"PLUGINS=x-pack", 
+		"XPACKSECURITYENABLED=true", 
+		"XPACKLICENSE=Trial", 
+		"SKIPSETTINGPASSWORDS=false",
+		"BOOTSTRAPPASSWORD=changeme",
+		"ELASTICUSERPASSWORD=elastic",
+		"KIBANAUSERPASSWORD=kibana",
+		"LOGSTASHSYSTEMUSERPASSWORD=logstash")
+
+    Invoke-SilentInstall -Exeargs $exeArgs
+
+    Context-PingNode -XPackSecurityInstalled $true
+
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack") }
+
+    Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:elastic" }
+}
+
+Describe "Silent Uninstall with setting up bootstrap password and x-pack users" {
+
+    Invoke-SilentUninstall
+
+	Context-NodeNotRunning
+
+	Context-EsConfigEnvironmentVariableNull
+
+	Context-EsHomeEnvironmentVariableNull
+
+	Context-MsiNotRegistered
+
+	Context-ElasticsearchServiceNotInstalled
+
+	$ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+	Context-EmptyInstallDirectory -Path $ExpectedHomeFolder
+}

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackUsers/SilentInstall-XPackUsers.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackUsers/SilentInstall-XPackUsers.Tests.ps1
@@ -1,0 +1,50 @@
+$currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
+Set-Location $currentDir
+
+# mapped sync folder for common scripts
+. $currentDir\..\common\Utils.ps1
+. $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
+
+Get-Version
+Get-PreviousVersions
+
+Describe "Silent Install with setting up x-pack users" {
+
+	$exeArgs = @(
+		"PLUGINS=x-pack", 
+		"XPACKSECURITYENABLED=true", 
+		"XPACKLICENSE=Trial", 
+		"SKIPSETTINGPASSWORDS=false",
+		"ELASTICUSERPASSWORD=elastic",
+		"KIBANAUSERPASSWORD=kibana",
+		"LOGSTASHSYSTEMUSERPASSWORD=logstash")
+
+    Invoke-SilentInstall -Exeargs $exeArgs
+
+    Context-PingNode -XPackSecurityInstalled $true
+
+    Context-PluginsInstalled -Expected @{ Plugins=@("x-pack") }
+
+    Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:elastic" }
+}
+
+Describe "Silent Uninstall with setting up x-pack users" {
+
+    Invoke-SilentUninstall
+
+	Context-NodeNotRunning
+
+	Context-EsConfigEnvironmentVariableNull
+
+	Context-EsHomeEnvironmentVariableNull
+
+	Context-MsiNotRegistered
+
+	Context-ElasticsearchServiceNotInstalled
+
+	$ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+	Context-EmptyInstallDirectory -Path $ExpectedHomeFolder
+}


### PR DESCRIPTION
Currently the upgrade from `5.x` to `6.0.0-rc2` is broken because the remove files thinks some files are no longer in use but are actually included in the installation:

```
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Executing op: FileRemove(,FileName=plugin-descriptor.properties,,ComponentId={DAAA2CBA-A1ED-4F29-AFBF-5478158C1303})
MSI (s) (58:74) [23:51:18:087]: Verifying accessibility of file: plugin-descriptor.properties
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Executing op: FileRemove(,FileName=plugin-security.policy,,ComponentId={DAAA2CBA-A1ED-4F29-AFBF-5478375400DD})
MSI (s) (58:74) [23:51:18:087]: Verifying accessibility of file: plugin-security.policy
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
```

This was an attempt to give files with duplicate names that are suffixed by wix with `.N` a more stable name but this does not seem to fix the problem.