### PR TITLE
Fix/force paths out es home

### DIFF
--- a/src/Elastic.Configuration/Elastic.Configuration.csproj
+++ b/src/Elastic.Configuration/Elastic.Configuration.csproj
@@ -47,6 +47,7 @@
     <Compile Include="EnvironmentBased\Java\JavaEnvironmentStateProvider.cs" />
     <Compile Include="EnvironmentBased\KibanaEnvironmentStateProvider.cs" />
     <Compile Include="Extensions\ExceptionEventLogExtensions.cs" />
+    <Compile Include="Extensions\StringPathExtensions.cs" />
     <Compile Include="FileBased\JvmOpts\LocalJvmOptionsConfiguration.cs" />
     <Compile Include="FileBased\Yaml\ElasticsearchYamlConfiguration.cs" />
     <Compile Include="FileBased\Yaml\ElasticsearchYamlSettings.cs" />

--- a/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentConfiguration.cs
+++ b/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentConfiguration.cs
@@ -42,15 +42,28 @@ namespace Elastic.Configuration.EnvironmentBased
 				StateProvider.ConfigDirectoryMachineVariable,
 			}
 			.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
-
-		public string HomeDirectory => new []
+		
+		public string HomeDirectoryFromEnvironmentVariable => new []
 			{
 				StateProvider.HomeDirectoryProcessVariable,
 				StateProvider.HomeDirectoryUserVariable,
-				StateProvider.HomeDirectoryMachineVariable,
+				StateProvider.HomeDirectoryMachineVariable
+			}
+			.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
+
+		public string HomeDirectory => new []
+			{
+				this.HomeDirectoryFromEnvironmentVariable,
 				this.HomeDirectoryInferred
 			}
 			.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
+
+		public string ConfigDirectoryFromEnvironmentVariable => new []
+		{
+			StateProvider.ConfigDirectoryProcessVariable,
+			StateProvider.ConfigDirectoryUserVariable,
+			StateProvider.ConfigDirectoryMachineVariable,
+		}.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
 
 		public string ConfigDirectory
 		{
@@ -73,22 +86,10 @@ namespace Elastic.Configuration.EnvironmentBased
 		{
 			get
 			{
-				var esHome = new[]
-				{
-					StateProvider.HomeDirectoryProcessVariable,
-					StateProvider.HomeDirectoryUserVariable,
-					StateProvider.HomeDirectoryMachineVariable,
-				}.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
-
+				var esHome = this.HomeDirectoryFromEnvironmentVariable;
 				if (string.IsNullOrWhiteSpace(esHome)) return false;
-				
-				var config = new []
-				{
-					StateProvider.ConfigDirectoryProcessVariable,
-					StateProvider.ConfigDirectoryUserVariable,
-					StateProvider.ConfigDirectoryMachineVariable,
-				}.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
-				
+
+				var config = this.ConfigDirectoryFromEnvironmentVariable;
 				return !string.IsNullOrWhiteSpace(config) && config.IsSubPathOf(esHome);
 			}
 		}

--- a/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentConfiguration.cs
+++ b/src/Elastic.Configuration/EnvironmentBased/ElasticsearchEnvironmentConfiguration.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using Elastic.Configuration.Extensions;
 
 namespace Elastic.Configuration.EnvironmentBased
 {
@@ -65,6 +66,30 @@ namespace Elastic.Configuration.EnvironmentBased
 
 				var homeDir = this.HomeDirectory;
 				return string.IsNullOrEmpty(homeDir) ? null : Path.Combine(homeDir, "config");
+			}
+		}
+
+		public bool ConfigDirectoryIsSpecifiedAndSubPathOfEsHome
+		{
+			get
+			{
+				var esHome = new[]
+				{
+					StateProvider.HomeDirectoryProcessVariable,
+					StateProvider.HomeDirectoryUserVariable,
+					StateProvider.HomeDirectoryMachineVariable,
+				}.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
+
+				if (string.IsNullOrWhiteSpace(esHome)) return false;
+				
+				var config = new []
+				{
+					StateProvider.ConfigDirectoryProcessVariable,
+					StateProvider.ConfigDirectoryUserVariable,
+					StateProvider.ConfigDirectoryMachineVariable,
+				}.FirstOrDefault(v=>!string.IsNullOrWhiteSpace(v));
+				
+				return !string.IsNullOrWhiteSpace(config) && config.IsSubPathOf(esHome);
 			}
 		}
 

--- a/src/Elastic.Configuration/Extensions/StringPathExtensions.cs
+++ b/src/Elastic.Configuration/Extensions/StringPathExtensions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+
+namespace Elastic.Configuration.Extensions
+{
+	public static class StringPathExtensions
+	{
+		/// <summary>
+		/// Returns true if <paramref name="path"/> starts with the path <paramref name="baseDirPath"/>.
+		/// The comparison is case-insensitive, handles / and \ slashes as folder separators and
+		/// only matches if the base dir folder name is matched exactly ("c:\foobar\file.txt" is not a sub path of "c:\foo").
+		/// </summary>
+		public static bool IsSubPathOf(this string path, string baseDirPath)
+		{
+			var normalizedPath = Path.GetFullPath(path.Replace('/', '\\')
+				.WithEnding("\\"));
+
+			var normalizedBaseDirPath = Path.GetFullPath(baseDirPath.Replace('/', '\\')
+				.WithEnding("\\"));
+
+			return normalizedPath.StartsWith(normalizedBaseDirPath, StringComparison.OrdinalIgnoreCase);
+		}
+
+		/// <summary>
+		/// Returns <paramref name="str"/> with the minimal concatenation of <paramref name="ending"/> (starting from end) that
+		/// results in satisfying .EndsWith(ending).
+		/// </summary>
+		/// <example>"hel".WithEnding("llo") returns "hello", which is the result of "hel" + "lo".</example>
+		private static string WithEnding(this string str, string ending)
+		{
+			if (str == null) return ending;
+
+			var result = str;
+
+			// Right() is 1-indexed, so include these cases
+			// * Append no characters
+			// * Append up to N characters, where N is ending length
+			for (var i = 0; i <= ending.Length; i++)
+			{
+				var tmp = result + ending.Right(i);
+				if (tmp.EndsWith(ending)) return tmp;
+			}
+
+			return result;
+		}
+
+		/// <summary>Gets the rightmost <paramref name="length" /> characters from a string.</summary>
+		/// <param name="value">The string to retrieve the substring from.</param>
+		/// <param name="length">The number of characters to retrieve.</param>
+		/// <returns>The substring.</returns>
+		private static string Right(this string value, int length)
+		{
+			if (value == null) throw new ArgumentNullException(nameof(value));
+			if (length < 0)
+				throw new ArgumentOutOfRangeException(nameof(length), length, "Length is less than zero");
+
+			return (length < value.Length) ? value.Substring(value.Length - length) : value;
+		}
+	}
+}

