### PR TITLE
Fix/start timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ paket.exe
 build/*
 !build/scripts
 !build/scripts/*
+build/scripts/obj
 build/tools/vagrant/.vagrant
 !build/tools
 !build/tools/*

--- a/src/Installer/Elastic.Installer.Domain/Elastic.Installer.Domain.csproj
+++ b/src/Installer/Elastic.Installer.Domain/Elastic.Installer.Domain.csproj
@@ -24,7 +24,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -34,7 +33,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -81,8 +81,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			this.HigherVersionAlreadyInstalled = versionConfig.HigherVersionAlreadyInstalled;
 
 			this.LocationsModel = new LocationsModel(elasticsearchEnvironmentConfiguration, yamlConfiguration, versionConfig, fileSystem);
-			this.NoticeModel = new NoticeModel(versionConfig, serviceStateProvider, this.LocationsModel);
 			this.ServiceModel = new ServiceModel(serviceStateProvider, versionConfig);
+			this.NoticeModel = new NoticeModel(versionConfig, serviceStateProvider, this.LocationsModel, this.ServiceModel);
 			this.ConfigurationModel = new ConfigurationModel(yamlConfiguration, localJvmOptions);
 
 			var pluginDependencies = this.WhenAnyValue(

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Notice/NoticeModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Notice/NoticeModel.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Elastic.Installer.Domain.Configuration.Service;
 using Elastic.Installer.Domain.Configuration.Wix;
 using Elastic.Installer.Domain.Model.Base;
+using Elastic.Installer.Domain.Model.Base.Service;
 using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
 using Elastic.Installer.Domain.Properties;
 using ReactiveUI;
@@ -15,11 +16,13 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Notice
 		public NoticeModel(
 			VersionConfiguration versionConfig, 
 			IServiceStateProvider serviceStateProvider, 
-			LocationsModel locationsModel
+			LocationsModel locationsModel,
+			ServiceModel serviceModel
 			)
 		{
 			this.IsRelevant = versionConfig.ExistingVersionInstalled;
 			this.LocationsModel = locationsModel;
+			this.ServiceModel = serviceModel;
 			this.Header = "Notice";
 			this.ExistingVersion = versionConfig.ExistingVersion;
 			this.CurrentVersion = versionConfig.CurrentVersion;
@@ -76,6 +79,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Notice
 
 		public sealed override void Refresh() { }
 
+		public ServiceModel ServiceModel { get; }
 		public LocationsModel LocationsModel { get; }
 		public SemVersion CurrentVersion { get; }
 		public SemVersion ExistingVersion { get; }

--- a/src/Installer/Elastic.Installer.UI/Elastic.Installer.UI.csproj
+++ b/src/Installer/Elastic.Installer.UI/Elastic.Installer.UI.csproj
@@ -39,7 +39,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -49,7 +48,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml
@@ -55,7 +55,17 @@
              HorizontalAlignment="Left" VerticalAlignment="Top"/>
 
     </Grid>
-    <Grid Grid.Row="1" Grid.Column="0" x:Name="ReadOnlyPropertiesGrid">
+    <Grid Grid.Row="1" Grid.Column="0" x:Name="ControlGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="25" />
+      </Grid.RowDefinitions>
+      <CheckBox Grid.Row="0" Grid.Column="0" x:Name="StartServiceAfterInstallCheckBox" Margin="7, 0, 0,0" 
+                Content="{x:Static resx:ViewResources.ServiceView_StartAfterInstallCheckBox}" HorizontalAlignment="Stretch" VerticalAlignment="Top" />
+    </Grid>
+    <Grid Grid.Row="2" Grid.Column="0" x:Name="ReadOnlyPropertiesGrid">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="Auto"/>
         <ColumnDefinition Width="*"/>
@@ -108,15 +118,9 @@
       <Label Grid.Row="4" Grid.Column="1" x:Name="LogsDirectoryLabel" 
              Margin="0, -10, 0,0"
                HorizontalAlignment="Stretch" VerticalAlignment="Top" />
-      <Label Grid.Row="5" Grid.Column="0" x:Name="RunAsServiceHeaderLabel" 
-             FontWeight="Bold"
-             Margin="0, -10, 0,0"
-             Content="{x:Static resx:ViewResources.NoticeView_RunAsServiceHeaderLabel}" 
+      <Label Grid.Row="5" Grid.Column="0" x:Name="RunAsServiceHeaderLabel" FontWeight="Bold" Margin="0, -10, 0,0" Content="{x:Static resx:ViewResources.NoticeView_RunAsServiceHeaderLabel}" 
              HorizontalAlignment="Left" VerticalAlignment="Top" />
-      <Label Grid.Row="5" Grid.Column="1" x:Name="RunAsServiceLabel" 
-             Margin="0, -10, 0,0" Content="Yes"
-               HorizontalAlignment="Stretch" VerticalAlignment="Top" />
-
+      <Label Grid.Row="5" Grid.Column="1" x:Name="RunAsServiceLabel" Margin="0, -10, 0,0" Content="Yes" HorizontalAlignment="Stretch" VerticalAlignment="Top" />
     </Grid>
   </Grid>
 </controls:StepControl>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml.cs
@@ -44,11 +44,21 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 					this.ExistingVersionTextBox.Visibility = v ? Visible : Collapsed;
 				});
 
+			//Using a separate observable in the case we add more parameters to the control grid on the notice model
+			this.WhenAny(view => view.ViewModel.InstalledAsService, v => v.GetValue())
+				.Subscribe(v =>
+				{
+					this.ControlGrid.Visibility = v ? Visible : Collapsed;
+				});
+
 			this.WhenAny(view => view.ViewModel.InstalledAsService, v=>v.GetValue())
 				.Subscribe(v => {
 					this.RunAsServiceHeaderLabel.Visibility = v ? Visible : Collapsed;
 					this.RunAsServiceLabel.Visibility = v ? Visible : Collapsed;
+					this.StartServiceAfterInstallCheckBox.Visibility = v ? Visible : Collapsed;
 				});
+			
+			this.Bind(ViewModel, vm => vm.ServiceModel.StartAfterInstall, v => v.StartServiceAfterInstallCheckBox.IsChecked);
 		}
 	}
 }

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -24,7 +24,6 @@ namespace Elastic.InstallerHosts.Elasticsearch
 		public void Application_Startup(object sender, StartupEventArgs e)
 		{
 			var state = InstallationModelTester.ValidPreflightChecks(s => s
-				.ServicePreviouslyInstalled()
 				.Wix(currentVersion:"6.1.0", existingVersion:"6.0.0")
 			);
 			var model = state.InstallationModel;

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -10,6 +10,7 @@ using Elastic.Installer.Domain.Configuration.Wix;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 using Elastic.Installer.Domain.Model.Base.Closing;
 using Elastic.Installer.Domain.Model.Elasticsearch;
+using Elastic.Installer.Domain.Tests.Elasticsearch.Models;
 using Elastic.Installer.UI.Elasticsearch;
 using ReactiveUI;
 
@@ -22,8 +23,11 @@ namespace Elastic.InstallerHosts.Elasticsearch
 	{
 		public void Application_Startup(object sender, StartupEventArgs e)
 		{
-			var wix = new WixStateProvider(Product.Elasticsearch, "6.0.0");
-			var model = ElasticsearchInstallationModel.Create(wix, NoopSession.Elasticsearch);
+			var state = InstallationModelTester.ValidPreflightChecks(s => s
+				.ServicePreviouslyInstalled()
+				.Wix(currentVersion:"6.1.0", existingVersion:"6.0.0")
+			);
+			var model = state.InstallationModel;
 
 			var window = new MainWindow(model, new ManualResetEvent(false));
 			model.InstallUITask = async () =>
@@ -35,7 +39,7 @@ namespace Elastic.InstallerHosts.Elasticsearch
 			window.Show();
 
 			RxApp.MainThreadScheduler = new DispatcherScheduler(Application.Current.Dispatcher);
-			Application.Current.Resources["InstallerTitle"] = wix.CurrentVersion.ToString();
+			Application.Current.Resources["InstallerTitle"] = model.ClosingModel.CurrentVersion.ToString();
 		}
 	}
 }

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/Elastic.InstallerHosts.Elasticsearch.csproj
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/Elastic.InstallerHosts.Elasticsearch.csproj
@@ -25,7 +25,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -114,10 +113,6 @@
       <Project>{faeee7b2-9bad-40c3-81fe-ff81f7b1291f}</Project>
       <Name>Elastic.Configuration</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\InstallerHosts\Elastic.InstallerHosts\Elastic.InstallerHosts.csproj">
-      <Project>{0d75a3ab-8569-4739-9f18-f5972dd276b2}</Project>
-      <Name>Elastic.Domain.Installer</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Installer\Elastic.Installer.Domain\Elastic.Installer.Domain.csproj">
       <Project>{d49c6dc3-0df0-4455-bd19-88aee8de51c1}</Project>
       <Name>Elastic.Installer.Domain</Name>
@@ -125,6 +120,10 @@
     <ProjectReference Include="..\..\Installer\Elastic.Installer.UI\Elastic.Installer.UI.csproj">
       <Project>{d22b47af-05f4-4e52-9211-05672a12ee0d}</Project>
       <Name>Elastic.Installer.UI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Tests\Elastic.Domain.Tests\Elastic.Domain.Tests.csproj">
+      <Project>{7453d0b7-4972-476e-9529-a6f0573948cd}</Project>
+      <Name>Elastic.Domain.Tests</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Elastic.ProcessHosts.Elasticsearch.csproj
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Elastic.ProcessHosts.Elasticsearch.csproj
@@ -23,7 +23,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>

--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
@@ -103,8 +103,7 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 			if (this.Started || string.IsNullOrWhiteSpace(message)) return;
 
 			if (!started) return;
-			this.BlockingSubject.OnNext(this.StartedHandle);
-			this.Started = true;
+			this.RunningState = RunningState.ConfirmedStarted;
 			this.StartedHandle.Set();
 		}
 

--- a/src/ProcessHosts/Elastic.ProcessHosts/Kibana/Process/KibanaProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Kibana/Process/KibanaProcess.cs
@@ -113,8 +113,7 @@ namespace Elastic.ProcessHosts.Kibana.Process
 			if (!message.TryGetStartedConfirmation(out string host, out int? port)) return;
 			this.Host = host;
 			this.Port = port;
-			this.BlockingSubject.OnNext(this.StartedHandle);
-			this.Started = true;
+			this.RunningState = RunningState.ConfirmedStarted;
 			this.StartedHandle.Set();
 		}
 	}

--- a/src/ProcessHosts/Elastic.ProcessHosts/Process/ObservableProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Process/ObservableProcess.cs
@@ -17,7 +17,14 @@ namespace Elastic.ProcessHosts.Process
 		private bool Started { get; set; }
 		public int LastExitCode { get; private set; }
 		public bool UserInteractive => Environment.UserInteractive;
-		public TimeSpan WaitForStarted => TimeSpan.FromMinutes(2);
+		/*
+		 * From: https://msdn.microsoft.com/en-us/library/windows/desktop/ms686321(v=vs.85).aspx
+		 * As with ControlService, StartService will block for 30 seconds if any service is busy handling a control code.
+		 * If the busy service still has not returned from its handler function when the timeout expires,
+		 * StartService fails with ERROR_SERVICE_REQUEST_TIMEOUT. This is because the SCM processes only one service control notification at a time.
+		 * 
+		 */
+		public TimeSpan WaitForStarted => TimeSpan.FromSeconds(25);
 
 		private IObservable<ConsoleOut> OutStream { get; set; }
 

