### PR TITLE
Bug/reset ui states

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Notice/NoticeModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Notice/NoticeModel.cs
@@ -5,6 +5,7 @@ using Elastic.Installer.Domain.Configuration.Wix;
 using Elastic.Installer.Domain.Model.Base;
 using Elastic.Installer.Domain.Model.Base.Service;
 using Elastic.Installer.Domain.Model.Elasticsearch.Locations;
+using Elastic.Installer.Domain.Model.Elasticsearch.XPack;
 using Elastic.Installer.Domain.Properties;
 using ReactiveUI;
 using Semver;
@@ -13,7 +14,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Notice
 {
 	public class NoticeModel : StepBase<NoticeModel, NoticeModelValidator>
 	{
-		private static readonly SemVersion XPackInstalledByDefaultVersion = "6.3.0";
 		private readonly IServiceStateProvider _serviceStateProvider;
 
 		public NoticeModel(
@@ -66,7 +66,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Notice
 			if (!string.IsNullOrWhiteSpace(this.UpgradeTextHeader))
 				this.UpgradeTextHeader = string.Format(this.UpgradeTextHeader, versionConfig.PreviousVersion, versionConfig.InstallerVersion);
 
-			this.ShowOpeningXPackBanner = this.ExistingVersion < XPackInstalledByDefaultVersion;
+			this.ShowOpeningXPackBanner = this.ExistingVersion < XPackModel.XPackInstalledByDefaultVersion;
 			this.ShowUpgradeDocumentationLink = versionConfig.VersionChange == VersionChange.Major || versionConfig.VersionChange == VersionChange.Minor;
 			
 			this.ExistingVersionInstalled = versionConfig.ExistingVersionInstalled;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -11,7 +11,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 	public class XPackModel : StepBase<XPackModel, XPackModelValidator>
 	{
 		public const XPackLicenseMode DefaultXPackLicenseMode = XPackLicenseMode.Basic;
-		
+		public static readonly SemVersion XPackInstalledByDefaultVersion = "6.3.0";
+
 		public XPackModel(VersionConfiguration versionConfig,
 			IObservable<bool> canAutomaticallySetupUsers,
 			IObservable<bool> upgradeFromXPackPlugin)
@@ -21,7 +22,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 				//show x-pack tab when we're upgrading from a version lower than `6.3.0` and the x-pack plugin was not installed.
 				//otherwise assume x-pack is installed and only show the tab on new installs
 				this.IsRelevant = 
-					(versionConfig.InstallationDirection == Up && versionConfig.PreviousVersion < "6.3.0" && !b) 
+					(versionConfig.InstallationDirection == Up && versionConfig.PreviousVersion < XPackInstalledByDefaultVersion && !b) 
 					|| versionConfig.InstallationDirection == None;
 			});
 			
@@ -44,6 +45,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			this.LogstashSystemUserPassword = null;
 			this.BootstrapPassword = null;
 			this.XPackSecurityEnabled = false;
+			this.XPackLicense = DefaultXPackLicenseMode;
 		}
 
 		public SemVersion CurrentVersion { get; }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/XPack/XPackModel.cs
@@ -33,7 +33,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			this.Header = "X-Pack";
 			this.CurrentVersion = versionConfig.InstallerVersion;
 			this.OpenLicensesAndSubscriptions = ReactiveCommand.Create();
-			this.RegisterBasicLicense = ReactiveCommand.Create();
 			this.OpenManualUserConfiguration = ReactiveCommand.Create();
 			this.Refresh();
 		}
@@ -123,8 +122,6 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.XPack
 			&& this.XPackSecurityEnabled;
 
 		public ReactiveCommand<object> OpenLicensesAndSubscriptions { get; }
-
-		public ReactiveCommand<object> RegisterBasicLicense { get; }
 
 		public ReactiveCommand<object> OpenManualUserConfiguration { get; }
 

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/ConfigurationView.xaml
@@ -119,8 +119,7 @@
                                    TextAlignment="Left" IsReadOnly="True"
                                      StringFormat="{x:Static resx:ViewResources.ConfigurationView_MinimumMasterNodesNotSet}"
                                      />