--- a/src/Elastic.Installer.sln
+++ b/src/Elastic.Installer.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{953B0596
 		..\.gitignore = ..\.gitignore
 		..\build.bat = ..\build.bat
 		..\paket.dependencies = ..\paket.dependencies
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "scripts", "..\build\scripts\scripts.fsproj", "{86F63532-E509-49A1-8D83-A4651E073B16}"

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -51,6 +51,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				nameof(JavaMisconfigured),
 				nameof(Using32BitJava),
 				nameof(BadElasticsearchYamlFile),
+				nameof(HasEsHomeVariableButNoPreviousInstallation),
 				nameof(ConfigDirectoryIsSpecifiedAndSubPathOfEsHome)
 			})
 			.ToArray();
@@ -250,6 +251,13 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			set => this.RaiseAndSetIfChanged(ref configDirectoryIsSpecifiedAndSubPathOfEsHome, value);
 		}
 		
+		bool hasEsHomeVariableButNoPreviousInstallation;
+		public bool HasEsHomeVariableButNoPreviousInstallation
+		{
+			get => hasEsHomeVariableButNoPreviousInstallation;
+			set => this.RaiseAndSetIfChanged(ref hasEsHomeVariableButNoPreviousInstallation, value);
+		}
+		
 		bool using32BitJava;
 		public bool Using32BitJava
 		{
@@ -270,6 +278,10 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 
 			this.JavaInstalled = JavaConfiguration.JavaInstalled;
 			this.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome = ElasticsearchEnvironmentConfiguration.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome;
+
+			this.HasEsHomeVariableButNoPreviousInstallation = 
+				!this.Installed && !string.IsNullOrWhiteSpace(ElasticsearchEnvironmentConfiguration.HomeDirectoryFromEnvironmentVariable);
+
 			this.JavaMisconfigured = JavaConfiguration.JavaMisconfigured;
 			this.Using32BitJava = JavaConfiguration.Using32BitJava;
 			this.BadElasticsearchYamlFile = _yamlConfiguration.FoundButNotValid;

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -50,7 +50,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 				nameof(JavaInstalled),
 				nameof(JavaMisconfigured),
 				nameof(Using32BitJava),
-				nameof(BadElasticsearchYamlFile)
+				nameof(BadElasticsearchYamlFile),
+				nameof(ConfigDirectoryIsSpecifiedAndSubPathOfEsHome)
 			})
 			.ToArray();
 
@@ -242,6 +243,13 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			set => this.RaiseAndSetIfChanged(ref badElasticsearchYamlFile, value);
 		}
 		
+		bool configDirectoryIsSpecifiedAndSubPathOfEsHome;
+		public bool ConfigDirectoryIsSpecifiedAndSubPathOfEsHome
+		{
+			get => configDirectoryIsSpecifiedAndSubPathOfEsHome;
+			set => this.RaiseAndSetIfChanged(ref configDirectoryIsSpecifiedAndSubPathOfEsHome, value);
+		}
+		
 		bool using32BitJava;
 		public bool Using32BitJava
 		{
@@ -261,6 +269,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			foreach (var step in this.AllSteps) step.Refresh();
 
 			this.JavaInstalled = JavaConfiguration.JavaInstalled;
+			this.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome = ElasticsearchEnvironmentConfiguration.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome;
 			this.JavaMisconfigured = JavaConfiguration.JavaMisconfigured;
 			this.Using32BitJava = JavaConfiguration.Using32BitJava;
 			this.BadElasticsearchYamlFile = _yamlConfiguration.FoundButNotValid;
@@ -277,6 +286,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			sb.AppendLine($"- {nameof(MsiLogFileLocation)} = " + MsiLogFileLocation);
 			sb.AppendLine($"- {nameof(JavaInstalled)} = " + JavaInstalled);
 			sb.AppendLine($"- {nameof(JavaMisconfigured)} = " + JavaMisconfigured);
+			sb.AppendLine($"- {nameof(ConfigDirectoryIsSpecifiedAndSubPathOfEsHome)} = " + ConfigDirectoryIsSpecifiedAndSubPathOfEsHome);
 			sb.AppendLine($"- {nameof(Using32BitJava)} = " + Using32BitJava);
 			sb.AppendLine($"- {nameof(BadElasticsearchYamlFile)} = " + BadElasticsearchYamlFile);
 			sb.AppendLine(this.NoticeModel.ToString());

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModelValidator.cs
@@ -10,6 +10,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 		public static readonly string AlreadyInstalled = TextResources.NoticeModelValidator_AlreadyInstalled;
 		public static readonly string HigherVersionInstalled = TextResources.NoticeModelValidator_HigherVersionInstalled;
 		public static readonly string ConfigDirectoryIsSpecifiedAndSubPathOfEsHome = TextResources.NoticeModelValidator_ConfigDirectoryIsSpecifiedAndSubPathOfEsHome;
+		public static readonly string HasEsHomeVariableButNoPreviousInstallation = TextResources.NoticeModelValidator_HasEsHomeVariableButNoPreviousInstallation;
 		public static readonly string JavaInstalled = TextResources.NoticeModelValidator_JavaInstalled;
 		public static readonly string JavaMisconfigured = TextResources.NoticeModelValidator_JavaMisconfigured;
 		public static readonly string Using32BitJava = TextResources.NoticeModelValidator_Using32BitJava;
@@ -27,6 +28,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			RuleFor(vm => vm.BadElasticsearchYamlFile).Must(b => !b).WithMessage(BadElasticsearchYamlFile);
 			
 			RuleFor(vm => vm.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome).Must(b => !b).WithMessage(ConfigDirectoryIsSpecifiedAndSubPathOfEsHome);
+
+			RuleFor(vm => vm.HasEsHomeVariableButNoPreviousInstallation).Must(b => !b).WithMessage(HasEsHomeVariableButNoPreviousInstallation);
 
 			RuleFor(vm => vm.SameVersionAlreadyInstalled)
 				.Must(b => !b)

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModelValidator.cs
@@ -9,6 +9,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 	{
 		public static readonly string AlreadyInstalled = TextResources.NoticeModelValidator_AlreadyInstalled;
 		public static readonly string HigherVersionInstalled = TextResources.NoticeModelValidator_HigherVersionInstalled;
+		public static readonly string ConfigDirectoryIsSpecifiedAndSubPathOfEsHome = TextResources.NoticeModelValidator_ConfigDirectoryIsSpecifiedAndSubPathOfEsHome;
 		public static readonly string JavaInstalled = TextResources.NoticeModelValidator_JavaInstalled;
 		public static readonly string JavaMisconfigured = TextResources.NoticeModelValidator_JavaMisconfigured;
 		public static readonly string Using32BitJava = TextResources.NoticeModelValidator_Using32BitJava;
@@ -24,6 +25,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			RuleFor(vm => vm.Using32BitJava).Must(b => !b).WithMessage(Using32BitJava);
 			
 			RuleFor(vm => vm.BadElasticsearchYamlFile).Must(b => !b).WithMessage(BadElasticsearchYamlFile);
+			
+			RuleFor(vm => vm.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome).Must(b => !b).WithMessage(ConfigDirectoryIsSpecifiedAndSubPathOfEsHome);
 
 			RuleFor(vm => vm.SameVersionAlreadyInstalled)
 				.Must(b => !b)

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModelValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using Elastic.Configuration.Extensions;
 using Elastic.Installer.Domain.Properties;
 using FluentValidation;
 
@@ -33,8 +34,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 				.Must(this.MustBeRooted).WithMessage(DirectoryMustNotBeRelative, ConfigurationText)
 				.Must(this.InstallOnKnownDrive)
 				.WithMessage(DirectoryUsesUnknownDrive, x => ConfigurationText, x => new DirectoryInfo(x.ConfigDirectory).Root.Name)
-				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, ConfigurationText)
-				.Must(this.NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, ConfigurationText)
+				.Must(NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, ConfigurationText)
+				.Must(NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, ConfigurationText)
 				.When(m=>!string.IsNullOrWhiteSpace(m.InstallDir));
 
 			RuleFor(vm => vm.DataDirectory)
@@ -43,8 +44,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 				.Must(this.MustBeRooted).WithMessage(DirectoryMustNotBeRelative, DataText)
 				.Must(this.InstallOnKnownDrive)
 				.WithMessage(DirectoryUsesUnknownDrive, x => DataText, x => new DirectoryInfo(x.DataDirectory).Root.Name)
-				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, DataText)
-				.Must(this.NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, DataText)
+				.Must(NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, DataText)
+				.Must(NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, DataText)
 				.When(m=>!string.IsNullOrWhiteSpace(m.InstallDir));
 
 			RuleFor(vm => vm.LogsDirectory)
