### PR TITLE
Feature/duplicate components

### DIFF
--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="50f217e3-97b7-47ba-95f7-685f7db0c8aa" Name="Elasticsearch 6.0.0-beta2" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="576ef794-b3e3-4640-b717-1ed7d820d06e" Name="Elasticsearch 6.0.0-rc2" Language="1033" Codepage="Windows-1252" Version="6.0.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_6.0.0_beta2_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_6.0.0_rc2_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -17,15 +17,15 @@
             </Component>
 
             <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\LICENSE.txt" />
+              <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\LICENSE.txt" />
             </Component>
 
             <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\NOTICE.txt" />
+              <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\NOTICE.txt" />
             </Component>
 
             <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\README.textile" />
+              <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\README.textile" />
             </Component>
 
             <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -44,23 +44,23 @@
               </Component>
 
               <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
-                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-env.bat" />
+                <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-env.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-keystore.bat" />
+                <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-keystore.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-plugin.bat" />
+                <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-plugin.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch-translog.bat" />
+                <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch-translog.bat" />
               </Component>
 
               <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\bin\elasticsearch.exe" />
+                <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\bin\elasticsearch.exe" />
 
                 <ServiceControl Id="elasticsearch.exe" Name="Elasticsearch" Stop="both" Wait="yes" />
               </Component>
@@ -75,15 +75,15 @@
               </Component>
 
               <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\elasticsearch.yml" />
+                <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\config\elasticsearch.yml" />
               </Component>
 
               <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\jvm.options" />
+                <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\config\jvm.options" />
               </Component>
 
               <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\config\log4j2.properties" />
+                <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\config\log4j2.properties" />
               </Component>
 
             </Directory>
@@ -95,144 +95,144 @@
                 <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
               </Component>
 
-              <Component Id="Component.elasticsearch_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547804f08fa5" Win64="yes">
-                <File Id="elasticsearch_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\elasticsearch-6.0.0-beta2.jar" />
+              <Component Id="Component.elasticsearch_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547875a3b5fd" Win64="yes">
+                <File Id="elasticsearch_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\elasticsearch-6.0.0-rc2.jar" />
               </Component>
 
               <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\HdrHistogram-2.1.9.jar" />
+                <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\HdrHistogram-2.1.9.jar" />
               </Component>
 
               <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\hppc-0.7.1.jar" />
+                <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\hppc-0.7.1.jar" />
               </Component>
 
               <Component Id="Component.jackson_core_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547893aa28cb" Win64="yes">
-                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-core-2.8.6.jar" />
+                <File Id="jackson_core_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-core-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_cbor_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861586cf6" Win64="yes">
-                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-cbor-2.8.6.jar" />
+                <File Id="_...kson_dataformat_cbor_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-dataformat-cbor-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...son_dataformat_smile_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784de96360" Win64="yes">
-                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-smile-2.8.6.jar" />
+                <File Id="_...son_dataformat_smile_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-dataformat-smile-2.8.6.jar" />
               </Component>
 
               <Component Id="Component._...kson_dataformat_yaml_2.8.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c6651b54" Win64="yes">
-                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jackson-dataformat-yaml-2.8.6.jar" />
+                <File Id="_...kson_dataformat_yaml_2.8.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jackson-dataformat-yaml-2.8.6.jar" />
               </Component>
 
-              <Component Id="Component._...ersion_checker_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547860ec5a68" Win64="yes">
-                <File Id="_...ersion_checker_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\java-version-checker-6.0.0-beta2.jar" />
+              <Component Id="Component._..._version_checker_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547879d9c68c" Win64="yes">
+                <File Id="_..._version_checker_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\java-version-checker-6.0.0-rc2.jar" />
               </Component>
 
               <Component Id="Component.jna_4.4.0_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838772020" Win64="yes">
-                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jna-4.4.0-1.jar" />
+                <File Id="jna_4.4.0_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jna-4.4.0-1.jar" />
               </Component>
 
               <Component Id="Component.joda_time_2.9.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c3044" Win64="yes">
-                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\joda-time-2.9.5.jar" />
+                <File Id="joda_time_2.9.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\joda-time-2.9.5.jar" />
               </Component>
 
               <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jopt-simple-5.0.2.jar" />
+                <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jopt-simple-5.0.2.jar" />
               </Component>
 
               <Component Id="Component.jts_1.13.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bde079f3" Win64="yes">
-                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\jts-1.13.jar" />
+                <File Id="jts_1.13.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\jts-1.13.jar" />
               </Component>
 
