### PR TITLE
Always include WixFailWhenDeferred custom action

### DIFF
--- a/build/scripts/Build.fsx
+++ b/build/scripts/Build.fsx
@@ -115,7 +115,7 @@ module Builder =
                let exitCode = ExecProcess (fun info ->
                                 info.FileName <- sprintf "%sElastic.Installer.Msi" MsiBuildDir
                                 info.WorkingDirectory <- MsiDir
-                                info.Arguments <- [product.Name; version.FullVersion; Path.GetFullPath(InDir); getBuildParam "release"] |> String.concat " "
+                                info.Arguments <- [product.Name; version.FullVersion; Path.GetFullPath(InDir)] |> String.concat " "
                                ) <| TimeSpan.FromMinutes 20.
     
                if exitCode <> 0 then failwithf "Error building MSI for %s" product.Name

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/Elasticsearch.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/Elasticsearch.cs
@@ -17,16 +17,8 @@ namespace Elastic.Installer.Msi.Elasticsearch
 {
 	public class Elasticsearch : Product
 	{
-		private readonly bool _releaseMode;
 		private static readonly string InstallAsServiceProperty = nameof(ServiceModel.InstallAsService).ToUpperInvariant();
 		private static readonly string StartAfterInstallProperty = nameof(ServiceModel.StartAfterInstall).ToUpperInvariant();
-
-		public Elasticsearch(bool releaseMode) => _releaseMode = releaseMode;
-
-		/// <summary>
-		/// Needed for generic custom actions.
-		/// </summary>
-		public Elasticsearch() { }
 
 		public override IEnumerable<string> AllArguments => ElasticsearchArgumentParser.AllArguments;
 
@@ -172,17 +164,14 @@ namespace Elastic.Installer.Msi.Elasticsearch
 				feature.Add(new XElement(ns + "ComponentRef", new XAttribute("Id", componentId)));
 			}
 
-			// include WixFailWhenDeferred Custom Action when not building a release
+			// include WixFailWhenDeferred Custom Action
 			// see http://wixtoolset.org/documentation/manual/v3/customactions/wixfailwhendeferred.html
-			if (!_releaseMode)
-			{
-				var product = documentRoot.Descendants(ns + "Product").First();
-				product.Add(new XElement(ns + "CustomActionRef",
-						new XAttribute("Id", "WixFailWhenDeferred")
-					)
-				);
-			}
-
+			var product = documentRoot.Descendants(ns + "Product").First();
+			product.Add(new XElement(ns + "CustomActionRef",
+					new XAttribute("Id", "WixFailWhenDeferred")
+				)
+			);
+			
 			// Add condition to InstallServices
 			var installExecuteSequence = documentRoot.Descendants(ns + "InstallExecuteSequence").Single();
 


### PR DESCRIPTION
This commit adds the WixFailWhenDeferred custom action to released Windows Installers, to allow the failure integration tests to run against build candidates