@@ -53,8 +54,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 				.Must(this.MustBeRooted).WithMessage(DirectoryMustNotBeRelative, LogsText)
 				.Must(this.InstallOnKnownDrive)
 				.WithMessage(DirectoryUsesUnknownDrive, x => LogsText, x => new DirectoryInfo(x.LogsDirectory).Root.Name)
-				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, LogsText)
-				.Must(this.NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, LogsText)
+				.Must(NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, LogsText)
+				.Must(NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, LogsText)
 				.When(m=>!string.IsNullOrWhiteSpace(m.InstallDir));
 
 		}
@@ -77,16 +78,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 		private static readonly string X86ProgramFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 		private static readonly string ProgramFiles = LocationsModel.DefaultProgramFiles;
 
-		
-		public bool NotBeChildOfInstallationDirectory(LocationsModel model, string path) => !this.IsSubPathOf(model, model.InstallDir, path);
-		
-		public bool NotBeChildOfProgramFiles(LocationsModel model, string path) =>
-			!this.IsSubPathOf(model, X86ProgramFiles, path) && !this.IsSubPathOf(model, ProgramFiles, path);
+		private static bool NotBeChildOfInstallationDirectory(LocationsModel model, string path) => !path.IsSubPathOf(model.InstallDir);
 
-		public bool IsSubPathOf(LocationsModel model, string badParent, string path)
-		{
-			//if (!this.MustBeRooted(model, badParent) || !this.MustBeRooted(model, path)) return true;
-			return path.StartsWith(badParent, StringComparison.InvariantCultureIgnoreCase);
-		}
+		private static bool NotBeChildOfProgramFiles(LocationsModel model, string path) => !path.IsSubPathOf(X86ProgramFiles) && !path.IsSubPathOf(ProgramFiles);
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModelValidator.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 		public static readonly string DirectoryMustNotBeRelative = TextResources.LocationsModelValidator_DirectoryMustNotBeRelative;
 		public static readonly string DirectoryUsesUnknownDrive = TextResources.LocationsModelValidator_DirectoryUsesUnknownDrive;
 		public static readonly string DirectorySetToNonWritableLocation = TextResources.LocationsModelValidator_DirectorySetToNonWritableLocation;
-		public static readonly string DirectoryMustBeChildOf = TextResources.LocationsModelValidator_DirectoryMustBeChildOf;
+		public static readonly string DirectoryMustNotBeChildOf = TextResources.LocationsModelValidator_DirectoryMustNotBeChildOf;
 		public static readonly string Installation = TextResources.LocationsModelValidator_Installation;
 		public static readonly string ConfigurationText = TextResources.LocationsModelValidator_Configuration;
 		public static readonly string DataText = TextResources.LocationsModelValidator_Data;
@@ -33,12 +33,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 				.Must(this.MustBeRooted).WithMessage(DirectoryMustNotBeRelative, ConfigurationText)
 				.Must(this.InstallOnKnownDrive)
 				.WithMessage(DirectoryUsesUnknownDrive, x => ConfigurationText, x => new DirectoryInfo(x.ConfigDirectory).Root.Name)
-				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, ConfigurationText);
-
-			RuleFor(vm => vm.ConfigDirectory)
-				.Must((vm, conf) => this.IsSubPathOf(vm, vm.InstallDir, conf))
-				.When(vm => vm.PlaceWritableLocationsInSamePath)
-				.WithMessage(DirectoryMustBeChildOf, vm => ConfigurationText, vm => vm.InstallDir);
+				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, ConfigurationText)
+				.Must(this.NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, ConfigurationText)
+				.When(m=>!string.IsNullOrWhiteSpace(m.InstallDir));
 
 			RuleFor(vm => vm.DataDirectory)
 				.Cascade(CascadeMode.StopOnFirstFailure)
@@ -46,12 +43,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 				.Must(this.MustBeRooted).WithMessage(DirectoryMustNotBeRelative, DataText)
 				.Must(this.InstallOnKnownDrive)
 				.WithMessage(DirectoryUsesUnknownDrive, x => DataText, x => new DirectoryInfo(x.DataDirectory).Root.Name)
-				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, DataText);
-
-			RuleFor(vm => vm.DataDirectory)
-				.Must((vm, data) => this.IsSubPathOf(vm, vm.InstallDir, data))
-				.When(vm => vm.PlaceWritableLocationsInSamePath)
-				.WithMessage(DirectoryMustBeChildOf, vm => DataText, vm => vm.InstallDir);
+				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, DataText)
+				.Must(this.NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, DataText)
+				.When(m=>!string.IsNullOrWhiteSpace(m.InstallDir));
 
 			RuleFor(vm => vm.LogsDirectory)
 				.Cascade(CascadeMode.StopOnFirstFailure)