-              <Component Id="Component.log4j_1.2_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd896f3f" Win64="yes">
-                <File Id="log4j_1.2_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-1.2-api-2.8.2.jar" />
+              <Component Id="Component.log4j_1.2_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e2d" Win64="yes">
+                <File Id="log4j_1.2_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\log4j-1.2-api-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component.log4j_api_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547830b6218a" Win64="yes">
-                <File Id="log4j_api_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-api-2.8.2.jar" />
+              <Component Id="Component.log4j_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f021e" Win64="yes">
+                <File Id="log4j_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\log4j-api-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component.log4j_core_2.8.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789b3cb698" Win64="yes">
-                <File Id="log4j_core_2.8.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\log4j-core-2.8.2.jar" />
+              <Component Id="Component.log4j_core_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7d0b698" Win64="yes">
+                <File Id="log4j_core_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\log4j-core-2.9.1.jar" />
               </Component>
 
-              <Component Id="Component._...mon_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780929e8b4" Win64="yes">
-                <File Id="_...mon_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-analyzers-common-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component._...ene_analyzers_common_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788a792dca" Win64="yes">
+                <File Id="_...ene_analyzers_common_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-analyzers-common-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ecs_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f02cdcc8" Win64="yes">
-                <File Id="_...ecs_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-backward-codecs-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component._...cene_backward_codecs_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841437ac6" Win64="yes">
+                <File Id="_...cene_backward_codecs_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-backward-codecs-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ore_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866da270f" Win64="yes">
-                <File Id="_...ore_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-core-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_core_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a124553f" Win64="yes">
+                <File Id="lucene_core_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-core-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ing_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478afc97d45" Win64="yes">
-                <File Id="_...ing_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-grouping-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_grouping_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788f6cd426" Win64="yes">
+                <File Id="lucene_grouping_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-grouping-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ter_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788b4151ab" Win64="yes">
-                <File Id="_...ter_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-highlighter-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_highlighter_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb3a0fdb" Win64="yes">
+                <File Id="lucene_highlighter_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-highlighter-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...oin_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783e6e1f07" Win64="yes">
-                <File Id="_...oin_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-join-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_join_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c83b3d6" Win64="yes">
+                <File Id="lucene_join_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-join-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ory_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781fe9ccc8" Win64="yes">
-                <File Id="_...ory_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-memory-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_memory_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547810d92d9b" Win64="yes">
+                <File Id="lucene_memory_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-memory-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...isc_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788066f951" Win64="yes">
-                <File Id="_...isc_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-misc-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_misc_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d5eceeb7" Win64="yes">
+                <File Id="lucene_misc_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-misc-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ies_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ed2d09d5" Win64="yes">
-                <File Id="_...ies_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-queries-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_queries_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785b80136d" Win64="yes">
+                <File Id="lucene_queries_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-queries-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ser_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789366bdba" Win64="yes">
-                <File Id="_...ser_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-queryparser-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_queryparser_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f001e130" Win64="yes">
+                <File Id="lucene_queryparser_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-queryparser-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...box_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fb85033" Win64="yes">
-                <File Id="_...box_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-sandbox-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_sandbox_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478dd7ea387" Win64="yes">
+                <File Id="lucene_sandbox_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-sandbox-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ial_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838c7d3c2" Win64="yes">
-                <File Id="_...ial_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_spatial_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478edf7eaf2" Win64="yes">
+                <File Id="lucene_spatial_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-spatial-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...ras_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478473148cb" Win64="yes">
-                <File Id="_...ras_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial-extras-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component._...ucene_spatial_extras_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547837d91172" Win64="yes">
+                <File Id="_...ucene_spatial_extras_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-spatial-extras-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...l3d_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478757075b0" Win64="yes">
-                <File Id="_...l3d_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-spatial3d-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_spatial3d_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547825791cc7" Win64="yes">
+                <File Id="lucene_spatial3d_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-spatial3d-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component._...est_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478780e47de" Win64="yes">
-                <File Id="_...est_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\lucene-suggest-7.0.0-snapshot-a128fcb.jar" />
+              <Component Id="Component.lucene_suggest_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547840b4c821" Win64="yes">
+                <File Id="lucene_suggest_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\lucene-suggest-7.0.1.jar" />
               </Component>
 
-              <Component Id="Component.plugin_cli_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f2f1542" Win64="yes">
-                <File Id="plugin_cli_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\plugin-cli-6.0.0-beta2.jar" />
+              <Component Id="Component.plugin_cli_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547800fb880d" Win64="yes">
+                <File Id="plugin_cli_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\plugin-cli-6.0.0-rc2.jar" />
               </Component>
 
               <Component Id="Component.securesm_1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478665b59f8" Win64="yes">
-                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\securesm-1.1.jar" />
+                <File Id="securesm_1.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\securesm-1.1.jar" />
               </Component>
 
               <Component Id="Component.snakeyaml_1.15.jar" Guid="daaa2cba-a1ed-4f29-afbf-547878b9ea35" Win64="yes">
-                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\snakeyaml-1.15.jar" />
+                <File Id="snakeyaml_1.15.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\snakeyaml-1.15.jar" />
               </Component>
 
               <Component Id="Component.spatial4j_0.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780eb71a08" Win64="yes">