-      <Label Grid.Row="5" Grid.Column="0"  x:Name="UnicastHostsLabel" Content="{x:Static resx:ViewResources.ConfigurationView_UnicastHostsLabel}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-      <Label Grid.Row="5" Grid.Column="1"  Content="{x:Static resx:ViewResources.ConfigurationView_UnicastExplanationLabel}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+      <Label Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"  x:Name="UnicastHostsLabel" Content="{x:Static resx:ViewResources.ConfigurationView_UnicastHostsLabel}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
       <ListBox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4" x:Name="UnicastNodesListBox" 
                Margin="5, 0, 0, 0"
                VerticalContentAlignment="Stretch" 

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml
@@ -82,14 +82,14 @@
          <Image Source="{DynamicResource XPackLogo}"/>
       </Viewbox>
       <StackPanel Grid.Row="1" Grid.Column="1" x:Name="XPackStackPanel">
-          <TextBlock Text="is now included by default" 
+        <TextBlock Text="{x:Static resx:ViewResources.NoticeView_XPackIncludedByDefault}" 
                      VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0 10 0 0" 
                      Foreground="{DynamicResource VersionColorBrush}" FontSize="26"
                      FontFamily="{DynamicResource OpenSans}" FontWeight="Normal"
                      />
           <Button x:Name="ReadMoreOnXPackOpening"  Style="{DynamicResource Link}"
                      Margin="0, 0, 0,0"
-                     Content="Find out more about the opening of x-pack" 
+                     Content="{x:Static resx:ViewResources.NoticeView_ReadMoreOnXPackOpening}" 
                      HorizontalAlignment="Left" VerticalAlignment="Top"/>
         
       </StackPanel>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/NoticeView.xaml.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Windows;
 using Elastic.Installer.Domain.Model.Elasticsearch.Notice;
-using Elastic.Installer.Domain.Properties;
 using Elastic.Installer.UI.Controls;
 using Elastic.Installer.UI.Properties;
 using ReactiveUI;
@@ -25,12 +24,19 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 
 		protected override void InitializeBindings()
 		{
+			var visibility = ViewModel.InstalledAsService ? Visible : Collapsed;
+			RunAsServiceHeaderLabel.Visibility = visibility;
+			RunAsServiceLabel.Visibility = visibility;
+			StartServiceAfterInstallCheckBox.Visibility = visibility;
+
 			this.OneWayBind(ViewModel, vm => vm.UpgradeText, view => view.UpgradeTextBox.Text);
 			this.OneWayBind(ViewModel, vm => vm.UpgradeTextHeader, view => view.UpgradeLabel.Content);
 			this.OneWayBind(ViewModel, vm => vm.LocationsModel.InstallDir, view => view.InstallationDirectoryLabel.Content);
 			this.OneWayBind(ViewModel, vm => vm.LocationsModel.DataDirectory, view => view.DataDirectoryLabel.Content);
 			this.OneWayBind(ViewModel, vm => vm.LocationsModel.ConfigDirectory, view => view.ConfigDirectoryLabel.Content);
 			this.OneWayBind(ViewModel, vm => vm.LocationsModel.LogsDirectory, view => view.LogsDirectoryLabel.Content);
+			this.Bind(ViewModel, vm => vm.InstalledAsService, v => v.StartServiceAfterInstallCheckBox.IsChecked);
+			this.Bind(ViewModel, vm => vm.ServiceModel.StartAfterInstall, v => v.StartServiceAfterInstallCheckBox.IsChecked);
 
 			var majorMinor = $"{this.ViewModel.CurrentVersion.Major}.{this.ViewModel.CurrentVersion.Minor}";
 			this.BindCommand(ViewModel, vm => vm.ReadMoreOnUpgrades, v => v.ReadMoreOnUpgrades, nameof(ReadMoreOnUpgrades.Click));
@@ -43,8 +49,7 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 				.Subscribe(b =>
 				{
 					this.XPackLogo.Visibility = b ? Visible : Collapsed;
-					this.XPackStackPanel.Visibility = b ? Visible : Collapsed;
-					
+					this.XPackStackPanel.Visibility = b ? Visible : Collapsed;				
 				});
 
 			this.WhenAnyValue(view => view.ViewModel.ExistingVersionInstalled, view => view.ViewModel.ShowUpgradeDocumentationLink)
@@ -54,22 +59,6 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 					this.ReadOnlyPropertiesGrid.Visibility = installed ? Visible : Collapsed;
 					this.ReadMoreOnUpgrades.Visibility = installed && showUpgrade ? Visible : Collapsed;
 				});