@@ -59,12 +53,10 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 				.Must(this.MustBeRooted).WithMessage(DirectoryMustNotBeRelative, LogsText)
 				.Must(this.InstallOnKnownDrive)
 				.WithMessage(DirectoryUsesUnknownDrive, x => LogsText, x => new DirectoryInfo(x.LogsDirectory).Root.Name)
-				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, LogsText);
+				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, LogsText)
+				.Must(this.NotBeChildOfInstallationDirectory).WithMessage(DirectoryMustNotBeChildOf, LogsText)
+				.When(m=>!string.IsNullOrWhiteSpace(m.InstallDir));
 
-			RuleFor(vm => vm.LogsDirectory)
-				.Must((vm, logs) => this.IsSubPathOf(vm, vm.InstallDir, logs))
-				.When(vm => vm.PlaceWritableLocationsInSamePath)
-				.WithMessage(DirectoryMustBeChildOf, vm => LogsText, vm => vm.InstallDir);
 		}
 
 		public bool MustBeRooted(LocationsModel model, string path)
@@ -85,12 +77,15 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 		private static readonly string X86ProgramFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 		private static readonly string ProgramFiles = LocationsModel.DefaultProgramFiles;
 
+		
+		public bool NotBeChildOfInstallationDirectory(LocationsModel model, string path) => !this.IsSubPathOf(model, model.InstallDir, path);
+		
 		public bool NotBeChildOfProgramFiles(LocationsModel model, string path) =>
 			!this.IsSubPathOf(model, X86ProgramFiles, path) && !this.IsSubPathOf(model, ProgramFiles, path);
 
 		public bool IsSubPathOf(LocationsModel model, string badParent, string path)
 		{
-			if (!this.MustBeRooted(model, badParent) || !this.MustBeRooted(model, path)) return true;
+			//if (!this.MustBeRooted(model, badParent) || !this.MustBeRooted(model, path)) return true;
 			return path.StartsWith(badParent, StringComparison.InvariantCultureIgnoreCase);
 		}
 	}

--- a/src/Installer/Elastic.Installer.Domain/Model/Kibana/Locations/LocationsModelValidator.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Kibana/Locations/LocationsModelValidator.cs
@@ -12,7 +12,6 @@ namespace Elastic.Installer.Domain.Model.Kibana.Locations
 		public static readonly string DirectoryMustNotBeRelative = TextResources.LocationsModelValidator_DirectoryMustNotBeRelative;
 		public static readonly string DirectoryUsesUnknownDrive = TextResources.LocationsModelValidator_DirectoryUsesUnknownDrive;
 		public static readonly string DirectorySetToNonWritableLocation = TextResources.LocationsModelValidator_DirectorySetToNonWritableLocation;
-		public static readonly string DirectoryMustBeChildOf = TextResources.LocationsModelValidator_DirectoryMustBeChildOf;
 		public static readonly string Installation = TextResources.LocationsModelValidator_Installation;
 		public static readonly string ConfigurationText = TextResources.LocationsModelValidator_Configuration;
 		public static readonly string DataText = TextResources.LocationsModelValidator_Data;
@@ -35,10 +34,6 @@ namespace Elastic.Installer.Domain.Model.Kibana.Locations
 				.WithMessage(DirectoryUsesUnknownDrive, x => LogsText, x => new DirectoryInfo(x.LogsDirectory).Root.Name)
 				.Must(this.NotBeChildOfProgramFiles).WithMessage(DirectorySetToNonWritableLocation, LogsText);
 