-                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\spatial4j-0.6.jar" />
+                <File Id="spatial4j_0.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\spatial4j-0.6.jar" />
               </Component>
 
               <Component Id="Component.t_digest_3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547811092469" Win64="yes">
-                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\lib\t-digest-3.0.jar" />
+                <File Id="t_digest_3.0.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\lib\t-digest-3.0.jar" />
               </Component>
 
             </Directory>
@@ -245,12 +245,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...s_matrix_stats_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547807bf2122" Win64="yes">
-                  <File Id="_...s_matrix_stats_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-beta2.jar" />
+                <Component Id="Component._...ggs_matrix_stats_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788b304b71" Win64="yes">
+                  <File Id="_...ggs_matrix_stats_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\aggs-matrix-stats\aggs-matrix-stats-6.0.0-rc2.jar" />
                 </Component>
 
                 <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                  <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -262,12 +262,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.analysis_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component._...nalysis_common_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b14f4d14" Win64="yes">
-                  <File Id="_...nalysis_common_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\analysis-common\analysis-common-6.0.0-beta2.jar" />
+                <Component Id="Component.analysis_common_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547880555aa2" Win64="yes">
+                  <File Id="analysis_common_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\analysis-common\analysis-common-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.1" Guid="daaa2cba-a1ed-4f29-afbf-5478fec21303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\analysis-common\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478d8242033" Win64="yes" Id="Component.analysis_common.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\analysis-common\plugin-descriptor.properties" Id="analysis_common.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -279,20 +279,20 @@
                   <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.ingest_common_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478840c9f26" Win64="yes">
-                  <File Id="ingest_common_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\ingest-common-6.0.0-beta2.jar" />
+                <Component Id="Component.ingest_common_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787fbc6428" Win64="yes">
+                  <File Id="ingest_common_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\ingest-common-6.0.0-rc2.jar" />
                 </Component>
 
                 <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\jcodings-1.0.12.jar" />
+                  <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\jcodings-1.0.12.jar" />
                 </Component>
 
                 <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\joni-2.1.6.jar" />
+                  <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\joni-2.1.6.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.2" Guid="daaa2cba-a1ed-4f29-afbf-5478a0f11303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\ingest-common\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54787f80fa71" Win64="yes" Id="Component.ingest_common.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\ingest-common\plugin-descriptor.properties" Id="ingest_common.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -305,35 +305,35 @@
                 </Component>
 
                 <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                  <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-5.0.4.jar" />
+                  <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\asm-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-commons-5.0.4.jar" />
+                  <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\asm-commons-5.0.4.jar" />
                 </Component>
 
                 <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\asm-tree-5.0.4.jar" />
+                  <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\asm-tree-5.0.4.jar" />
                 </Component>
 
-                <Component Id="Component._...ang_expression_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478927f9e5a" Win64="yes">
-                  <File Id="_...ang_expression_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\lang-expression-6.0.0-beta2.jar" />
+                <Component Id="Component.lang_expression_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ada7b060" Win64="yes">
+                  <File Id="lang_expression_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\lang-expression-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component._...ons_7.0.0_snapshot_a128fcb.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cc3c0f50" Win64="yes">
-                  <File Id="_...ons_7.0.0_snapshot_a128fcb.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\lucene-expressions-7.0.0-snapshot-a128fcb.jar" />
+                <Component Id="Component.lucene_expressions_7.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786da126c8" Win64="yes">
+                  <File Id="lucene_expressions_7.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\lucene-expressions-7.0.1.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.3" Guid="daaa2cba-a1ed-4f29-afbf-5478158c1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54787452d429" Win64="yes" Id="Component.lang_expression.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\plugin-descriptor.properties" Id="lang_expression.plugin_descriptor.properties" />
                 </Component>
 
                 <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-expression\plugin-security.policy" />
+                  <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-expression\plugin-security.policy" />
                 </Component>
 
               </Directory>
@@ -346,19 +346,19 @@
                 </Component>
 
                 <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\compiler-0.9.3.jar" />
+                  <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\compiler-0.9.3.jar" />
                 </Component>
 
-                <Component Id="Component.lang_mustache_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ce3bb6c6" Win64="yes">
-                  <File Id="lang_mustache_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\lang-mustache-6.0.0-beta2.jar" />
+                <Component Id="Component.lang_mustache_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b3812d77" Win64="yes">
+                  <File Id="lang_mustache_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\lang-mustache-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.4" Guid="daaa2cba-a1ed-4f29-afbf-5478b7bb1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54781d17feb8" Win64="yes" Id="Component.lang_mustache.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\plugin-descriptor.properties" Id="lang_mustache.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.1" Guid="daaa2cba-a1ed-4f29-afbf-5478375400dd" Win64="yes">
-                  <File Id="plugin_security.policy.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-mustache\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54789821efe2" Win64="yes" Id="Component.lang_mustache.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-mustache\plugin-security.policy" Id="lang_mustache.plugin_security.policy" />
                 </Component>
 
               </Directory>
