### PR TITLE
Allow installation of plugins from staging

### DIFF
--- a/build/scripts/Products.fsx
+++ b/build/scripts/Products.fsx
@@ -26,7 +26,7 @@ module Paths =
     let ArtifactDownloadsUrl = "https://artifacts.elastic.co/downloads"
 
     let StagingDownloadsUrl product version hash = 
-        sprintf "https://staging.elastic.co/%s-%s/downloads/windows-installers/%s/%s-%s.msi" 
+        sprintf "https://staging.elastic.co/%s-%s/downloads/%s/%s-%s.msi" 
             version hash product product version
 
 module Products =

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -147,6 +147,14 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 		public Func<Task<string>> HttpsProxyUITask { get; set; }
 		public ReactiveCommand<string> SetHttpsProxy { get; }
 
+		private string pluginsStaging;
+		[StaticArgument(nameof(PluginsStaging))]
+		public string PluginsStaging
+		{
+			get => this.pluginsStaging;
+			set => this.RaiseAndSetIfChanged(ref this.pluginsStaging, value);
+		}
+
 		protected override IEnumerable<Plugin> GetPlugins()
 		{
 			yield return new Plugin

--- a/src/Tests/Elastic.Installer.Integration.Tests/Bootstrapper.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Bootstrapper.ps1
@@ -60,7 +60,7 @@ $buildOutDir = Join-Path -Path $solutionDir -ChildPath "build\out"
 
 $semanticVersion = ConvertTo-SemanticVersion $Version
 
-$installer = Get-Installer -location $buildOutDir -Version $semanticVersion.FullVersion
+$installer = Get-Installer -location $buildOutDir -Version $semanticVersion
 if ($installer -eq $null) {
     log "No $($semanticVersion.FullVersion) installer found in $buildOutDir. Build the installer by running build.bat in the solution root" -l Error
     Exit 1
@@ -68,7 +68,7 @@ if ($installer -eq $null) {
 
 foreach($previousVersion in $PreviousVersions) {
 	$semanticVersion = ConvertTo-SemanticVersion $previousVersion
-	$installer = Get-Installer -location $buildOutDir -Version $semanticVersion.FullVersion
+	$installer = Get-Installer -location $buildOutDir -Version $semanticVersion
 	if ($installer -eq $null) {
 		log "No $($semanticVersion.FullVersion) installer found in $buildOutDir. Build the installer by running build.bat in the solution root" -l Error
 		Exit 1

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
@@ -30,6 +30,9 @@ Param(
 $env:Version = $Version
 $env:PreviousVersions = $PreviousVersions -join ","
 
+# Update Security Protocol for HTTPS requests
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
 cd $currentDir
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
@@ -400,20 +400,8 @@ function Invoke-IntegrationTests($CurrentDir, $TestDirs, $VagrantProvider, $Vers
 	}
 }
 
-function Get-Installer([string] $Location, $Product, $Version) {
-	if (!$Product) {
-		$Product = "elasticsearch"
-	}
-
-	if (!$Location) {
-		$Location = ".\..\out"
-	}
-
-	if (!$Version) {
-		$Version = ($Global:Version).FullVersion
-	}
-
-	$exePath = "$Location\$Product\$Product-$Version.msi"
+function Get-Installer([string] $Location = ".\..\out", $Product = "elasticsearch", $Version = $Global:Version) {
+	$exePath = "$Location\$Product\$Product-$($Version.FullVersion).msi"
 	log "get windows installer from $exePath" -l Debug   
 
     if (!(Test-Path $exePath)) {
@@ -484,8 +472,7 @@ function Invoke-SilentInstall {
         [Parameter(Position=0)]
         $Exeargs,
 
-		[string]
-		$Version,
+		$Version = $Global:Version,
 
 		[switch]
 		$Upgrade
@@ -517,8 +504,7 @@ function Invoke-SilentUninstall {
         [Parameter(Position=0)]
         $Exeargs,
 
-		[string]
-		$Version
+		$Version = $Global:Version
     )
 
     $QuotedArgs = Add-Quotes $Exeargs

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailUpgrade/SilentInstall-FailUpgrade.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailUpgrade/SilentInstall-FailUpgrade.Tests.ps1
@@ -18,7 +18,7 @@ Describe -Tag 'PreviousVersions' "Silent Install fail upgrade - Install previous
 
 	$v = $previousVersion.FullVersion
 	
-    Invoke-SilentInstall -Version $v
+    Invoke-SilentInstall -Version $previousVersion
 
     Context-ElasticsearchService
 
@@ -69,7 +69,7 @@ Describe -Tag 'PreviousVersions' "Silent Install fail upgrade - Fail when upgrad
 	$startDate = Get-Date
 
 	Context "Failed installation" {
-		$exitCode = Invoke-SilentInstall -Exeargs @("WIXFAILWHENDEFERRED=1") -Version $v -Upgrade
+		$exitCode = Invoke-SilentInstall -Exeargs @("WIXFAILWHENDEFERRED=1") -Version $version -Upgrade
 
 		It "Exit code is 1603" {
 			$exitCode | Should Be 1603
@@ -151,7 +151,7 @@ Describe -Tag 'PreviousVersions' "Silent Uninstall fail upgrade - Uninstall $($p
 
 	$v = $previousVersion.FullVersion
 
-    Invoke-SilentUninstall -Version $v
+    Invoke-SilentUninstall -Version $previousVersion
 
 	Context-NodeNotRunning
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-HeapSize/SilentInstall-HeapSize.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-HeapSize/SilentInstall-HeapSize.Tests.ps1
@@ -12,7 +12,7 @@ Get-PreviousVersions
 Describe "Silent Install with 1024mb heap size" {
     $HeapSize = 1024
 
-    Invoke-SilentInstall @(,"SELECTEDMEMORY=$HeapSize")
+    Invoke-SilentInstall -Exeargs @("SELECTEDMEMORY=$HeapSize")
 
     Context-PingNode -XPackSecurityInstalled $false
     Context-JvmOptions -Expected @{

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradeDefault/SilentInstall-UpgradeDefault.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradeDefault/SilentInstall-UpgradeDefault.Tests.ps1
@@ -16,7 +16,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade - Install previous vers
 
 	$v = $previousVersion.FullVersion
 
-    Invoke-SilentInstall -Version $v
+    Invoke-SilentInstall -Version $previousVersion
 
     Context-ElasticsearchService
 
@@ -65,7 +65,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade - Upgrade from $($previ
 
 	$v = $version.FullVersion
 
-    Invoke-SilentInstall -Version $v -Upgrade
+    Invoke-SilentInstall -Version $version -Upgrade
 
 	$ProgramFiles = Get-ProgramFilesFolder
     $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
@@ -116,7 +116,7 @@ Describe -Tag 'PreviousVersions' "Silent Uninstall upgrade - Uninstall new versi
 
 	$v = $version.FullVersion
 
-    Invoke-SilentUninstall -Version $v
+    Invoke-SilentUninstall -Version $version
 
 	Context-NodeNotRunning
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradeDifferentVolume/SilentInstall-UpgradeDifferentVolume.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradeDifferentVolume/SilentInstall-UpgradeDifferentVolume.Tests.ps1
@@ -23,7 +23,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade different volume - Inst
 
 	$v = $previousVersion.FullVersion
 
-    Invoke-SilentInstall -Exeargs $ExeArgs -Version $v
+    Invoke-SilentInstall -Exeargs $ExeArgs -Version $previousVersion
 
     Context-ElasticsearchService
 
@@ -68,7 +68,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade different volume - Upgr
 
 	$v = $version.FullVersion
 
-    Invoke-SilentInstall -Exeargs $ExeArgs -Version $v -Upgrade
+    Invoke-SilentInstall -Exeargs $ExeArgs -Version $version -Upgrade
 
     Context-EsHomeEnvironmentVariable -Expected $InstallDir
 
@@ -115,7 +115,7 @@ Describe -Tag 'PreviousVersions' "Silent Uninstall upgrade different volume - Un
 
 	$v = $version.FullVersion
 
-    Invoke-SilentUninstall -Version $v
+    Invoke-SilentUninstall -Version $version
 
 	Context-NodeNotRunning
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradePlugins/SilentInstall-UpgradePlugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradePlugins/SilentInstall-UpgradePlugins.Tests.ps1
@@ -17,7 +17,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade with plugins - Install 
 
 	$v = $previousVersion.FullVersion
 
-    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment") -Version $v
+    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment") -Version $previousVersion
 
     Context-ElasticsearchService
 
@@ -66,7 +66,7 @@ Describe -Tag 'PreviousVersions' "Silent Install upgrade with plugins - Upgrade 
 
 	$v = $version.FullVersion
 
-    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment") -Version $v -Upgrade
+    Invoke-SilentInstall -Exeargs @("PLUGINS=x-pack,ingest-geoip,ingest-attachment") -Version $version -Upgrade
 
     $ProgramFiles = Get-ProgramFilesFolder
     $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
@@ -117,7 +117,7 @@ Describe -Tag 'PreviousVersions' "Silent Uninstall upgrade with plugins - Uninst
 
 	$v = $version.FullVersion
 
-    Invoke-SilentUninstall -Version $v
+    Invoke-SilentUninstall -Version $version
 
 	Context-NodeNotRunning
 


### PR DESCRIPTION
This PR adds the ability to specify `PLUGINSSTAGING` parameter to allow plugins to be downloaded and installed from staging. This will allow all integration tests to run for build candidates.