-			RuleFor(vm => vm.LogsDirectory)
-				.Must((vm, logs) => this.IsSubPathOf(vm.InstallDir, logs))
-				.When(vm => vm.PlaceWritableLocationsInSamePath)
-				.WithMessage(DirectoryMustBeChildOf, vm => LogsText, vm => vm.InstallDir);
 		}
 
 		public bool MustBeRooted(string path)

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -504,6 +504,17 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An ES_HOME environment variable exists but no previous installation was detected.
+        ///The MSI does not support upgrading from a previous zip based deploy.
+        ///.
+        /// </summary>
+        public static string NoticeModelValidator_HasEsHomeVariableButNoPreviousInstallation {
+            get {
+                return ResourceManager.GetString("NoticeModelValidator_HasEsHomeVariableButNoPreviousInstallation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A higher version is already installed.  In order to downgrade, you must uninstall this version first.
         ///PLEASE NOTE: an uninstall will always remove the data folder be sure you move it elsewhere if you need to keep it..
         /// </summary>

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -235,20 +235,20 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} directory must be a sub folder of {1} because the place in same folder flag was also set..
-        /// </summary>
-        public static string LocationsModelValidator_DirectoryMustBeChildOf {
-            get {
-                return ResourceManager.GetString("LocationsModelValidator_DirectoryMustBeChildOf", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} directory must be specified..
         /// </summary>
         public static string LocationsModelValidator_DirectoryMustBeSpecified {
             get {
                 return ResourceManager.GetString("LocationsModelValidator_DirectoryMustBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} directory can not be a sub folder of the installation directory.
+        /// </summary>
+        public static string LocationsModelValidator_DirectoryMustNotBeChildOf {
+            get {
+                return ResourceManager.GetString("LocationsModelValidator_DirectoryMustNotBeChildOf", resourceCulture);
             }
         }
         

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.Designer.cs
@@ -494,6 +494,16 @@ namespace Elastic.Installer.Domain.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The previous ES_PATH_CONF or ES_CONFIG appears to be a subfolder 
+        ///of ES_HOME please move these before starting the installation..
+        /// </summary>
+        public static string NoticeModelValidator_ConfigDirectoryIsSpecifiedAndSubPathOfEsHome {
+            get {
+                return ResourceManager.GetString("NoticeModelValidator_ConfigDirectoryIsSpecifiedAndSubPathOfEsHome", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A higher version is already installed.  In order to downgrade, you must uninstall this version first.
         ///PLEASE NOTE: an uninstall will always remove the data folder be sure you move it elsewhere if you need to keep it..
         /// </summary>

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -160,9 +160,9 @@ Java won't used compressed pointers.</value>
     <value>{0} directory must be specified.</value>
     <comment>{0} = Directory Name</comment>
   </data>
-  <data name="LocationsModelValidator_DirectoryMustBeChildOf" xml:space="preserve">
-    <value>{0} directory must be a sub folder of {1} because the place in same folder flag was also set.</value>
-    <comment>{0} = Directory Name, {1} = Installation Directory</comment>
+  <data name="LocationsModelValidator_DirectoryMustNotBeChildOf" xml:space="preserve">
+    <value>{0} directory can not be a sub folder of the installation directory</value>
+    <comment>{0} = Directory Name</comment>
   </data>
   <data name="LocationsModelValidator_DirectoryMustNotBeRelative" xml:space="preserve">
     <value>{0} directory must not be relative.</value>

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -253,6 +253,11 @@ invalid  and prevented seeding current values.</value>
     <value>The previous ES_PATH_CONF or ES_CONFIG appears to be a subfolder 
 of ES_HOME please move these before starting the installation.</value>
   </data>
+  <data name="NoticeModelValidator_HasEsHomeVariableButNoPreviousInstallation" xml:space="preserve">
+    <value>An ES_HOME environment variable exists but no previous installation was detected.
+The MSI does not support upgrading from a previous zip based deploy.
+</value>
+  </data>
   <data name="NoticeModel_ExistingVersion" xml:space="preserve">
     <value>Previously installed version: {0}</value>
   </data>

--- a/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
+++ b/src/Installer/Elastic.Installer.Domain/Properties/TextResources.resx
@@ -249,6 +249,10 @@ Java won't used compressed pointers.</value>
     <value>The elasticsearch.yml file we found in ES_PATH_CONF appears to be 
 invalid  and prevented seeding current values.</value>
   </data>
+  <data name="NoticeModelValidator_ConfigDirectoryIsSpecifiedAndSubPathOfEsHome" xml:space="preserve">
+    <value>The previous ES_PATH_CONF or ES_CONFIG appears to be a subfolder 
+of ES_HOME please move these before starting the installation.</value>
+  </data>
   <data name="NoticeModel_ExistingVersion" xml:space="preserve">
     <value>Previously installed version: {0}</value>
   </data>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/LocationsView.xaml
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/LocationsView.xaml
@@ -42,19 +42,18 @@
       <TextBox x:Name="InstallDirectoryTextBox" IsReadOnly="True" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="5,0,5,0" />
       <Button x:Name="InstallDirectoryBrowseButton" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_InstallDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
 
-      <CheckBox x:Name="CustomLocationsCheckBox" Grid.Row="2" Grid.ColumnSpan="3" Content="{x:Static resx:ViewResources.LocationsView_ElasticsearchCustomLocationsCheckBox}" HorizontalAlignment="Stretch" VerticalAlignment="Center" FontWeight="SemiBold" Margin="5,0,0,0"/>
 
-      <Label x:Name="DataDirectoryLabel" Grid.Row="3" Grid.Column="0" Content="{x:Static resx:ViewResources.LocationsView_DataDirectoryLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" />
-      <TextBox x:Name="DataDirectoryTextBox"  IsReadOnly="True" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" />
-      <Button x:Name="DataDirectoryBrowseButton" Grid.Row="3" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_DataDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
+      <Label x:Name="DataDirectoryLabel" Grid.Row="2" Grid.Column="0" Content="{x:Static resx:ViewResources.LocationsView_DataDirectoryLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" />
+      <TextBox x:Name="DataDirectoryTextBox"  IsReadOnly="True" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" />
+      <Button x:Name="DataDirectoryBrowseButton" Grid.Row="2" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_DataDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
 
-      <Label x:Name="ConfigDirectoryLabel" Grid.Row="4" Grid.Column="0" Content="{x:Static resx:ViewResources.LocationsView_ConfigDirectoryLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
-      <TextBox x:Name="ConfigDirectoryTextBox"  IsReadOnly="True" Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" />
-      <Button x:Name="ConfigDirectoryBrowseButton" Grid.Row="4" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_ConfigDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
+      <Label x:Name="ConfigDirectoryLabel" Grid.Row="3" Grid.Column="0" Content="{x:Static resx:ViewResources.LocationsView_ConfigDirectoryLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,0,10,0" />
+      <TextBox x:Name="ConfigDirectoryTextBox"  IsReadOnly="True" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" />
+      <Button x:Name="ConfigDirectoryBrowseButton" Grid.Row="3" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_ConfigDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
 
-      <Label x:Name="LogsDirectoryLabel" Grid.Row="5" Grid.Column="0" Content="{x:Static resx:ViewResources.LocationsView_LogsDirectoryLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" />
-      <TextBox x:Name="LogsDirectoryTextBox"  IsReadOnly="True" Grid.Row="5" Grid.Column="1" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" />
-      <Button x:Name="LogsDirectoryBrowseButton" Grid.Row="5" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_LogsDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
+      <Label x:Name="LogsDirectoryLabel" Grid.Row="4" Grid.Column="0" Content="{x:Static resx:ViewResources.LocationsView_LogsDirectoryLabel}" HorizontalAlignment="Left" VerticalAlignment="Center" />
+      <TextBox x:Name="LogsDirectoryTextBox"  IsReadOnly="True" Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" />
+      <Button x:Name="LogsDirectoryBrowseButton" Grid.Row="4" Grid.Column="2" Content="{x:Static resx:ViewResources.LocationsView_LogsDirectoryBrowseButton}" Height="30" VerticalAlignment="Center" />
 
 
     </Grid>

--- a/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/LocationsView.xaml.cs
+++ b/src/Installer/Elastic.Installer.UI/Elasticsearch/Steps/LocationsView.xaml.cs
@@ -33,7 +33,6 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 		protected override void InitializeBindings()
 		{
 			this.Bind(ViewModel, vm => vm.ConfigureLocations, v => v.CustomLocationsRadioButton.IsChecked);
-			this.Bind(ViewModel, vm => vm.PlaceWritableLocationsInSamePath, v => v.CustomLocationsCheckBox.IsChecked);
 
 			this.WhenAnyValue(view => view.ViewModel.ConfigureLocations)
 				.Subscribe(x =>
@@ -42,10 +41,9 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 					//this.InstallDirectoryLabel.IsEnabled = x;
 					this.InstallDirectoryTextBox.IsEnabled = x;
 					this.InstallDirectoryBrowseButton.IsEnabled = x;
-					this.CustomLocationsCheckBox.IsEnabled = x;
 				});
 
-			this.WhenAnyValue(view => view.ViewModel.ConfigureAllLocations)
+			this.WhenAnyValue(view => view.ViewModel.ConfigureLocations)
 				.Subscribe(x =>
 				{
 					this.DataDirectoryLabel.IsEnabled = x;
@@ -64,14 +62,6 @@ namespace Elastic.Installer.UI.Elasticsearch.Steps
 			this.Bind(ViewModel, vm => vm.ConfigDirectory, v => v.ConfigDirectoryTextBox.Text);
 			this.Bind(ViewModel, vm => vm.LogsDirectory, v => v.LogsDirectoryTextBox.Text);
 
-			this.InstallDirectoryTextBox.Events().TextChanged
-				.Subscribe(e =>
-				{
-					if (ViewModel.PlaceWritableLocationsInSamePath && this.CustomLocationsCheckBox.IsChecked.HasValue)
-						ViewModel.PlaceWritableLocationsInSamePath = this.CustomLocationsCheckBox.IsChecked.Value;
-				});
-			this.CustomLocationsCheckBox.Events().Click
-				.Subscribe(e => ViewModel.PlaceWritableLocationsInSamePath = this.CustomLocationsCheckBox.IsChecked.GetValueOrDefault());
 			this.InstallDirectoryBrowseButton.Events().Click
 				.Subscribe(folder => this.BrowseForFolder(ViewModel.InstallDir, (result) => { ViewModel.InstallDir = result; }));
 			this.DataDirectoryBrowseButton.Events().Click

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -20,7 +20,8 @@ namespace Elastic.InstallerHosts.Elasticsearch
 		public void Application_Startup(object sender, StartupEventArgs e)
 		{
 			var state = InstallationModelTester.ValidPreflightChecks(s => s
-				.Wix(current: "6.3.0", upgradeFrom: "6.2.3")
+				//.Wix(current: "6.3.0", upgradeFrom: "6.2.3")
+				.Wix(current: "6.3.0")
 				.ServicePreviouslyInstalled()
 			);
 			var model = state.InstallationModel;

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -20,11 +20,11 @@ namespace Elastic.InstallerHosts.Elasticsearch
 		public void Application_Startup(object sender, StartupEventArgs e)
 		{
 			var state = InstallationModelTester.ValidPreflightChecks(s => s
-				//.Wix(current: "6.3.0", upgradeFrom: "6.2.3")
-				.Wix(current: "6.3.0")
+				.Wix(current: "6.3.0", upgradeFrom: "6.2.3")
+				//.Wix(current: "6.3.0")
 				.Elasticsearch(es=>es
-					.EsHomeMachineVariable(@"C:\elasticsearch")
-					.EsConfigMachineVariable(@"C:\elasticsearch\config")
+					.EsHomeMachineVariable(@"C:\elasticsearch\6.2.3")
+					.EsConfigMachineVariable(@"C:\elasticsearch\6.2.3\config")
 				)
 				.ServicePreviouslyInstalled()
 			);

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -22,6 +22,10 @@ namespace Elastic.InstallerHosts.Elasticsearch
 			var state = InstallationModelTester.ValidPreflightChecks(s => s
 				//.Wix(current: "6.3.0", upgradeFrom: "6.2.3")
 				.Wix(current: "6.3.0")
+				.Elasticsearch(es=>es
+					.EsHomeMachineVariable(@"C:\elasticsearch")
+					.EsConfigMachineVariable(@"C:\elasticsearch\config")
+				)
 				.ServicePreviouslyInstalled()
 			);
 			var model = state.InstallationModel;

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/TestSetupStateProvider.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/TestSetupStateProvider.cs
@@ -112,16 +112,12 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 				{
 					IsUninstalling = uninstalling,
 					IsRollback = rollback,
-					IsInstalled = uninstalling,
-					IsInstalling = !uninstalling
 				};
 			}
 			else
 			{
 				this.SessionState.IsUninstalling = uninstalling;
 				this.SessionState.IsRollback = rollback;
-				this.SessionState.IsInstalled = uninstalling;
-				this.SessionState.IsInstalling = !uninstalling;
 				if (sessionVariables != null)
 				{
 					foreach (var sessionVariable in sessionVariables)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/MemoryTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/MemoryTests.cs
@@ -65,6 +65,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 
 
 		[Fact] void RespectsJvmOptsFile() => WithValidPreflightChecks(s => s
+				.Wix(alreadyInstalled: true)
 				.Elasticsearch(e => e
 					.EsHomeMachineVariable(LocationsModel.DefaultProgramFiles)
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTestBase.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTestBase.cs
@@ -20,6 +20,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 		protected InstallationModelTester WithExistingElasticsearchYaml(string yamlContents)  =>
 			InstallationModelTester.ValidPreflightChecks(s=>s
+				.Wix(alreadyInstalled: true)
 				.Elasticsearch(e=>e
 					.EsHomeMachineVariable(LocationsModel.DefaultProgramFiles)
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
@@ -122,7 +122,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 				.And.HaveCount(this.InstallationModel.FirstInvalidStepValidationFailures.Count);
 
 			validateErrors?.Invoke(step.ValidationFailures);
-
+			
 			return this;
 		}
 
@@ -170,6 +170,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 			this.InstallationModel.FirstInvalidStepValidationFailures.Should().BeEmpty();
 			step.ValidationFailures.Should().BeEmpty();
+			
+			this.InstallationModel.ValidationFailures.Should().BeEmpty();
+			this.InstallationModel.PrerequisiteFailures.Should().BeEmpty();
 
 			return this;
 		}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
@@ -13,19 +13,15 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 	{
 		/* Instantiatiing a new InstallationModel will be invalid without 
 		 * Setting some preflight checks */
-		[Fact] void PreflightChecks() => Pristine()
-			.HasSetupValidationFailures(errors=>errors
-				.ShouldHaveErrors(
-					TextResources.NoticeModelValidator_JavaInstalled
-				)
-			)
-			//Java is a fixable prequisite error
-			.HasPrerequisiteErrors(errors=>errors
+		[Fact]
+		void PreflightChecks() => Pristine()
+			.HasSetupValidationFailures(errors => errors
 				.ShouldHaveErrors(TextResources.NoticeModelValidator_JavaInstalled)
 			)
-			.IsValidOnFirstStep()
-			//Assure we can not proceed past the current step
-			.CanClickNext(true);
+			//Java is a fixable prequisite error
+			.HasPrerequisiteErrors(errors => errors
+				.ShouldHaveErrors(TextResources.NoticeModelValidator_JavaInstalled)
+			);
 	
 		/* A model with all preflight checks set is valid */
 		[Fact] void CanClickNextWhenValid() => WithValidPreflightChecks()

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InvalidExternalStates/ElasticsearchYamlStateTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InvalidExternalStates/ElasticsearchYamlStateTests.cs
@@ -14,8 +14,13 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.InvalidExternalSta
 		[Fact] void SeedsFromEmptyElasticsearchYaml() => WithExistingElasticsearchYaml($@"")
 				.IsValidOnFirstStep();
 		
-		[Fact] void SeedsInvalidYamlFile() => WithExistingElasticsearchYaml($@"x=")
-				.HasSetupValidationFailures(errors=>errors.ShouldHaveErrors(TextResources.NoticeModelValidator_BadElasticsearchYamlFile));
+		[Fact] void SeedsInvalidYamlFile() => 
+			WithExistingElasticsearchYaml($@"x=")
+				.HasSetupValidationFailures(errors=>errors
+					.ShouldHaveErrors(
+						TextResources.NoticeModelValidator_BadElasticsearchYamlFile
+					)
+				);
 
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationModelTests.cs
@@ -17,16 +17,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 		}
 
 		[Fact] void InstallDirectoryNotEmpty() => this._model
-			.OnStep(m => m.LocationsModel, step =>
+			.OnStep(m => m.LocationsModel, model =>
 			{
-				step.InstallDir = null;
-			})
-			.IsInvalidOnStep(m => m.LocationsModel, errors => errors
-				.ShouldHaveErrors(string.Format(LocationsModelValidator.DirectoryMustBeSpecified, LocationsModelValidator.Installation))
-			)
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.InstallDir = string.Empty;
+				model.InstallDir = string.Empty;
 			})
 			.IsInvalidOnStep(m => m.LocationsModel, errors => errors
 				.ShouldHaveErrors(string.Format(LocationsModelValidator.DirectoryMustBeSpecified, LocationsModelValidator.Installation))

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsArgumentsTests.cs
@@ -15,7 +15,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 		{
 			m.LocationsModel.ConfigDirectory.Should().Be(this.CustomConfig);
 			m.LocationsModel.ConfigureLocations.Should().BeTrue();
-			m.LocationsModel.ConfigureAllLocations.Should().BeTrue();
 		});
 
 		[Fact] void DataDirectory() => Argument(nameof(LocationsModel.DataDirectory), this.CustomConfig, m =>
@@ -28,8 +27,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			m.LocationsModel.LogsDirectory.Should().Be(this.CustomConfig);
 		});
 
-		[Fact]
-		void InstallDirectory()
+		[Fact] void InstallDirectory()
 		{
 			var customHome = this.CustomHome;
 			var customHomeVersion = Path.Combine(this.CustomHome, TestSetupStateProvider.DefaultTestVersion);
@@ -37,6 +35,15 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			{
 				m.LocationsModel.InstallDir.Should().Be(customHomeVersion);
 				m.LocationsModel.ConfigureLocations.Should().BeTrue();
+			});
+		}
+		[Fact] void InstallDirectoryEmpty()
+		{
+			Argument(nameof(LocationsModel.InstallDir), "", "", (m, s) =>
+			{
+				m.LocationsModel.InstallDir.Should().Be("");
+				m.LocationsModel.ConfigureLocations.Should().BeTrue();
+				m.LocationsModel.IsValid.Should().BeFalse();
 			});
 		}
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsFlagTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsFlagTests.cs
@@ -31,36 +31,12 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 				step.ConfigureLocations.Should().BeFalse();
 			});
 
-		[Fact] void ConfigureAllLocationsShouldBeFalse() => this._model
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.ConfigureAllLocations.Should().BeFalse();
-			});
-
-		[Fact] void ConfigureAllIsReactive() => this._model 
-			//When setting configure locations ConfigureAllLocations is also set
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				var allLocations = false;
-				step.WhenAnyValue(vm => vm.ConfigureAllLocations).Subscribe(b => allLocations = b);
-				step.ConfigureLocations = true;
-				allLocations.Should().BeTrue();
-			})
-			//When setting PlaceWritableLocationsInSamePath however we are no longer configuring all locations
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				var allLocations = true;
-				step.WhenAnyValue(vm => vm.ConfigureAllLocations).Subscribe(b => allLocations = b);
-				step.PlaceWritableLocationsInSamePath = true;
-				allLocations.Should().BeFalse();
-			});
 
 		[Fact] void UpdatingInstallDirectoryShouldSetConfigureLocations() => this._model
 			.OnStep(m => m.LocationsModel, step =>
 			{
 				step.InstallDir = "C:\\Elasticsearch";
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
 			});
 
 		[Fact] void UpdatingDataDirectoryShouldBothFlags() => this._model
@@ -68,7 +44,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			{
 				step.DataDirectory = "C:\\Elasticsearch";
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
 			});
 
 		[Fact] void UpdatingConfDirectoryShouldBothFlags() => this._model
@@ -76,39 +51,19 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			{
 				step.ConfigDirectory = "C:\\Elasticsearch";
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
-			});
-
-		[Fact] void UpdatingLogsDirectoryShouldBothFlags() => this._model
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.LogsDirectory = "C:\\Elasticsearch";
-				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
-			})
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.PlaceWritableLocationsInSamePath = true;
-				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeFalse();
-				step.LogsDirectory.Should().NotBe("C:\\Elasticsearch");
 			});
 
 		[Fact] void UnsettingConfigureLocationsResets() => this._model
 			.OnStep(m => m.LocationsModel, step =>
 			{
 				step.LogsDirectory = "C:\\Elasticsearch";
-				step.PlaceWritableLocationsInSamePath = true;
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeFalse();
 			})
 			.OnStep(m => m.LocationsModel, step =>
 			{
 				step.ConfigureLocations = false;
 				step.LogsDirectory.Should().NotBe("C:\\Elasticsearch");
-				step.ConfigureAllLocations.Should().BeFalse();
 				step.ConfigureLocations.Should().BeFalse();
-				step.PlaceWritableLocationsInSamePath.Should().BeFalse();
 			});
 
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/SeedLocationsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/SeedLocationsTests.cs
@@ -30,7 +30,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			{
 				step.ConfigDirectory.Should().Be(_customConfig);
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
 			});
 
 		[Fact] void DataDirectoryIsReadFromElasticsearchYaml() => WithValidPreflightChecks(s => s
@@ -46,7 +45,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			.OnStep(m => m.LocationsModel, step =>
 			{
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
 				step.DataDirectory.Should().Be($"{_customHome}\\MyDataFolder");
 			});
 
@@ -63,7 +61,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 			.OnStep(m => m.LocationsModel, step =>
 			{
 				step.ConfigureLocations.Should().BeTrue();
-				step.ConfigureAllLocations.Should().BeTrue();
 				step.LogsDirectory.Should().Be($"{_customHome}\\MyDataFolder");
 			});
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/WritableLocationsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/WritableLocationsTests.cs
@@ -19,88 +19,23 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 				.IsValidOnStep(m => m.LocationsModel);
 		}
 