@@ -370,24 +370,24 @@
                   <RemoveFolder Id="INSTALLDIR.modules.lang_painless.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.antlr4_runtime_4.5.1_1.jar.1" Guid="daaa2cba-a1ed-4f29-afbf-54783beb6496" Win64="yes">
-                  <File Id="antlr4_runtime_4.5.1_1.jar.1" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-547876342478" Win64="yes" Id="Component.lang_painless.antlr4_runtime_4.5.1_1.jar">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\antlr4-runtime-4.5.1-1.jar" Id="lang_painless.antlr4_runtime_4.5.1_1.jar" />
                 </Component>
 
                 <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\asm-debug-all-5.1.jar" />
+                  <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\asm-debug-all-5.1.jar" />
                 </Component>
 
-                <Component Id="Component.lang_painless_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547839bfb98f" Win64="yes">
-                  <File Id="lang_painless_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\lang-painless-6.0.0-beta2.jar" />
+                <Component Id="Component.lang_painless_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781f6c7414" Win64="yes">
+                  <File Id="lang_painless_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\lang-painless-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.5" Guid="daaa2cba-a1ed-4f29-afbf-54782b561303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54783080798c" Win64="yes" Id="Component.lang_painless.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\plugin-descriptor.properties" Id="lang_painless.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.2" Guid="daaa2cba-a1ed-4f29-afbf-5478375100dd" Win64="yes">
-                  <File Id="plugin_security.policy.2" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\lang-painless\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54782978c919" Win64="yes" Id="Component.lang_painless.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\lang-painless\plugin-security.policy" Id="lang_painless.plugin_security.policy" />
                 </Component>
 
               </Directory>
@@ -399,12 +399,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.parent_join_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789363c25b" Win64="yes">
-                  <File Id="parent_join_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\parent-join\parent-join-6.0.0-beta2.jar" />
+                <Component Id="Component.parent_join_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782f2a9c25" Win64="yes">
+                  <File Id="parent_join_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\parent-join\parent-join-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.6" Guid="daaa2cba-a1ed-4f29-afbf-5478ce851303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.6" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\parent-join\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-547800c6720f" Win64="yes" Id="Component.parent_join.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\parent-join\plugin-descriptor.properties" Id="parent_join.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -416,12 +416,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.percolator_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784eca6dcb" Win64="yes">
-                  <File Id="percolator_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\percolator\percolator-6.0.0-beta2.jar" />
+                <Component Id="Component.percolator_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547895fd7669" Win64="yes">
+                  <File Id="percolator_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\percolator\percolator-6.0.0-rc2.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.7" Guid="daaa2cba-a1ed-4f29-afbf-547842201303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.7" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\percolator\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54780f787589" Win64="yes" Id="Component.percolator.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\percolator\plugin-descriptor.properties" Id="percolator.plugin_descriptor.properties" />
                 </Component>
 
               </Directory>
@@ -434,43 +434,43 @@
                 </Component>
 
                 <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
-                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\commons-codec-1.10.jar" />
+                  <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\commons-codec-1.10.jar" />
                 </Component>
 
                 <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
-                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\commons-logging-1.1.3.jar" />
+                  <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\commons-logging-1.1.3.jar" />
                 </Component>
 
-                <Component Id="Component._...ch_rest_client_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d0764d61" Win64="yes">
-                  <File Id="_...ch_rest_client_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\elasticsearch-rest-client-6.0.0-beta2.jar" />
+                <Component Id="Component._...arch_rest_client_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789468de9f" Win64="yes">
+                  <File Id="_...arch_rest_client_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\elasticsearch-rest-client-6.0.0-rc2.jar" />
                 </Component>
 
                 <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
-                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpasyncclient-4.1.2.jar" />
+                  <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpasyncclient-4.1.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
-                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpclient-4.5.2.jar" />
+                  <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpclient-4.5.2.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
-                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpcore-4.4.5.jar" />
+                  <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpcore-4.4.5.jar" />
                 </Component>
 
                 <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
-                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\httpcore-nio-4.4.5.jar" />
+                  <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\httpcore-nio-4.4.5.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.8" Guid="daaa2cba-a1ed-4f29-afbf-5478e44f1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.8" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54781e892253" Win64="yes" Id="Component.reindex.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\plugin-descriptor.properties" Id="reindex.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.3" Guid="daaa2cba-a1ed-4f29-afbf-5478375200dd" Win64="yes">
-                  <File Id="plugin_security.policy.3" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cf2f45a9" Win64="yes" Id="Component.reindex.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\plugin-security.policy" Id="reindex.plugin_security.policy" />
                 </Component>
 