-
-			//Using a separate observable in the case we add more parameters to the control grid on the notice model
-			this.WhenAny(view => view.ViewModel.InstalledAsService, v => v.GetValue())
-				.Subscribe(v =>
-				{
-					this.ControlGrid.Visibility = v ? Visible : Collapsed;
-				});
-
-			this.WhenAny(view => view.ViewModel.InstalledAsService, v=>v.GetValue())
-				.Subscribe(v => {
-					this.RunAsServiceHeaderLabel.Visibility = v ? Visible : Collapsed;
-					this.RunAsServiceLabel.Visibility = v ? Visible : Collapsed;
-					this.StartServiceAfterInstallCheckBox.Visibility = v ? Visible : Collapsed;
-				});
-			
-			this.Bind(ViewModel, vm => vm.ServiceModel.StartAfterInstall, v => v.StartServiceAfterInstallCheckBox.IsChecked);
 		}
 	}
 }

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/XPackView.xaml.cs
@@ -49,7 +49,6 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 			this.BindCommand(ViewModel, vm => vm.OpenManualUserConfiguration, v => v.OpenManualUserConfigurationLink, nameof(OpenManualUserConfigurationLink.Click));
 
 			this.ViewModel.OpenLicensesAndSubscriptions.Subscribe(x => Process.Start(ViewResources.XPackView_OpenLicensesAndSubscriptions));