--- a/src/ProcessHosts/Elastic.ProcessHosts/Process/ProcessBase.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Process/ProcessBase.cs
@@ -78,10 +78,9 @@ namespace Elastic.ProcessHosts.Process
 			this.Disposables.Add(observable.Connect());
 
 			var timeout = this._process.WaitForStarted;
-			if (this.StartedHandle.WaitOne(timeout, true)) return;
-
-			this.Stop();
-			throw new StartupException($"Could not start process within ({timeout}): {bin} {string.Join(" ", args)}");
+			//we wait for 1 minute to attempt a clean start (meaning when the service is started elasticsearch is started)
+			//this is a best effort, elasticsearch could take longer to start if it needs to relocate shards for instance
+			this.StartedHandle.WaitOne(timeout, true);
 		}
 
 		public void Stop()

--- a/src/ProcessHosts/Elastic.ProcessHosts/Process/ProcessBase.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Process/ProcessBase.cs
@@ -18,7 +18,7 @@ namespace Elastic.ProcessHosts.Process
 
 		protected string ProcessExe { get; set; }
 		protected IEnumerable<string> Arguments { private get; set; }
-		protected bool Started { get; set; }
+		public bool Started { get; protected set; }
 		protected string HomeDirectory { get; set; }
 		protected string ConfigDirectory { get; set; }
 