-                <Component Id="Component.reindex_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783a09d668" Win64="yes">
-                  <File Id="reindex_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\reindex\reindex-6.0.0-beta2.jar" />
+                <Component Id="Component.reindex_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785f4bfc98" Win64="yes">
+                  <File Id="reindex_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\reindex\reindex-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -482,16 +482,16 @@
                   <RemoveFolder Id="INSTALLDIR.modules.repository_url.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.9" Guid="daaa2cba-a1ed-4f29-afbf-547859ea1303" Win64="yes">
-                  <File Id="plugin_descriptor.properties.9" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478fa248f9a" Win64="yes" Id="Component.repository_url.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\repository-url\plugin-descriptor.properties" Id="repository_url.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.4" Guid="daaa2cba-a1ed-4f29-afbf-5478374f00dd" Win64="yes">
-                  <File Id="plugin_security.policy.4" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-547898a6f299" Win64="yes" Id="Component.repository_url.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\repository-url\plugin-security.policy" Id="repository_url.plugin_security.policy" />
                 </Component>
 
-                <Component Id="Component.repository_url_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478349d4525" Win64="yes">
-                  <File Id="repository_url_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\repository-url\repository-url-6.0.0-beta2.jar" />
+                <Component Id="Component.repository_url_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866acf685" Win64="yes">
+                  <File Id="repository_url_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\repository-url\repository-url-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -504,43 +504,43 @@
                 </Component>
 
                 <Component Id="Component.netty_buffer_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-547881350591" Win64="yes">
-                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
+                  <File Id="netty_buffer_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-buffer-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_codec_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478677b2eca" Win64="yes">
-                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
+                  <File Id="netty_codec_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-codec-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...ty_codec_http_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bebaa9fe" Win64="yes">
-                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
+                  <File Id="_...ty_codec_http_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-codec-http-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_common_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7df66c" Win64="yes">
-                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
+                  <File Id="netty_common_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-common-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component.netty_handler_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fda2ab4a" Win64="yes">
-                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
+                  <File Id="netty_handler_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-handler-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...etty_resolver_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785164d95f" Win64="yes">
-                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
+                  <File Id="_...etty_resolver_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-resolver-4.1.13.Final.jar" />
                 </Component>
 
                 <Component Id="Component._...tty_transport_4.1.13.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bbded01b" Win64="yes">
-                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
+                  <File Id="_...tty_transport_4.1.13.Final.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\netty-transport-4.1.13.Final.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.10" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae8" Win64="yes">
-                  <File Id="plugin_descriptor.properties.10" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54789fb1b618" Win64="yes" Id="Component.transport_netty4.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\plugin-descriptor.properties" Id="transport_netty4.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.plugin_security.policy.5" Guid="daaa2cba-a1ed-4f29-afbf-5478375000dd" Win64="yes">
-                  <File Id="plugin_security.policy.5" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\plugin-security.policy" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478345f9901" Win64="yes" Id="Component.transport_netty4.plugin_security.policy">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\plugin-security.policy" Id="transport_netty4.plugin_security.policy" />
                 </Component>
 
-                <Component Id="Component._...ansport_netty4_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d74b642c" Win64="yes">
-                  <File Id="_...ansport_netty4_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\transport-netty4\transport-netty4-6.0.0-beta2.jar" />
+                <Component Id="Component.transport_netty4_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547806940ff0" Win64="yes">
+                  <File Id="transport_netty4_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\transport-netty4\transport-netty4-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -552,12 +552,12 @@
                   <RemoveFolder Id="INSTALLDIR.modules.tribe.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.plugin_descriptor.properties.11" Guid="daaa2cba-a1ed-4f29-afbf-5478c3802ae9" Win64="yes">
-                  <File Id="plugin_descriptor.properties.11" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\tribe\plugin-descriptor.properties" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ada2480d" Win64="yes" Id="Component.tribe.plugin_descriptor.properties">
+                  <File Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\tribe\plugin-descriptor.properties" Id="tribe.plugin_descriptor.properties" />
                 </Component>
 
-                <Component Id="Component.tribe_6.0.0_beta2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc2204cf" Win64="yes">
-                  <File Id="tribe_6.0.0_beta2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-beta2\modules\tribe\tribe-6.0.0-beta2.jar" />
+                <Component Id="Component.tribe_6.0.0_rc2.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cb39fad4" Win64="yes">
+                  <File Id="tribe_6.0.0_rc2.jar" Source="..\..\..\build\in\elasticsearch-6.0.0-rc2\modules\tribe\tribe-6.0.0-rc2.jar" />
                 </Component>
 
               </Directory>
@@ -587,52 +587,52 @@
     <CustomAction Id="Action2SetProp_CONFIGDIRECTORY" Property="CONFIGDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\config" Return="check" Execute="immediate" />
     <CustomAction Id="Action3SetProp_LOGSDIRECTORY" Property="LOGSDIRECTORY" Value="[%ALLUSERSPROFILE]\Elastic\Elasticsearch\logs" Return="check" Execute="immediate" />
     <CustomAction Id="Action4SetProp_NODENAME" Property="NODENAME" Value="[%COMPUTERNAME]" Return="check" Execute="immediate" />