-			this.ViewModel.RegisterBasicLicense.Subscribe(x => Process.Start(ViewResources.XPackView_RegisterBasicLicense));
 
 			var majorMinor = $"{this.ViewModel.CurrentVersion.Major}.{this.ViewModel.CurrentVersion.Minor}";
 			this.ViewModel.OpenManualUserConfiguration.Subscribe(x => Process.Start(string.Format(ViewResources.XPackView_ManualUserConfiguration, majorMinor)));

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.Designer.cs
@@ -433,7 +433,7 @@ namespace Elastic.Installer.UI.Properties {
         ///   Looks up a localized string similar to This step allows you to specify some settings found in the [b]elasticsearch.yml[/b] and [b]jvm.options[/b] files located in the [b]config[/b] folder.  We&apos;re only exposing common settings here that you almost always want to change.  Any options not shown here must be set manually in the files after the installation has been completed.
         ///
         ///
-        ///[b]Cluster name[/b]: The name of the cluster this Elasticsearch node should be a part of.  The cluster name is used to discover and auto-join other nodes.  It is important no [rest of string was truncated]&quot;;.
+        ///[b]Cluster name[/b]: The name of the cluster this Elasticsearch node should be a part of.  The cluster name is used to discover and auto-join other nodes.  It is important [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Elasticsearch_Help {
             get {
@@ -485,7 +485,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Server name[/b]: A human-readable display name that identifies this Kibana instance.
         ///
-        ///[b]Base Path[/b]: Enables you to specify a path to m [rest of string was truncated]&quot;;.
+        ///[b]Base Path[/b]: Enables you to specify a pa [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationView_Kibana_Help {
             get {
@@ -665,15 +665,6 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
-        /// </summary>
-        public static string ConfigurationView_UnicastExplanationLabel {
-            get {
-                return ResourceManager.GetString("ConfigurationView_UnicastExplanationLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unicast Hosts.
         /// </summary>
         public static string ConfigurationView_UnicastHostsLabel {
@@ -762,7 +753,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Index Name[/b]: Kibana uses an index in Elasticsearch to store saved searches, visualizations and dashboards. Kibana creates a new index if the index doesn’t already exist.
         ///
-        ///[b]Username[/b] and [b]Password[/b]: If your Elasticsearch is protected with basic authentication, these settings provide the username and password that the Kiba [rest of string was truncated]&quot;;.
+        ///[b]Username[/b] and [b]Password[/b]: If your Elasticsearch is protected with basic authentication, these settings provide the username and password that t [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConnectingView_Kibana_Help {
             get {
@@ -1042,7 +1033,7 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]Config[/b]: The directory where Elasticsearch will store its configuration files.
         ///
-        ///It is a best practice to keep your logs, config, and data directories separate from yo [rest of string was truncated]&quot;;.
+        ///It is a best practice to keep your logs, config, and data directories separa [rest of string was truncated]&quot;;.
         /// </summary>
         public static string LocationsView_Elasticsearch_Help {
             get {
@@ -1137,9 +1128,9 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Heya! Welcome the {0} Windows intaller.
+        ///   Looks up a localized string similar to Heya! Welcome the {0} Windows Installer.
         ///
-        ///This installer will walk you through various steps to help you configure and install {0} on your system.  To make things easier, we&apos;ve gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you may want to change..
+        ///This installer will walk you through various steps to help you configure and install {0} on your system.  To make things easier, we&apos;ve gone ahead and pre-populated everything with sensible defaults, but there are a few things you may want to change..
         /// </summary>
         public static string MainWindow_Help {
             get {
@@ -1330,6 +1321,15 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Read more about the opening of X-Pack.
+        /// </summary>
+        public static string NoticeView_ReadMoreOnXPackOpening {
+            get {
+                return ResourceManager.GetString("NoticeView_ReadMoreOnXPackOpening", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Read only properties during upgrade.
         /// </summary>
         public static string NoticeView_ReadOnlyPropertiesHeader {
@@ -1344,6 +1344,15 @@ namespace Elastic.Installer.UI.Properties {
         public static string NoticeView_RunAsServiceHeaderLabel {
             get {
                 return ResourceManager.GetString("NoticeView_RunAsServiceHeaderLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to is now included by default.
+        /// </summary>
+        public static string NoticeView_XPackIncludedByDefault {
+            get {
+                return ResourceManager.GetString("NoticeView_XPackIncludedByDefault", resourceCulture);
             }
         }
         
@@ -1375,11 +1384,11 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), custom discovery, and more.
+        ///   Looks up a localized string similar to Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom datatypes for mapping, custom analyzers (in a more built-in fashion), custom discovery, and more.
         ///
-        ///We&apos;ve only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins are downloaded at installation time.
+        ///We&apos;ve only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins selected within the installer will be downloaded at installation time, so an internet connection must be available.
         ///
-        ///It is common for many companies to set up a proxy through which resources will be downloaded from the internet. As such, you may need to specify [rest of string was truncated]&quot;;.
+        ///It is common for many companies to set up a proxy thr [rest of string was truncated]&quot;;.
         /// </summary>
         public static string PluginsView_Elasticsearch_Help {
             get {
@@ -1684,97 +1693,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uninstall Elasticsearch.
-        /// </summary>
-        public static string SilentSetup__Uninstall {
-            get {
-                return ResourceManager.GetString("SilentSetup__Uninstall", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can not start setup because of conflicting parameters e.g specifying /i and /u.
-        /// </summary>
-        public static string SilentSetup_AmbiguousFlags {
-            get {
-                return ResourceManager.GetString("SilentSetup_AmbiguousFlags", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Options signal how and what routine the setup should run.
-        /// </summary>
-        public static string SilentSetup_CommandLineOptions {
-            get {
-                return ResourceManager.GetString("SilentSetup_CommandLineOptions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Variables control the values used during (un)installation.
-        /// </summary>
-        public static string SilentSetup_CommandLineVariables {
-            get {
-                return ResourceManager.GetString("SilentSetup_CommandLineVariables", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Installs Elasticsearch on Windows. Run without arguments for interactive setup or with command line options for silent setup..
-        /// </summary>
-        public static string SilentSetup_Description {
-            get {
-                return ResourceManager.GetString("SilentSetup_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Display help text and exit.
-        /// </summary>
-        public static string SilentSetup_Help {
-            get {
-                return ResourceManager.GetString("SilentSetup_Help", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Install Variables.
-        /// </summary>
-        public static string SilentSetup_InstallVariables {
-            get {
-                return ResourceManager.GetString("SilentSetup_InstallVariables", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Options.
-        /// </summary>
-        public static string SilentSetup_Options {
-            get {
-                return ResourceManager.GetString("SilentSetup_Options", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Elasticsearch {0} Installer.
-        /// </summary>
-        public static string SilentSetup_Title {
-            get {
-                return ResourceManager.GetString("SilentSetup_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Uninstall Variables.
-        /// </summary>
-        public static string SilentSetup_UninstallVariables {
-            get {
-                return ResourceManager.GetString("SilentSetup_UninstallVariables", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Access to all free x-pack features without an expiry date on the license. 
+        ///   Looks up a localized string similar to Access to all free X-Pack Basic features without an expiry date on the license. 
         ///    .
         /// </summary>
         public static string XPackView_BasicDescription {
@@ -1806,11 +1725,9 @@ namespace Elastic.Installer.UI.Properties {
         ///
         ///[b]License[/b]: This setting specifies the type of license to apply to X-Pack. 
         ///
-        ///    A [b]Basic license[/b] is free and provides access only to a subset of X-Pack features. 
+        ///    A [b]Basic license[/b] is free and provides access only to a subset of X-Pack features. A Basic license does not expire and you do not need to register it.
         ///
-        ///    A [b]Trial license[/b] provides access to all of the X-Pack Enterprise features, including Machine Learning, Graph, Alerting, Security, amongst others.
-        ///
-        ///    Both Basic and Trial licenses applied are valid for 30 days. You can register to receive a free 1 year Basic license  [rest of string was truncated]&quot;;.
+        ///    A [b]Trial license[/b] provides access to all of the X-Pack features, including Machine Learning, Graph, Alerting, Security, amongst others. A Trial license is valid for 30 days after which time X-Pack [rest of string was truncated]&quot;;.
         /// </summary>
         public static string XPackView_Elasticsearch_Help {
             get {
@@ -1891,7 +1808,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Elasticsearch system users need to be setup manually. Either you are not installing as a service that gets started after installation, or you&apos;ve opted to start Elasticsearch manually when needed..
+        ///   Looks up a localized string similar to Elasticsearch built-in users need to be setup manually. Either you are not installing as a service that gets started after installation, or you&apos;ve opted to start Elasticsearch manually when needed..
         /// </summary>
         public static string XPackView_ManualUserConfigurationNeeded {
             get {
@@ -1918,24 +1835,6 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://register.elastic.co/.
-        /// </summary>
-        public static string XPackView_RegisterBasicLicense {
-            get {
-                return ResourceManager.GetString("XPackView_RegisterBasicLicense", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Register for a free Basic license .
-        /// </summary>
-        public static string XPackView_RegisterBasicLicenseLink {
-            get {
-                return ResourceManager.GetString("XPackView_RegisterBasicLicenseLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Security.
         /// </summary>
         public static string XPackView_SecurityLabel {
@@ -1954,7 +1853,7 @@ namespace Elastic.Installer.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access to all X-Pack Enterprise features for 30 days, including Machine Learning, Graph, Alerting, Security, and others.
+        ///   Looks up a localized string similar to Access to all X-Pack features for 30 days, including Machine Learning, Graph, Alerting, Security, and others.
         ///    .
         /// </summary>
         public static string XPackView_TrialDescription {

--- a/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
+++ b/src/Installer/Elastic.Installer.UI/Properties/ViewResources.resx
@@ -177,9 +177,6 @@
   <data name="ConfigurationView_SliderLabel" xml:space="preserve">
     <value>Max</value>
   </data>
-  <data name="ConfigurationView_UnicastExplanationLabel" xml:space="preserve">
-    <value />
-  </data>
   <data name="ConfigurationView_UnicastHostsLabel" xml:space="preserve">
     <value>Unicast Hosts</value>
   </data>
@@ -305,18 +302,18 @@
     <value>Basic License</value>
   </data>
   <data name="XPackView_TrialDescription" xml:space="preserve">
-    <value>Access to all X-Pack Enterprise features for 30 days, including Machine Learning, Graph, Alerting, Security, and others.
+    <value>Access to all X-Pack features for 30 days, including Machine Learning, Graph, Alerting, Security, and others.
     </value>
   </data>
   <data name="XPackView_BasicDescription" xml:space="preserve">
-    <value>Access to all free x-pack features without an expiry date on the license. 
+    <value>Access to all free X-Pack Basic features without an expiry date on the license. 
     </value>
   </data>
   <data name="XPackView_SubscriptionsLink" xml:space="preserve">
     <value>Full overview of licences and subscriptions</value>
   </data>
   <data name="XPackView_ManualUserConfigurationNeeded" xml:space="preserve">
-    <value>Elasticsearch system users need to be setup manually. Either you are not installing as a service that gets started after installation, or you've opted to start Elasticsearch manually when needed.</value>
+    <value>Elasticsearch built-in users need to be setup manually. Either you are not installing as a service that gets started after installation, or you've opted to start Elasticsearch manually when needed.</value>
   </data>
   <data name="XPackView_ManualUserConfigurationLink" xml:space="preserve">
     <value>How to setup users manually</value>
@@ -458,17 +455,19 @@ X-Pack is a proprietary plugin that falls under the Elastic EULA.</value>
 
 [b]Node name[/b]: The unique name given to this particular Elasticsearch node.
 
-[b]Node role[/b]: The type(s) of role(s) this node should have.  If no roles are assigned, then it will act as a coordinating node, and only route requests to other nodes in your cluster.
+[b]Roles[/b]: The type(s) of role(s) this node should have.  If no roles are assigned, then it will act as a coordinating node, and only route requests to other nodes in your cluster.
 
 [b]Memory[/b]: The amount of memory to allocate to the JVM heap for Elasticsearch.  The standard rule of thumb is to allocate 50% of available memory to the heap, but never exceed 30.5 GB, leaving the remaining 50% free to ensure there is enough for kernel file system caches.  The 30.5 GB limit is recommended in order to prevent the JVM from entering 64-bit address space, which will result in a performance degradation.
 
-[b]Lock memory[/b]: Windows will try to use as much memory as possible for file system caches and eagerly swap out unused application memory, possibly resulting in the Elasticsearch process being swapped, which is very bad for performance and node stability. By choosing to lock memory, Elasticsearch will leverage the native VirtualLock function in Windows, in an effort to keep the JVM in physical memory at all times.
+[b]Lock JVM memory[/b]: Windows will try to use as much memory as possible for file system caches and eagerly swap out unused application memory, possibly resulting in the Elasticsearch process being swapped, which is very bad for performance and node stability. By choosing to lock memory, Elasticsearch will leverage the native VirtualLock function in Windows, in an effort to keep the JVM in physical memory at all times.
 
 [b]Network host[/b]: By default, Elasticsearch binds to loopback addresses only (e.g. [b]127.0.0.1[/b]).  This is sufficient to run a single development node on a server. However, in order to communicate to form a cluster on other servers, your node will need to bind to a non-loopback address.
 
 [b]HTTP port[/b]: The port to communicate with Elasticsearch REST API over HTTP.
 
-[b]Transport port[/b]: The port to use for node-to-node communication over the Elasticsearch transport protocol.</value>
+[b]Transport port[/b]: The port to use for node-to-node communication over the Elasticsearch transport protocol.
+
+[b]Unicast Hosts[/b]: A collection of hosts (with optional ports) to use for unicast discovery, a process for discovering nodes within a cluster, as well as electing a master node.</value>
   </data>
   <data name="LocationsView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Locations Help</value>
@@ -490,20 +489,20 @@ It is a best practice to keep your logs, config, and data directories separate f
     <value>Installation Help</value>
   </data>
   <data name="MainWindow_Help" xml:space="preserve">
-    <value>Heya! Welcome the {0} Windows intaller.
+    <value>Heya! Welcome the {0} Windows Installer.
 
-This installer will walk you through various steps to help you configure and install {0} on your system.  To make things easier, we've gone ahead and pre-populated everything with all of the sensible defaults, but there are a few things you may want to change.</value>
+This installer will walk you through various steps to help you configure and install {0} on your system.  To make things easier, we've gone ahead and pre-populated everything with sensible defaults, but there are a few things you may want to change.</value>
     <comment>{0} = Product name</comment>
   </data>
   <data name="PluginsView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Plugin Help</value>
   </data>
   <data name="PluginsView_Elasticsearch_Help" xml:space="preserve">
-    <value>Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom mapping types, custom analyzers (in a more built-in fashion), custom discovery, and more.
+    <value>Plugins are a way to enhance the core Elasticsearch functionality.  They range from adding custom datatypes for mapping, custom analyzers (in a more built-in fashion), custom discovery, and more.
 
-We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins are downloaded at installation time.
+We've only listed the official Elasticsearch plugins here, but there are many more community plugins that can be installed manually. Plugins selected within the installer will be downloaded at installation time, so an internet connection must be available.
 
-It is common for many companies to set up a proxy through which resources will be downloaded from the internet. As such, you may need to specify the host name and port of a corporate proxy to allow the installer to successfully install plugins. Since official Elasticsearch plugins are installed from 
+It is common for many companies to set up a proxy through which resources will be downloaded from the internet. As such, you may need to specify the host name and port of a corporate proxy to allow the installer to successfully install plugins. Since official Elasticsearch plugins are installed from
 https://artifacts.elastic.co, a HTTPS proxy can be specified.</value>
   </data>
   <data name="XPackView_Elasticsearch_Help_Header" xml:space="preserve">
@@ -514,21 +513,22 @@ https://artifacts.elastic.co, a HTTPS proxy can be specified.</value>
 
 [b]License[/b]: This setting specifies the type of license to apply to X-Pack. 
 
-    A [b]Basic license[/b] is free and provides access only to a subset of X-Pack features. 
+    A [b]Basic license[/b] is free and provides access only to a subset of X-Pack features. A Basic license does not expire and you do not need to register it.
 
-    A [b]Trial license[/b] provides access to all of the X-Pack Enterprise features, including Machine Learning, Graph, Alerting, Security, amongst others.
+    A [b]Trial license[/b] provides access to all of the X-Pack features, including Machine Learning, Graph, Alerting, Security, amongst others. A Trial license is valid for 30 days after which time X-Pack will operate in a degraded mode. See https://www.elastic.co/guide/en/x-pack/{0}/license-expiration.html for further details.
 
-    Both Basic and Trial licenses applied are valid for 30 days. You can register to receive a free 1 year Basic license at https://register.elastic.co/ and get in touch if you'd like to request information on other license types at https://www.elastic.co/subscriptions.
+    Get in touch if you'd like further information on licenses and subscriptions at https://www.elastic.co/subscriptions.
 
 [b]Enable X-Pack Security[/b]: Whether X-Pack Security should be enabled on the node. Enabling X-Pack Security will require authentication credentials to communicate with the cluster.
 
-[b]Defer setting up users until later[/b]: Whether the built-in user roles should be set up as part of installation. Setting these users up requires a running cluster as the credentials are stored within an index in the cluster.
+[b]Defer setting up users until later[/b]: Whether the built-in users should be set up as part of installation. Setting up built-in users requires a running cluster as the credentials are stored within an index in the cluster.
 
 [b]elastic[/b]: The password for the built-in 'elastic' user account.
 
 [b]kibana[/b]: The password for the built-in 'kibana' user account.
 
 [b]logstash system[/b]: The password for the built-in 'logstash_system' user account.</value>
+    <comment>{0} = major minor version</comment>
   </data>
   <data name="ServiceView_Elasticsearch_Help_Header" xml:space="preserve">
     <value>Service Help</value>
@@ -636,37 +636,6 @@ Alternatively, you may choose to not install Elasticsearch as a service and run 
   </data>
   <data name="InstallOptions_UnicastHosts" xml:space="preserve">
     <value>A comma-separated list of hosts to use for unicast discovery</value>
-  </data>
-  <data name="SilentSetup_CommandLineOptions" xml:space="preserve">
-    <value>Options signal how and what routine the setup should run</value>
-  </data>
-  <data name="SilentSetup_CommandLineVariables" xml:space="preserve">
-    <value>Variables control the values used during (un)installation</value>
-  </data>
-  <data name="SilentSetup_Options" xml:space="preserve">
-    <value>Options</value>
-  </data>
-  <data name="SilentSetup_InstallVariables" xml:space="preserve">
-    <value>Install Variables</value>
-  </data>
-  <data name="SilentSetup_UninstallVariables" xml:space="preserve">
-    <value>Uninstall Variables</value>
-  </data>
-  <data name="SilentSetup_Description" xml:space="preserve">
-    <value>Installs Elasticsearch on Windows. Run without arguments for interactive setup or with command line options for silent setup.</value>
-  </data>
-  <data name="SilentSetup_Help" xml:space="preserve">
-    <value>Display help text and exit</value>
-  </data>
-  <data name="SilentSetup_AmbiguousFlags" xml:space="preserve">
-    <value>Can not start setup because of conflicting parameters e.g specifying /i and /u</value>
-  </data>
-  <data name="SilentSetup_Title" xml:space="preserve">
-    <value>Elasticsearch {0} Installer</value>
-    <comment>{0} = Installer Version</comment>
-  </data>
-  <data name="SilentSetup__Uninstall" xml:space="preserve">
-    <value>Uninstall Elasticsearch</value>
   </data>
   <data name="LocationsView_KibanaCustomLocationsCheckBox" xml:space="preserve">
     <value>Place logs in the same directory</value>
@@ -847,16 +816,16 @@ Alternatively, you may choose to not install Kibana as a service and run it manu
   <data name="XPackView_OpenLicensesAndSubscriptions" xml:space="preserve">
     <value>https://www.elastic.co/subscriptions</value>
   </data>
-  <data name="XPackView_RegisterBasicLicense" xml:space="preserve">
-    <value>https://register.elastic.co/</value>
-  </data>
-  <data name="XPackView_RegisterBasicLicenseLink" xml:space="preserve">
-    <value>Register for a free Basic license </value>
-  </data>
   <data name="PluginsView_SetHttpsProxy_Message" xml:space="preserve">
     <value>Configure a HTTPS proxy through which to download plugins as part of installation. A proxy can be specified in the form of host or host:port. If no port is specified, defaults to using port 443.</value>
   </data>
   <data name="PluginsView_SetHttpsProxy_Title" xml:space="preserve">
     <value>HTTPS proxy</value>
+  </data>
+  <data name="NoticeView_ReadMoreOnXPackOpening" xml:space="preserve">
+    <value>Read more about the opening of X-Pack</value>
+  </data>
+  <data name="NoticeView_XPackIncludedByDefault" xml:space="preserve">
+    <value>is now included by default</value>
   </data>
 </root>

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockWixStateProvider.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockWixStateProvider.cs
@@ -7,7 +7,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 	{
 		public MockWixStateProvider()
 		{
-			this.InstallerVersion = "5.0.0-alpha5";
+			this.InstallerVersion = TestSetupStateProvider.DefaultTestVersion;
 		}
 
 		public SemVersion PreviousVersion { get; set; }


### PR DESCRIPTION
This PR fixes the following bugs within the reset states of elements within the UI:

- resets state of the StartServiceAfterInstall checkbox to respect the state of an existing version installed as a service.

    Removes reactive binding of visibility of control grid to the state of the InstalledAsService property - visibility is fixed after state initialization.
- resets the X-Pack view back to a Basic X-Pack license when the reset state button is pressed

Fixes #180 
Fixes #182

Also tidy up the wording used within resources to correct spelling, capitalisation and improve the descriptions within help panel.