--- a/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
+++ b/src/Tests/Elastic.Domain.Tests/Elastic.Domain.Tests.csproj
@@ -15,6 +15,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -22,16 +23,15 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Observing/HandlerTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Observing/HandlerTests.cs
@@ -14,6 +14,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 			.Start(s =>
 			{
 				s.OutHandler.Handled.Count.Should().Be(StartedSession.Count);
+				s.Process.RunningState.Should().Be(RunningState.ConfirmedStarted);
 			});
 
 		[Fact] public void HandlerDoesNotSeeMessagesAfterStarted() => AllDefaults(new ConsoleSession(StartedSession)
@@ -22,6 +23,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 			.Start(s =>
 			{
 				s.OutHandler.Handled.Count.Should().Be(StartedSession.Count);
+				s.Process.RunningState.Should().Be(RunningState.ConfirmedStarted);
 			});
 
 		[Fact] public void StartedMessageFromWrongSectionIsIgnored() => AllDefaults(new ConsoleSession(BeforeStartedSession)
@@ -31,7 +33,8 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 			.Start(s =>
 			{
 				s.OutHandler.Handled.Count.Should().Be(BeforeStartedSession.Count + 1);
-				s.Process.Started.Should().BeFalse();
+				s.Process.Started.Should().BeTrue();
+				s.Process.RunningState.Should().Be(RunningState.AssumedStarted);
 			});
 
 		[Fact] public void UncaughtExceptionThrowBeforeStartedThrows() => AllDefaults(new ConsoleSession(BeforeStartedSession)
@@ -43,6 +46,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 				s.OutHandler.Handled.Count.Should().Be(BeforeStartedSession.Count);
 				e.Should().BeOfType<Exception>();
 				e.Message.Should().Contain("funky");
+				s.Process.RunningState.Should().Be(RunningState.Stopped);
 			});
 
 		[Fact] public void UncaughtExceptionThrowAfterStartedThrows() => AllDefaults(new ConsoleSession(StartedSession)
@@ -54,6 +58,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 				s.OutHandler.Handled.Count.Should().Be(StartedSession.Count);
 				e.Should().BeOfType<Exception>();
 				e.Message.Should().Contain("funky");
+				s.Process.RunningState.Should().Be(RunningState.Stopped);
 			});
 
 		[Fact] public void StartupExceptionThrowBeforeStartedThrows() => AllDefaults(new ConsoleSession(BeforeStartedSession)
@@ -64,6 +69,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 			{
 				s.OutHandler.Handled.Count.Should().Be(BeforeStartedSession.Count);
 				e.Should().BeOfType<StartupException>();
+				s.Process.RunningState.Should().Be(RunningState.Stopped);
 			});
 
 		[Fact] public void StartupExceptionThrowAfterStartedThrows() => AllDefaults(new ConsoleSession(StartedSession)
@@ -74,6 +80,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 			{
 				s.OutHandler.Handled.Count.Should().Be(StartedSession.Count);
 				e.Should().BeOfType<StartupException>();
+				s.Process.RunningState.Should().Be(RunningState.Stopped);
 			});
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Observing/HandlerTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Observing/HandlerTests.cs
@@ -28,11 +28,10 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Observing
 			{
 				{"[x][INFO ][o.e.n.NodeXX] [N] started"}
 			})
-			.StartThrows((e, s) =>
+			.Start(s =>
 			{
 				s.OutHandler.Handled.Count.Should().Be(BeforeStartedSession.Count + 1);
-				e.Should().BeOfType<StartupException>();
-				e.Message.Should().Contain("Could not start process within");
+				s.Process.Started.Should().BeFalse();
 			});
 
 		[Fact] public void UncaughtExceptionThrowBeforeStartedThrows() => AllDefaults(new ConsoleSession(BeforeStartedSession)


### PR DESCRIPTION
This removes the stop after the process fails to start after `2m` we still attempt to block for `25s` to aid a completely new installation. 

When upgrading through the UI the user can now also opt to not start the service:

![image](https://user-images.githubusercontent.com/245275/35862087-a981ea82-0b4a-11e8-9205-3aee98a1460e.png)

Which is only visible if the previous installation was installed as a service:

![image](https://user-images.githubusercontent.com/245275/35862175-f7cab426-0b4a-11e8-80b5-dee31f9d31f2.png)



This PR also has `InstallerHost.Elasticsearch` (only used to develop the UI) reference the tests so that we can start the UI in various states more easily using the `InstallerModelTester`