### PR TITLE
Disable proxy integration tests

### DIFF
--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/PesterBootstrap.ps1
@@ -55,8 +55,8 @@ if(-not(Get-Module -Name $pester)) {
 }
 
 if ($PreviousVersions) {
-	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile "$path" -OutputFormat "NUnitXml" -PassThru | Out-Null
+	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile "$path" -OutputFormat "NUnitXml" -ExcludeTag "Proxy" -PassThru | Out-Null
 }
 else {
-	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile "$path" -OutputFormat "NUnitXml" -ExcludeTag "PreviousVersions" -PassThru | Out-Null
+	Invoke-Pester -Path "$($drive)vagrant\*" -OutputFile "$path" -OutputFormat "NUnitXml" -ExcludeTag @("PreviousVersions","Proxy") -PassThru | Out-Null
 }

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Vagrantfile
@@ -19,7 +19,8 @@ Vagrant.configure("2") do |config|
     local.vm.synced_folder "./../../../../../build/out/", "/out"
     
     local.vm.provision "powershellget", type: "shell", inline: configure_powershellget()
-    local.vm.provision "fiddler", 		type: "shell", inline: configure_fiddler()  
+    # TODO: use another proxy available on chocolatey
+	#local.vm.provision "fiddler", 		type: "shell", inline: configure_fiddler()  
 	local.vm.provision "partition", 	type: "shell", inline: create_partition() 
   end
 
@@ -61,7 +62,8 @@ Vagrant.configure("2") do |config|
     azure.vm.provision "chocolatey", 	type: "shell", inline: configure_chocolatey() 
     azure.vm.provision "powershellget", type: "shell", inline: configure_powershellget()   
     azure.vm.provision "java", 			type: "shell", inline: configure_java()  
-    azure.vm.provision "fiddler", 		type: "shell", inline: configure_fiddler()  
+    # TODO: use another proxy available on chocolatey
+	#azure.vm.provision "fiddler", 		type: "shell", inline: configure_fiddler()  
   end
 
 end

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Proxy/SilentInstall-Proxy.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Proxy/SilentInstall-Proxy.Tests.ps1
@@ -9,7 +9,7 @@ Set-Location $currentDir
 Get-Version
 Get-PreviousVersions
 
-$tags = @('PreviousVersions', 'XPack') 
+$tags = @('PreviousVersions', 'XPack', 'Proxy') 
 
 Describe -Name "Silent Install x-pack through HTTPS proxy $(($Global:Version).Description)" -Tags $tags {
 	$port = 8888


### PR DESCRIPTION
This commit disables the proxy integration tests by adding a "Proxy" tag to the Describe blocks and then excluding tests with that tag applied.
The Fiddler package was removed from chocolatey on request of Telerik and an alternative package/approach should be taken.