### PR TITLE
Use String.Split instead of -split

### DIFF
--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -58,8 +58,9 @@ Target:
 
   Example: build.bat release es 5.5.3 C:/path_to_cert_file C:/path_to_password_file
 
-* integrate [Products] [Versions] [VagrantProvider] [TestTargets] [skiptests]  -
-  - run integration tests. Can filter tests by wildcard [TestTargets]
+* integrate [Products] [Versions] [VagrantProvider] [TestTargets] [switches] [skiptests]  -
+  - run integration tests. Can filter tests by wildcard [TestTargets], 
+    which match against the directory names of tests
 
   Example: build.bat integrate es 5.5.1,5.5.2 local * skiptests
 
@@ -117,6 +118,17 @@ skiptests:
 ----------
 
 Whether to skip unit tests.
+
+switches:
+---------
+
+Integration tests against a local vagrant provider support several switches
+    - -gui: launch vagrant with a GUI
+    - -nodestroy: do not destroy the vagrant box after the test has run
+    - -plugins:<comma separated plugins>: a list of plugin zips that exist within
+                                          the build/in directory, that should be installed
+                                          within integration tests instead of downloading. The plugin
+                                          zip names must match the installer version.
 
 """
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-Plugins/SilentInstall-Plugins.Tests.ps1
@@ -25,7 +25,7 @@ Describe -Name "Silent Install with $plugins plugins $(($Global:Version).Descrip
 
     Context-PingNode
 
-    Context-PluginsInstalled -Expected @{ Plugins=($plugins -split ",") }
+    Context-PluginsInstalled -Expected @{ Plugins=($plugins.Split(@(','), [StringSplitOptions]::RemoveEmptyEntries)) }
 
     Context-ClusterNameAndNodeName
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradePlugins/SilentInstall-UpgradePlugins.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-UpgradePlugins/SilentInstall-UpgradePlugins.Tests.ps1
@@ -57,7 +57,7 @@ Describe -Name "Silent Install upgrade with plugins install $($previousVersion.D
 		Path = $ExpectedConfigFolder
 	}
 
-    Context-PluginsInstalled -Expected @{ Plugins=($plugins -split ",") }
+    Context-PluginsInstalled -Expected @{ Plugins=($plugins.Split(@(','), [StringSplitOptions]::RemoveEmptyEntries)) }
 
     Context-MsiRegistered -Expected @{
 		Name = "Elasticsearch $v"
@@ -129,7 +129,7 @@ Describe -Name "Silent Install upgrade with plugins from $($previousVersion.Desc
 
 	Context-PingNode -XPackSecurityInstalled
 
-    Context-PluginsInstalled -Expected @{ Plugins=($plugins -split ",") }
+    Context-PluginsInstalled -Expected @{ Plugins=($plugins.Split(@(','), [StringSplitOptions]::RemoveEmptyEntries)) }
 
     Context-MsiRegistered
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPassword/SilentInstall-XPackBootstrapPassword.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPassword/SilentInstall-XPackBootstrapPassword.Tests.ps1
@@ -30,7 +30,7 @@ Describe -Name "Silent Install with setting up bootstrap password $(($Global:Ver
 
     Context-PingNode -XPackSecurityInstalled
 
-    Context-PluginsInstalled -Expected @{ Plugins=($plugins -split ",") }
+    Context-PluginsInstalled -Expected @{ Plugins=($plugins.Split(@(','), [StringSplitOptions]::RemoveEmptyEntries)) }
 
     Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:elastic" }
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPasswordAndXPackUsers/SilentInstall-XPackBootstrapPasswordAndXPackUsers.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackBootstrapPasswordAndXPackUsers/SilentInstall-XPackBootstrapPasswordAndXPackUsers.Tests.ps1
@@ -33,7 +33,7 @@ Describe -Name "Silent Install with setting up bootstrap password and x-pack use
 
     Context-PingNode -XPackSecurityInstalled
 
-    Context-PluginsInstalled -Expected @{ Plugins=($plugins -split ",") }
+    Context-PluginsInstalled -Expected @{ Plugins=($plugins.Split(@(','), [StringSplitOptions]::RemoveEmptyEntries)) }
 
     Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:elastic" }
 

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackUsers/SilentInstall-XPackUsers.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-XPackUsers/SilentInstall-XPackUsers.Tests.ps1
@@ -32,7 +32,7 @@ Describe -Name "Silent Install with setting up x-pack users $(($Global:Version).
 
     Context-PingNode -XPackSecurityInstalled
 
-    Context-PluginsInstalled -Expected @{ Plugins=($plugins -split ",") }
+    Context-PluginsInstalled -Expected @{ Plugins=($plugins.Split(@(','), [StringSplitOptions]::RemoveEmptyEntries)) }
 
     Context-ClusterNameAndNodeName -Expected @{ Credentials = "elastic:elastic" }
 


### PR DESCRIPTION
This commit changes the use of Powershell's `-split` operator to use
`String.Split()` instead, with the option to remove empty entries.