-    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallServiceAction_Props" Property="ElasticsearchUninstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallService" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackEnvironmentAction_Props" Property="ElasticsearchRollbackEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackEnvironment" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
     <CustomAction Id="ElasticsearchValidateArgumentsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchValidateArguments" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchCleanupAction_Props" Property="ElasticsearchCleanupAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchCleanupAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchCleanup" Return="ignore" Impersonate="no" Execute="commit" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallPluginsAction_Props" Property="ElasticsearchUninstallPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackDirectoriesAction_Props" Property="ElasticsearchRollbackDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackDirectories" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
     <CustomAction Id="ElasticsearchSetBootstrapPasswordAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchSetBootstrapPassword" Return="check" Impersonate="no" Execute="immediate" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallDirectoriesAction_Props" Property="ElasticsearchUninstallDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackServiceStartAction_Props" Property="ElasticsearchRollbackServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackServiceStart" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchPreserveInstallAction_Props" Property="ElasticsearchPreserveInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchPreserveInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPreserveInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchUninstallEnvironmentAction_Props" Property="ElasticsearchUninstallEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchUninstallEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchUninstallEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchRollbackInstallServiceAction_Props" Property="ElasticsearchRollbackInstallServiceAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchRollbackInstallServiceAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchRollbackInstallService" Return="check" Impersonate="no" Execute="rollback" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchEnvironmentAction_Props" Property="ElasticsearchEnvironmentAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchEnvironmentAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchEnvironment" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchDirectoriesAction_Props" Property="ElasticsearchDirectoriesAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchDirectoriesAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchDirectories" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchConfigurationAction_Props" Property="ElasticsearchConfigurationAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchConfigurationAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchConfiguration" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchJvmOptionsAction_Props" Property="ElasticsearchJvmOptionsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchJvmOptionsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchJvmOptions" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchPluginsAction_Props" Property="ElasticsearchPluginsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchPluginsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchPlugins" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchBootstrapPasswordAction_Props" Property="ElasticsearchBootstrapPasswordAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchBootstrapPasswordAction_Props" Property="ElasticsearchBootstrapPasswordAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchBootstrapPasswordAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchBootstrapPassword" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchServiceInstallAction_Props" Property="ElasticsearchServiceInstallAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceInstallAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceInstall" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchServiceStartAction_Props" Property="ElasticsearchServiceStartAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchServiceStartAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchServiceStart" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
-    <CustomAction Id="Set_ElasticsearchSetupXPackPasswordsAction_Props" Property="ElasticsearchSetupXPackPasswordsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
+    <CustomAction Id="Set_ElasticsearchSetupXPackPasswordsAction_Props" Property="ElasticsearchSetupXPackPasswordsAction" Value="PLACEWRITABLELOCATIONSINSAMEPATH=[PLACEWRITABLELOCATIONSINSAMEPATH];INSTALLDIR=[INSTALLDIR];DATADIRECTORY=[DATADIRECTORY];CONFIGDIRECTORY=[CONFIGDIRECTORY];LOGSDIRECTORY=[LOGSDIRECTORY];UNICASTNODES=[UNICASTNODES];CLUSTERNAME=[CLUSTERNAME];NODENAME=[NODENAME];MASTERNODE=[MASTERNODE];DATANODE=[DATANODE];INGESTNODE=[INGESTNODE];SELECTEDMEMORY=[SELECTEDMEMORY];LOCKMEMORY=[LOCKMEMORY];MINIMUMMASTERNODES=[MINIMUMMASTERNODES];NETWORKHOST=[NETWORKHOST];HTTPPORT=[HTTPPORT];TRANSPORTPORT=[TRANSPORTPORT];INSTALLASSERVICE=[INSTALLASSERVICE];STARTAFTERINSTALL=[STARTAFTERINSTALL];STARTWHENWINDOWSSTARTS=[STARTWHENWINDOWSSTARTS];USELOCALSYSTEM=[USELOCALSYSTEM];USEEXISTINGUSER=[USEEXISTINGUSER];USENETWORKSERVICE=[USENETWORKSERVICE];USER=[USER];PASSWORD=[PASSWORD];HTTPPROXYHOST=[HTTPPROXYHOST];HTTPPROXYPORT=[HTTPPROXYPORT];HTTPSPROXYHOST=[HTTPSPROXYHOST];HTTPSPROXYPORT=[HTTPSPROXYPORT];PLUGINS=[PLUGINS];ELASTICUSERPASSWORD=[ELASTICUSERPASSWORD];KIBANAUSERPASSWORD=[KIBANAUSERPASSWORD];LOGSTASHSYSTEMUSERPASSWORD=[LOGSTASHSYSTEMUSERPASSWORD];XPACKSECURITYENABLED=[XPACKSECURITYENABLED];SKIPSETTINGPASSWORDS=[SKIPSETTINGPASSWORDS];XPACKLICENSE=[XPACKLICENSE];BOOTSTRAPPASSWORD=[BOOTSTRAPPASSWORD];OPENDOCUMENTATIONAFTERINSTALLATION=[OPENDOCUMENTATIONAFTERINSTALLATION];UILevel=[UILevel];INSTALLDIR.bin=[INSTALLDIR.bin];VERSION=[VERSION];REMOVE=[REMOVE];ProductName=[ProductName];INSTALLDIR=[INSTALLDIR];UILevel=[UILevel];ProductCode=[ProductCode]" />
     <CustomAction Id="ElasticsearchSetupXPackPasswordsAction" BinaryKey="ElasticsearchUninstallServiceAction_File" DllEntry="ElasticsearchSetupXPackPasswords" Return="check" Impersonate="no" Execute="deferred" HideTarget="yes" />
     <CustomAction Id="PreventDowngrading" Error="Newer version already installed" />
 
     <Binary Id="ElasticsearchUninstallServiceAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="elasticsearch" />