-		[Fact] void WhenSettingsSamePathWeDoNotAcceptProgramFiles() => this._model
+		[Fact] void LogsDirectoryCanNotBeChildOfInstallDirectory() => this._model
 			.OnStep(m => m.LocationsModel, step =>
 			{
-				step.PlaceWritableLocationsInSamePath = true;
-			})
-			.IsInvalidOnStep(m => m.LocationsModel, errors => errors
-				.ShouldHaveErrors(
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.LogsText),
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.DataText),
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.ConfigurationText)
-				)
-			)
-			.CanClickNext(false);
-
-		[Fact] void UnsettingsPlaceInSamePathLeavesWritableFoldersInErrorState() => this._model
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.PlaceWritableLocationsInSamePath = true;
-			})
-			.IsInvalidOnStep(m => m.LocationsModel, errors => errors
-				.ShouldHaveErrors(
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.LogsText),
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.DataText),
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.ConfigurationText)
-				)
-			)
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				//eventhough we unset place writable folders in the same path, the folders do not change
-				step.PlaceWritableLocationsInSamePath = false;
-				step.LogsDirectory.Should().StartWith(step.InstallDir)
-					.And.StartWith(LocationsModel.DefaultProductInstallationDirectory);
-				step.ConfigDirectory.Should().StartWith(step.InstallDir)
-					.And.StartWith(LocationsModel.DefaultProductInstallationDirectory);
-				step.DataDirectory.Should().StartWith(step.InstallDir)
-					.And.StartWith(LocationsModel.DefaultProductInstallationDirectory);;
-			})
-			.IsInvalidOnStep(m => m.LocationsModel, errors => errors
-				.ShouldHaveErrors(
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.LogsText),
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.DataText),
-					string.Format(LocationsModelValidator.DirectorySetToNonWritableLocation, LocationsModelValidator.ConfigurationText)
-				)
-			)
-			.CanClickNext(false);
-
-		[Fact] void WhenSettingWritableFoldersWeCanAdvance() => this._model
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.InstallDir = _installDirectory;
-				step.PlaceWritableLocationsInSamePath = true;
-			})
-			.IsValidOnStep(m => m.LocationsModel)
-			.CanClickNext();
-
-		[Fact] void WhenSettingWritableFoldersOutOfOrderWeCanAdvance() => this._model
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.PlaceWritableLocationsInSamePath = true;
-				step.InstallDir = _installDirectory;
-			})
-			.IsValidOnStep(m => m.LocationsModel)
-			.CanClickNext();
-			
-		[Fact] void WithSameDirFlagSetManuallySettingWritableDirectoriesElsewhereIsAnError() => this._model
-			.OnStep(m => m.LocationsModel, step =>
-			{
-				step.PlaceWritableLocationsInSamePath = true;
 				step.InstallDir = _installDirectory;
 			})
 			.IsValidOnStep(m=>m.LocationsModel)
 			.OnStep(m => m.LocationsModel, step =>
 			{
-				step.LogsDirectory = "C:\\elsewhere";
-				step.DataDirectory = "C:\\elsewhere";
-				step.ConfigDirectory = "C:\\elsewhere";
+				step.LogsDirectory = Path.Combine(step.InstallDir, "logs");
+				step.DataDirectory = Path.Combine(step.InstallDir, "data");
+				step.ConfigDirectory = Path.Combine(step.InstallDir, "conf");
 			})
 			.IsInvalidOnStep(m => m.LocationsModel, errors => errors
 				.ShouldHaveErrors(
-					string.Format(LocationsModelValidator.DirectoryMustBeChildOf, LocationsModelValidator.LogsText, VersionSpecificInstallDirectory),
-					string.Format(LocationsModelValidator.DirectoryMustBeChildOf, LocationsModelValidator.DataText, VersionSpecificInstallDirectory),
-					string.Format(LocationsModelValidator.DirectoryMustBeChildOf, LocationsModelValidator.ConfigurationText, VersionSpecificInstallDirectory)
+					string.Format(LocationsModelValidator.DirectoryMustNotBeChildOf, LocationsModelValidator.LogsText),
+					string.Format(LocationsModelValidator.DirectoryMustNotBeChildOf, LocationsModelValidator.DataText),
+					string.Format(LocationsModelValidator.DirectoryMustNotBeChildOf, LocationsModelValidator.ConfigurationText)
 				)
 			)
 			.CanClickNext(false);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Notice/NoticeModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Notice/NoticeModelTests.cs
