### PR TITLE
Remove JavaScript and Python scripting plugins

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginType.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginType.cs
@@ -9,9 +9,7 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 		public static PluginType Analysis = new PluginType(TextResources.PluginType_Analysis);
 		public static PluginType Discovery = new PluginType(TextResources.PluginType_Discovery);
 		public static PluginType Snapshot = new PluginType(TextResources.PluginType_Snapshot);
-		public static PluginType Scripting = new PluginType(TextResources.PluginType_Scripting);
 		public static PluginType XPack = new PluginType(TextResources.PluginType_XPack);
-		public static PluginType ApiExtensions = new PluginType(TextResources.PluginType_ApiExtensions);
 		public static PluginType Ingest = new PluginType(TextResources.PluginType_Ingest);
 		public static PluginType Mapper = new PluginType(TextResources.PluginType_Mapper);
 		public static PluginType Store = new PluginType(TextResources.PluginType_Store);

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -271,22 +271,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 
 			yield return new Plugin
 			{
-				PluginType = PluginType.Scripting,
-				Url = "lang-javascript",
-				DisplayName = "JavaScript Language",
-				Description = TextResources.PluginsModel_JavaScriptLanguagePlugin
-			};
-
-			yield return new Plugin
-			{
-				PluginType = PluginType.Scripting,
-				Url = "lang-python",
-				DisplayName = "Python Language",
-				Description = TextResources.PluginsModel_PythonLanguagePlugin
-			};
-
-			yield return new Plugin
-			{
 				PluginType = PluginType.Snapshot,
 				Url = "repository-hdfs",
 				DisplayName = "Hadoop HDFS Repository",

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -514,7 +514,7 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An elasticsearch plugin written in Clojure that provides clojure as a scripting language for elasticsearch queries..
+        ///   Looks up a localized string similar to An Elasticsearch plugin written in Clojure that provides clojure as a scripting language for Elasticsearch queries..
         /// </summary>
         public static string PluginsModel_ClojureLanguagePlugin {
             get {
@@ -759,15 +759,6 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API Extensions.
-        /// </summary>
-        public static string PluginType_ApiExtensions {
-            get {
-                return ResourceManager.GetString("PluginType_ApiExtensions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Discovery.
         /// </summary>
         public static string PluginType_Discovery {
@@ -791,15 +782,6 @@ namespace Elastic.Installer.Domain.Properties {
         public static string PluginType_Mapper {
             get {
                 return ResourceManager.GetString("PluginType_Mapper", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Scripting.
-        /// </summary>
-        public static string PluginType_Scripting {
-            get {
-                return ResourceManager.GetString("PluginType_Scripting", resourceCulture);
             }
         }
         

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -221,9 +221,6 @@ Java won't used compressed pointers.</value>
   <data name="PluginType_Discovery" xml:space="preserve">
     <value>Discovery</value>
   </data>
-  <data name="PluginType_Scripting" xml:space="preserve">
-    <value>Scripting</value>
-  </data>
   <data name="PluginType_Snapshot" xml:space="preserve">
     <value>Snapshot</value>
   </data>
@@ -335,9 +332,6 @@ in this cluster are empty. To migrate this data back into the downgraded cluster
   </data>
   <data name="PluginsModel_XPack" xml:space="preserve">
     <value>X-Pack is an Elastic Stack extension that bundles security, alerting, monitoring, reporting, graph and machine learning capabilities into one easy-to-install package. While the X-Pack components are designed to work together seamlessly, you can easily enable or disable the features you want to use. X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
-  </data>
-  <data name="PluginType_ApiExtensions" xml:space="preserve">
-    <value>API Extensions</value>
   </data>
   <data name="PluginType_Ingest" xml:space="preserve">
     <value>Ingest</value>


### PR DESCRIPTION
This commit removes the JavaScript and Python scripting plugins that are no longer supported in Elasticsearch 6.0 onwards. Users should use Painless instead.

Closes #159