-    <Property Id="CurrentVersion" Value="6.0.0-beta2" />
+    <Property Id="CurrentVersion" Value="6.0.0-rc2" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -649,6 +649,10 @@
     <Property Id="LOCKMEMORY" Value="false" />
     <Property Id="HTTPPORT" Value="9200" />
     <Property Id="TRANSPORTPORT" Value="9300" />
+    <Property Id="HTTPPROXYHOST" />
+    <Property Id="HTTPPROXYPORT" />
+    <Property Id="HTTPSPROXYHOST" />
+    <Property Id="HTTPSPROXYPORT" />
     <Property Id="PLUGINS" />
     <Property Id="ELASTICUSERPASSWORD" Hidden="yes" />
     <Property Id="KIBANAUSERPASSWORD" Hidden="yes" />
@@ -670,83 +674,83 @@
       <ComponentRef Id="Component.elasticsearch.yml" />
       <ComponentRef Id="Component.jvm.options" />
       <ComponentRef Id="Component.log4j2.properties" />
-      <ComponentRef Id="Component.elasticsearch_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.elasticsearch_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_cbor_2.8.6.jar" />
       <ComponentRef Id="Component._...son_dataformat_smile_2.8.6.jar" />
       <ComponentRef Id="Component._...kson_dataformat_yaml_2.8.6.jar" />
-      <ComponentRef Id="Component._...ersion_checker_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._..._version_checker_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.jna_4.4.0_1.jar" />
       <ComponentRef Id="Component.joda_time_2.9.5.jar" />
       <ComponentRef Id="Component.jopt_simple_5.0.2.jar" />
       <ComponentRef Id="Component.jts_1.13.jar" />
-      <ComponentRef Id="Component.log4j_1.2_api_2.8.2.jar" />
-      <ComponentRef Id="Component.log4j_api_2.8.2.jar" />
-      <ComponentRef Id="Component.log4j_core_2.8.2.jar" />
-      <ComponentRef Id="Component._...mon_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ecs_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ore_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ing_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ter_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...oin_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ory_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...isc_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ies_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ser_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...box_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ial_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...ras_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...l3d_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component._...est_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component.plugin_cli_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.log4j_1.2_api_2.9.1.jar" />
+      <ComponentRef Id="Component.log4j_api_2.9.1.jar" />
+      <ComponentRef Id="Component.log4j_core_2.9.1.jar" />
+      <ComponentRef Id="Component._...ene_analyzers_common_7.0.1.jar" />
+      <ComponentRef Id="Component._...cene_backward_codecs_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_core_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_grouping_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_highlighter_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_join_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_memory_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_misc_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_queries_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_queryparser_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_sandbox_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_spatial_7.0.1.jar" />
+      <ComponentRef Id="Component._...ucene_spatial_extras_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_spatial3d_7.0.1.jar" />
+      <ComponentRef Id="Component.lucene_suggest_7.0.1.jar" />
+      <ComponentRef Id="Component.plugin_cli_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.securesm_1.1.jar" />
       <ComponentRef Id="Component.snakeyaml_1.15.jar" />
       <ComponentRef Id="Component.spatial4j_0.6.jar" />
       <ComponentRef Id="Component.t_digest_3.0.jar" />
-      <ComponentRef Id="Component._...s_matrix_stats_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._...ggs_matrix_stats_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component._...nalysis_common_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.1" />
-      <ComponentRef Id="Component.ingest_common_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.analysis_common_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.analysis_common.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.ingest_common_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.2" />
+      <ComponentRef Id="Component.ingest_common.plugin_descriptor.properties" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar" />
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component._...ang_expression_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component._...ons_7.0.0_snapshot_a128fcb.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.3" />
+      <ComponentRef Id="Component.lang_expression_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.lucene_expressions_7.0.1.jar" />
+      <ComponentRef Id="Component.lang_expression.plugin_descriptor.properties" />
       <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.4" />
