### PR TITLE
fix #206 INSTALLDIR needs to end with version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ start /wait msiexec.exe /i elasticsearch-5.5.0.msi /qn /l elastic-install.log NO
 
 | Parameter name                   | Description                      | Default value                    |
 | -------------------------------- | -------------------------------- | -------------------------------- |
-| INSTALLDIR                       | Elasticsearch installation path  | `%ProgramW6432%`\Elastic\Elasticsearch |
+| INSTALLDIR                       | Elasticsearch installation path, has to end with the current version number, | `%ProgramW6432%`\Elastic\Elasticsearch\6.3.1 |
 | DATADIRECTORY                    | Data directory path              | `%ALLUSERSPROFILE%`\Elastic\Elasticsearch\data |
 | CONFIGDIRECTORY                  | Config directory path            | `%ALLUSERSPROFILE%`\Elastic\Elasticsearch\config |
 | LOGSDIRECTORY                    | Logs directory path              | `%ALLUSERSPROFILE%`\Elastic\Elasticsearch\logs |

--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -146,7 +146,12 @@ Target "Integrate" (fun () ->
         p.AddScript(script).BeginInvoke(null, output)
               |> Async.AwaitIAsyncResult
               |> Async.Ignore
-    Async.RunSynchronously async)
+    Async.RunSynchronously async
+
+    if (p.InvocationStateInfo.State = PSInvocationState.Failed) then
+        failwith "PowerShell completed abnormally due to an error"
+)
+
 
 Target "Help" (fun () -> trace Commandline.usage)
 

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModel.cs
@@ -174,6 +174,8 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 
 		private string ForceVersionFolder(string directory)
 		{
+			if (string.IsNullOrWhiteSpace(directory)) return directory;
+			if (!Path.IsPathRooted(directory)) return directory;
 			return Path.Combine(GetRootedPathIfNecessary(directory), CurrentVersion);
 		}
 

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Locations/LocationsModel.cs
@@ -156,11 +156,11 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 		[Argument(nameof(InstallDir), PersistInRegistry = true)]
 		public string InstallDir
 		{
-			get => string.IsNullOrWhiteSpace(installDirectory) ? installDirectory : Path.Combine(installDirectory, CurrentVersion);
+			get => string.IsNullOrWhiteSpace(installDirectory) ? installDirectory : ForceVersionFolder(installDirectory);
 			set
 			{
-				var rooted = GetRootedPathIfNecessary(value);
-				this.RaiseAndSetIfChanged(ref installDirectory, rooted);
+				var versionFolder = ForceVersionFolder(value);
+				this.RaiseAndSetIfChanged(ref installDirectory, versionFolder);
 			}
 		}
 
@@ -170,6 +170,11 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Locations
 		{
 			get => previousInstallationDirectory;
 			set => this.RaiseAndSetIfChanged(ref previousInstallationDirectory, value);
+		}
+
+		private string ForceVersionFolder(string directory)
+		{
+			return Path.Combine(GetRootedPathIfNecessary(directory), CurrentVersion);
 		}
 
 		private string GetRootedPathIfNecessary(string value)

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Immediate/ValidateArgumentsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Immediate/ValidateArgumentsTask.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Elastic.Installer.Domain.Configuration.Wix.Session;
 
 namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Immediate
@@ -28,6 +29,11 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Immediate
 				var validationFailures = ValidationFailures(failures);
 				throw new Exception("Cannot continue installation because of the following errors" + Environment.NewLine + validationFailures);
 			}
+
+			var installDir = this.Session.Get<string>("INSTALLDIR");
+			var version = this.InstallationModel.NoticeModel.CurrentVersion.ToString();
+			if (!new Regex(version + @"\\?$").IsMatch(installDir))
+				throw new Exception($"INSTALLDIR does not end in current version number: {version} ({installDir})");
 			return true;
 		}
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsArgumentsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsArgumentsTests.cs
@@ -8,8 +8,8 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 {
 	public class LocationsArgumentsTests : InstallationModelArgumentsTestsBase
 	{
-		protected readonly string CustomHome = @"C:\\Elasticsearch";
-		protected readonly string CustomConfig = @"C:\\Conf";
+		protected readonly string CustomHome = @"C:\Elasticsearch";
+		protected readonly string CustomConfig = @"C:\Conf";
 
 		[Fact] void ConfigDirectory() => Argument(nameof(LocationsModel.ConfigDirectory), this.CustomConfig, m =>
 		{

--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailInstallDirNoVersion/SilentInstall-FailInstallDirNoVersion.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-FailInstallDirNoVersion/SilentInstall-FailInstallDirNoVersion.Tests.ps1
@@ -1,0 +1,49 @@
+$currentDir = Split-Path -parent $MyInvocation.MyCommand.Path
+Set-Location $currentDir
+
+# mapped sync folder for common scripts
+. $currentDir\..\common\Utils.ps1
+. $currentDir\..\common\CommonTests.ps1
+. $currentDir\..\common\SemVer.ps1
+
+Get-Version
+Get-PreviousVersions
+
+Describe "Silent Failed Install with Installation directory not ending in version $(($Global:Version).Description)" {
+
+	$startDate = Get-Date
+	$version = $Global:Version.FullVersion
+
+	Context "Failed installation" {
+		$exitCode = Invoke-SilentInstall -Exeargs @("INSTALLDIR=C:\elastic")
+
+		It "Exit code is 1603" {
+			$exitCode | Should Be 1603
+		}
+	}
+
+	Context-EventContainsFailedInstallMessage -StartDate $startDate -Version $version
+
+	Context-NodeNotRunning
+
+	Context-EsConfigEnvironmentVariableNull
+
+	Context-EsHomeEnvironmentVariableNull
+
+	Context-MsiNotRegistered
+
+	Context-ElasticsearchServiceNotInstalled
+
+	$ProgramFiles = Get-ProgramFilesFolder
+    $ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+	Context-EmptyInstallDirectory -Path $ExpectedHomeFolder
+
+	$configDirectory = "C:\ProgramData\Elastic\Elasticsearch\config"
+	$dataDirectory = $configDirectory | Split-Path | Join-Path -ChildPath "data"
+	$logsDirectory = $configDirectory | Split-Path | Join-Path -ChildPath "logs"
+
+	Context-DirectoryNotExist -Path $configDirectory -DeleteAfter
+	Context-DirectoryNotExist -Path $dataDirectory -DeleteAfter
+	Context-DirectoryNotExist -Path $logsDirectory -DeleteAfter
+}


### PR DESCRIPTION
UI always passes it with the version number as do our integration tests
but we need to fail more clearly if INSTALLDIR is specified on the
command line using silent installation and not ending in the current
version number.

Updated README to include this requirement