@@ -7,7 +7,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Notice
 	{
 		[Fact]
 		public void ErrorStates() => Pristine()
-			.IsValidOnFirstStep()
 			.HasSetupValidationFailures(errors => errors
 				.ShouldHaveErrors(
 					TextResources.NoticeModelValidator_JavaInstalled
@@ -22,25 +21,23 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Notice
 			.IsValidOnStep(m => m.LocationsModel)
 			.CanClickNext();
 
-		[Fact] public void MajorDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0", upgradeFrom: "6.0.0"))
-			.IsValidOnStep(m => m.NoticeModel)
-			.CanClickNext();
+		[Fact]
+		public void MajorDowngradeShowsNotice() => WithValidPreflightChecks(f => f.Wix("5.0.0", upgradeFrom: "6.0.0"))
+			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
 		[Fact] public void MajorUpgradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("6.0.0", upgradeFrom: "5.0.0"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
 		[Fact] public void MinorDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0", upgradeFrom: "5.1.0"))
-			.IsValidOnStep(m => m.NoticeModel)
-			.CanClickNext();
+			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
 		[Fact] public void MinorUpgradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.1.0", upgradeFrom: "5.0.0"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
 		[Fact] public void PatchDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.1.0", upgradeFrom: "5.1.1"))
-			.IsValidOnStep(m => m.NoticeModel)
-			.CanClickNext();
+			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
 		[Fact] public void PatchUpgradeDoesNotShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.1.1", upgradeFrom: "5.1.0"))
 			.IsValidOnStep(m => m.NoticeModel)
@@ -55,17 +52,15 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Notice
 			.IsValidOnStep(m => m.ConfigurationModel)
 			.CanClickNext();
 
-		[Fact] public void PrereleaseShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-alpha1", upgradeFrom: "5.0.0-alpha2"))
+		[Fact] public void PrereleaseShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-alpha4", upgradeFrom: "5.0.0-alpha2"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
-		[Fact] public void PrereleaseDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0", upgradeFrom: "5.0.0-alpha2"))
-			.IsValidOnStep(m => m.NoticeModel)
-			.CanClickNext();
+		[Fact] public void PrereleaseDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-rc2", upgradeFrom: "5.0.0"))
+			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
 		[Fact] public void PrereleaseUpgradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-rc2", upgradeFrom: "5.0.0"))
-			.IsValidOnStep(m => m.NoticeModel)
-			.CanClickNext();
+			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
 		[Fact] public void InstallingPrereleaseFirstTimeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-beta2", upgradeFrom: null))
 			.IsValidOnStep(m => m.NoticeModel)


### PR DESCRIPTION
We used to support upgrading from zip files and thus this option made sense. However since quite a while with the way our Wix engine executes the install sequence we no longer support this.

Putting conf/data/path in the same folder as the installation is not recommended so lets not expose this option. With this PR it will even be a validation error if conf/data/path is a sub folder of the
installation.

![image](https://user-images.githubusercontent.com/245275/39128519-441e37d2-4708-11e8-81fc-b0157773df6c.png)

Further more if we see that `ES_PATH_CONF` is a subfolder of `ES_HOME` at the start of the installation we block the installation from commencing:

![image](https://user-images.githubusercontent.com/245275/39128646-9b4f73e0-4708-11e8-93b3-914607c5460b.png)

This should fix #186 when doing an upgrade from a previous installation that had opted in to placed the special folders inside the installation directory.

Finally if we spot an `ES_HOME` but no previous installation we also prohibit the installation from beginning:

![image](https://user-images.githubusercontent.com/245275/39128773-f5169d54-4708-11e8-981f-c54003f3529c.png)

This should make it explicit that we do not support installations over previously zip installed Elasticsearch instances.