-      <ComponentRef Id="Component.plugin_security.policy.1" />
-      <ComponentRef Id="Component.antlr4_runtime_4.5.1_1.jar.1" />
+      <ComponentRef Id="Component.lang_mustache_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.lang_mustache.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.lang_mustache.plugin_security.policy" />
+      <ComponentRef Id="Component.lang_painless.antlr4_runtime_4.5.1_1.jar" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.lang_painless_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.5" />
-      <ComponentRef Id="Component.plugin_security.policy.2" />
-      <ComponentRef Id="Component.parent_join_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.6" />
-      <ComponentRef Id="Component.percolator_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.7" />
+      <ComponentRef Id="Component.lang_painless_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.lang_painless.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.lang_painless.plugin_security.policy" />
+      <ComponentRef Id="Component.parent_join_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.parent_join.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.percolator_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.percolator.plugin_descriptor.properties" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
-      <ComponentRef Id="Component._...ch_rest_client_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component._...arch_rest_client_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
       <ComponentRef Id="Component.httpclient_4.5.2.jar" />
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.8" />
-      <ComponentRef Id="Component.plugin_security.policy.3" />
-      <ComponentRef Id="Component.reindex_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.9" />
-      <ComponentRef Id="Component.plugin_security.policy.4" />
-      <ComponentRef Id="Component.repository_url_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.reindex.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.reindex.plugin_security.policy" />
+      <ComponentRef Id="Component.reindex_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.repository_url.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.repository_url.plugin_security.policy" />
+      <ComponentRef Id="Component.repository_url_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.netty_buffer_4.1.13.Final.jar" />
       <ComponentRef Id="Component.netty_codec_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...ty_codec_http_4.1.13.Final.jar" />
@@ -754,11 +758,11 @@
       <ComponentRef Id="Component.netty_handler_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...etty_resolver_4.1.13.Final.jar" />
       <ComponentRef Id="Component._...tty_transport_4.1.13.Final.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.10" />
-      <ComponentRef Id="Component.plugin_security.policy.5" />
-      <ComponentRef Id="Component._...ansport_netty4_6.0.0_beta2.jar" />
-      <ComponentRef Id="Component.plugin_descriptor.properties.11" />
-      <ComponentRef Id="Component.tribe_6.0.0_beta2.jar" />
+      <ComponentRef Id="Component.transport_netty4.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.transport_netty4.plugin_security.policy" />
+      <ComponentRef Id="Component.transport_netty4_6.0.0_rc2.jar" />
+      <ComponentRef Id="Component.tribe.plugin_descriptor.properties" />
+      <ComponentRef Id="Component.tribe_6.0.0_rc2.jar" />
       <ComponentRef Id="Component.INSTALLDIR" />
       <ComponentRef Id="Component.INSTALLDIR.bin.xpack" />
       <ComponentRef Id="Component.INSTALLDIR.bin" />

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","74d918")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","ea7bab")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
 [assembly: AssemblyVersionAttribute("6.0.0")]
 [assembly: AssemblyFileVersionAttribute("6.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("6.0.0-beta2")]
+[assembly: AssemblyInformationalVersionAttribute("6.0.0-rc2")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "74d918";
+        internal const System.String AssemblyMetadata_GitBuildHash = "ea7bab";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
         internal const System.String AssemblyVersion = "6.0.0";
         internal const System.String AssemblyFileVersion = "6.0.0";
-        internal const System.String AssemblyInformationalVersion = "6.0.0-beta2";
+        internal const System.String AssemblyInformationalVersion = "6.0.0-rc2";
     }
 }


### PR DESCRIPTION
Currently the upgrade from 5.x to 6.0.0-rc2 is broken because the remove files thinks some files are no longer in use but are actually included in the installation:

```
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Executing op: FileRemove(,FileName=plugin-descriptor.properties,,ComponentId={DAAA2CBA-A1ED-4F29-AFBF-5478158C1303})
MSI (s) (58:74) [23:51:18:087]: Verifying accessibility of file: plugin-descriptor.properties
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
MSI (s) (58:74) [23:51:18:087]: Executing op: FileRemove(,FileName=plugin-security.policy,,ComponentId={DAAA2CBA-A1ED-4F29-AFBF-5478375400DD})
MSI (s) (58:74) [23:51:18:087]: Verifying accessibility of file: plugin-security.policy
MSI (s) (58:74) [23:51:18:087]: Note: 1: 2318 2:  
```

This was an attempt to give files with duplicate names that are suffixed by wix with .N a more stable name but this does not seem to fix the problem.

Supersedes #123