### PR TITLE
Flag models created as part of tasks.

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Configuration/Wix/IWixStateProvider.cs
+++ b/src/Installer/Elastic.Installer.Domain/Configuration/Wix/IWixStateProvider.cs
@@ -9,5 +9,8 @@ namespace Elastic.Installer.Domain.Configuration.Wix
 		
 		/// <summary> The version that is currently being installed </summary>
 		SemVersion CurrentVersion { get; }
+		
+		/// <summary> Indicates the model was instantatiated when the installation is in progresss</summary>
+		bool InstallationInProgress { get; }
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Configuration/Wix/NoopWixStateProvider.cs
+++ b/src/Installer/Elastic.Installer.Domain/Configuration/Wix/NoopWixStateProvider.cs
@@ -7,5 +7,7 @@ namespace Elastic.Installer.Domain.Configuration.Wix
 		public SemVersion UpgradeFromVersion { get; set; }
 
 		public SemVersion CurrentVersion { get; set; } = "0.0.1-ignored";
+		
+		public bool InstallationInProgress { get; set; }
 	}
 }

--- a/src/Installer/Elastic.Installer.Domain/Configuration/Wix/WixStateProvider.cs
+++ b/src/Installer/Elastic.Installer.Domain/Configuration/Wix/WixStateProvider.cs
@@ -54,15 +54,19 @@ namespace Elastic.Installer.Domain.Configuration.Wix
 		/// <inheritdoc />
 		public SemVersion CurrentVersion { get; }
 
-		public WixStateProvider(Product product, Guid currentProductCode) 
-			:this(product, GetVersion(product, currentProductCode))
+		/// <inheritdoc />
+		public bool InstallationInProgress { get; }
+
+		public WixStateProvider(Product product, Guid currentProductCode, bool installationInProgress) 
+			:this(product, GetVersion(product, currentProductCode), installationInProgress)
 		{
 		}
 
-		public WixStateProvider(Product product, string currentVersion) 
+		public WixStateProvider(Product product, string currentVersion, bool installationInProgress) 
 		{
 			var installed = IsAlreadyInstalled(product, out var existingVersions);
 			this.CurrentVersion = currentVersion;
+			this.InstallationInProgress = installationInProgress;
 			// use the latest existing version installed.
 			// TODO: What should we do about prerelease versions here?
 			if (installed) this.UpgradeFromVersion = existingVersions.OrderByDescending(v => v).First();

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/ElasticsearchInstallationModel.cs
@@ -74,6 +74,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			var versionConfig = new VersionConfiguration(wixStateProvider, this.Session.IsInstalled);
 			this.SameVersionAlreadyInstalled = versionConfig.SameVersionAlreadyInstalled;
 			this.UnInstalling = this.Session.IsUninstalling;
+			this.InstallationInProgress = this._wixStateProvider.InstallationInProgress;
 			this.Installing = this.Session.IsInstalling;
 			this.Installed = this.Session.IsInstalled;
 			this.Upgrading = this.Session.IsUpgrading;
@@ -198,6 +199,11 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			this.ActiveStep.Validate();
 		}
 
+		/// <summary>
+		/// Indicates wheter the model was instantiated during the execution of the tasks.
+		/// </summary>
+		public bool InstallationInProgress { get; }
+
 		public bool Installing { get; }
 
 		public bool Installed { get; }
@@ -210,7 +216,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			var esEnvironmentConfig = ElasticsearchEnvironmentConfiguration.Default;
 			var serviceState = ServiceStateProvider.FromSession(session, ServiceModel.ElasticsearchServiceName);
 			var pluginState = PluginStateProviderBase.ElasticsearchDefault(session);
-
+			
 			var esConfig = ElasticsearchYamlConfiguration.FromFolder(esEnvironmentConfig.ConfigDirectory);
 			var jvmConfig = LocalJvmOptionsConfiguration.FromFolder(esEnvironmentConfig.ConfigDirectory);
 			var fileSystem = new FileSystem();
@@ -276,7 +282,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch
 			this.JavaInstalled = JavaConfiguration.JavaInstalled;
 			this.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome = ElasticsearchEnvironmentConfiguration.ConfigDirectoryIsSpecifiedAndSubPathOfEsHome;
 
-			this.HasEsHomeVariableButNoPreviousInstallation = 
+			// skip validation during the execution of the tasks, the validate argument tasks will handle this.
+			if (this.InstallationInProgress) this.HasEsHomeVariableButNoPreviousInstallation = false;
+			else this.HasEsHomeVariableButNoPreviousInstallation = 
 				!this.UnInstalling && !this.Installed && !string.IsNullOrWhiteSpace(ElasticsearchEnvironmentConfiguration.HomeDirectoryFromEnvironmentVariable);
 
 			this.JavaMisconfigured = JavaConfiguration.JavaMisconfigured;

--- a/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
+++ b/src/Installer/Elastic.Installer.Msi/_Generated/elasticsearch.wxs
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="1c17c35c-b09f-4c5d-a271-0ba0f03d591f" Name="Elasticsearch 6.3.1" Language="1033" Codepage="Windows-1252" Version="6.3.1" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
+  <Product Id="183c1455-1bdf-4e9c-a07b-bfba13447735" Name="Elasticsearch 6.3.0" Language="1033" Codepage="Windows-1252" Version="6.3.0" UpgradeCode="daaa2cba-a1ed-4f29-afbf-5478617b00f6" Manufacturer="Elastic">
     <Package InstallerVersion="200" Compressed="yes" Platform="x64" SummaryCodepage="Windows-1252" Languages="1033" InstallScope="perMachine" />
-    <Media Id="1" Cabinet="Elasticsearch_6.3.1_.cab" EmbedCab="yes" />
+    <Media Id="1" Cabinet="Elasticsearch_6.3.0_.cab" EmbedCab="yes" />
 
     <Condition Message="This installer requires at least .NET Framework 4.5 in order to run custom install actions. Please install .NET Framework 4.5 then run this installer again.">Installed OR NETFRAMEWORK45</Condition>
 
@@ -10,7 +10,7 @@
       <Directory Id="ProgramFiles64Folder" Name="ProgramFiles64Folder">
         <Directory Id="Elastic" Name="Elastic">
           <Directory Id="Product" Name="Elasticsearch">
-            <Directory Id="INSTALLDIR" Name="6.3.1">
+            <Directory Id="INSTALLDIR" Name="6.3.0">
               <Directory Id="INSTALLDIR.plugins" Name="plugins">
 
                 <Component Id="Component.INSTALLDIR.plugins" Guid="daaa2cba-a1ed-4f29-afbf-5478fc1afb65" Win64="yes">
@@ -26,15 +26,15 @@
               </Component>
 
               <Component Id="Component.LICENSE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478ddff8dfd" Win64="yes">
-                <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.3.1\LICENSE.txt" />
+                <File Id="LICENSE.txt" Source="..\..\..\build\in\elasticsearch-6.3.0\LICENSE.txt" />
               </Component>
 
               <Component Id="Component.NOTICE.txt" Guid="daaa2cba-a1ed-4f29-afbf-5478beafcf50" Win64="yes">
-                <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.3.1\NOTICE.txt" />
+                <File Id="NOTICE.txt" Source="..\..\..\build\in\elasticsearch-6.3.0\NOTICE.txt" />
               </Component>
 
               <Component Id="Component.README.textile" Guid="daaa2cba-a1ed-4f29-afbf-54787569b372" Win64="yes">
-                <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.3.1\README.textile" />
+                <File Id="README.textile" Source="..\..\..\build\in\elasticsearch-6.3.0\README.textile" />
               </Component>
 
               <Directory Id="INSTALLDIR.bin" Name="bin">
@@ -53,63 +53,63 @@
                 </Component>
 
                 <Component Id="Component.elasticsearch_certgen.bat" Guid="daaa2cba-a1ed-4f29-afbf-54784ab83d85" Win64="yes">
-                  <File Id="elasticsearch_certgen.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-certgen.bat" />
+                  <File Id="elasticsearch_certgen.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-certgen.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_certutil.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478d9d00c2d" Win64="yes">
-                  <File Id="elasticsearch_certutil.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-certutil.bat" />
+                  <File Id="elasticsearch_certutil.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-certutil.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_croneval.bat" Guid="daaa2cba-a1ed-4f29-afbf-547891a0c98c" Win64="yes">
-                  <File Id="elasticsearch_croneval.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-croneval.bat" />
+                  <File Id="elasticsearch_croneval.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-croneval.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478f708a154" Win64="yes">
-                  <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-env.bat" />
+                  <File Id="elasticsearch_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-env.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_keystore.bat" Guid="daaa2cba-a1ed-4f29-afbf-547886c8d35a" Win64="yes">
-                  <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-keystore.bat" />
+                  <File Id="elasticsearch_keystore.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-keystore.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_migrate.bat" Guid="daaa2cba-a1ed-4f29-afbf-54789a18eb19" Win64="yes">
-                  <File Id="elasticsearch_migrate.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-migrate.bat" />
+                  <File Id="elasticsearch_migrate.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-migrate.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_plugin.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780b44f88c" Win64="yes">
-                  <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-plugin.bat" />
+                  <File Id="elasticsearch_plugin.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-plugin.bat" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-5478c5bda48e" Win64="yes" Id="Component.INSTALLDIR_bin.elasticsearch_saml_metadata.bat">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-saml-metadata.bat" Id="INSTALLDIR_bin.elasticsearch_saml_metadata.bat" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-saml-metadata.bat" Id="INSTALLDIR_bin.elasticsearch_saml_metadata.bat" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-5478c3966a75" Win64="yes" Id="Component.INSTALLDIR_bin.elasticsearch_setup_passwords.bat">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-setup-passwords.bat" Id="INSTALLDIR_bin.elasticsearch_setup_passwords.bat" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-setup-passwords.bat" Id="INSTALLDIR_bin.elasticsearch_setup_passwords.bat" />
                 </Component>
 
-                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478a26ebaf1" Win64="yes" Id="Component.INSTALLDIR_bin.elasticsearch_sql_cli_6.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-sql-cli-6.3.1.jar" Id="INSTALLDIR_bin.elasticsearch_sql_cli_6.3.1.jar" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478949fbaf1" Win64="yes" Id="Component.INSTALLDIR_bin.elasticsearch_sql_cli_6.3.0.jar">
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-sql-cli-6.3.0.jar" Id="INSTALLDIR_bin.elasticsearch_sql_cli_6.3.0.jar" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_sql_cli.bat" Guid="daaa2cba-a1ed-4f29-afbf-547847acf46a" Win64="yes">
-                  <File Id="elasticsearch_sql_cli.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-sql-cli.bat" />
+                  <File Id="elasticsearch_sql_cli.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-sql-cli.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_syskeygen.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478c170bb7f" Win64="yes">
-                  <File Id="elasticsearch_syskeygen.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-syskeygen.bat" />
+                  <File Id="elasticsearch_syskeygen.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-syskeygen.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_translog.bat" Guid="daaa2cba-a1ed-4f29-afbf-547861a30033" Win64="yes">
-                  <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-translog.bat" />
+                  <File Id="elasticsearch_translog.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-translog.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch_users.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478c1f2b8ee" Win64="yes">
-                  <File Id="elasticsearch_users.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch-users.bat" />
+                  <File Id="elasticsearch_users.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch-users.bat" />
                 </Component>
 
                 <Component Id="Component.elasticsearch.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478f1f18046" Win64="yes">
-                  <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\elasticsearch.exe" />
+                  <File Id="elasticsearch.exe" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\elasticsearch.exe" />
 
                   <ServiceInstall Id="ElasticsearchService" Name="Elasticsearch" DisplayName="Elasticsearch" Description="You know, for Search." Type="ownProcess" Start="auto" ErrorControl="normal" Account="[ServiceAccount]" Interactive="no" Password="[ServicePassword]" Vital="yes" />
 
@@ -119,15 +119,15 @@
                 </Component>
 
                 <Component Id="Component.x_pack_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478511014df" Win64="yes">
-                  <File Id="x_pack_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack-env.bat" />
+                  <File Id="x_pack_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack-env.bat" />
                 </Component>
 
                 <Component Id="Component.x_pack_security_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-547864321760" Win64="yes">
-                  <File Id="x_pack_security_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack-security-env.bat" />
+                  <File Id="x_pack_security_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack-security-env.bat" />
                 </Component>
 
                 <Component Id="Component.x_pack_watcher_env.bat" Guid="daaa2cba-a1ed-4f29-afbf-54780aba9e52" Win64="yes">
-                  <File Id="x_pack_watcher_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack-watcher-env.bat" />
+                  <File Id="x_pack_watcher_env.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack-watcher-env.bat" />
                 </Component>
 
                 <Directory Id="INSTALLDIR.bin.x_pack" Name="x-pack">
@@ -138,75 +138,75 @@
                   </Component>
 
                   <Component Id="Component.certgen" Guid="daaa2cba-a1ed-4f29-afbf-54783406527f" Win64="yes">
-                    <File Id="certgen" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\certgen" />
+                    <File Id="certgen" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\certgen" />
                   </Component>
 
                   <Component Id="Component.certgen.bat" Guid="daaa2cba-a1ed-4f29-afbf-547806b1e999" Win64="yes">
-                    <File Id="certgen.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\certgen.bat" />
+                    <File Id="certgen.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\certgen.bat" />
                   </Component>
 
                   <Component Id="Component.certutil" Guid="daaa2cba-a1ed-4f29-afbf-54780dccf200" Win64="yes">
-                    <File Id="certutil" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\certutil" />
+                    <File Id="certutil" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\certutil" />
                   </Component>
 
                   <Component Id="Component.certutil.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478cc7051af" Win64="yes">
-                    <File Id="certutil.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\certutil.bat" />
+                    <File Id="certutil.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\certutil.bat" />
                   </Component>
 
                   <Component Id="Component.croneval" Guid="daaa2cba-a1ed-4f29-afbf-547851a13c1b" Win64="yes">
-                    <File Id="croneval" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\croneval" />
+                    <File Id="croneval" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\croneval" />
                   </Component>
 
                   <Component Id="Component.croneval.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478e1726b0d" Win64="yes">
-                    <File Id="croneval.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\croneval.bat" />
+                    <File Id="croneval.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\croneval.bat" />
                   </Component>
 
                   <Component Id="Component.migrate" Guid="daaa2cba-a1ed-4f29-afbf-54785f215251" Win64="yes">
-                    <File Id="migrate" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\migrate" />
+                    <File Id="migrate" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\migrate" />
                   </Component>
 
                   <Component Id="Component.migrate.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478310095d3" Win64="yes">
-                    <File Id="migrate.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\migrate.bat" />
+                    <File Id="migrate.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\migrate.bat" />
                   </Component>
 
                   <Component Id="Component.saml_metadata" Guid="daaa2cba-a1ed-4f29-afbf-5478c8d12147" Win64="yes">
-                    <File Id="saml_metadata" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\saml-metadata" />
+                    <File Id="saml_metadata" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\saml-metadata" />
                   </Component>
 
                   <Component Id="Component.saml_metadata.bat" Guid="daaa2cba-a1ed-4f29-afbf-547895b0361a" Win64="yes">
-                    <File Id="saml_metadata.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\saml-metadata.bat" />
+                    <File Id="saml_metadata.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\saml-metadata.bat" />
                   </Component>
 
                   <Component Id="Component.setup_passwords" Guid="daaa2cba-a1ed-4f29-afbf-5478efb263ad" Win64="yes">
-                    <File Id="setup_passwords" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\setup-passwords" />
+                    <File Id="setup_passwords" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\setup-passwords" />
                   </Component>
 
                   <Component Id="Component.setup_passwords.bat" Guid="daaa2cba-a1ed-4f29-afbf-54784748b8ec" Win64="yes">
-                    <File Id="setup_passwords.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\setup-passwords.bat" />
+                    <File Id="setup_passwords.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\setup-passwords.bat" />
                   </Component>
 
                   <Component Id="Component.sql_cli" Guid="daaa2cba-a1ed-4f29-afbf-54788d617e1c" Win64="yes">
-                    <File Id="sql_cli" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\sql-cli" />
+                    <File Id="sql_cli" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\sql-cli" />
                   </Component>
 
                   <Component Id="Component.sql_cli.bat" Guid="daaa2cba-a1ed-4f29-afbf-54789e3f9f24" Win64="yes">
-                    <File Id="sql_cli.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\sql-cli.bat" />
+                    <File Id="sql_cli.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\sql-cli.bat" />
                   </Component>
 
                   <Component Id="Component.syskeygen" Guid="daaa2cba-a1ed-4f29-afbf-5478ecf63072" Win64="yes">
-                    <File Id="syskeygen" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\syskeygen" />
+                    <File Id="syskeygen" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\syskeygen" />
                   </Component>
 
                   <Component Id="Component.syskeygen.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478c4e987c7" Win64="yes">
-                    <File Id="syskeygen.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\syskeygen.bat" />
+                    <File Id="syskeygen.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\syskeygen.bat" />
                   </Component>
 
                   <Component Id="Component.users" Guid="daaa2cba-a1ed-4f29-afbf-54785c4bb70a" Win64="yes">
-                    <File Id="users" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\users" />
+                    <File Id="users" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\users" />
                   </Component>
 
                   <Component Id="Component.users.bat" Guid="daaa2cba-a1ed-4f29-afbf-5478a99af13c" Win64="yes">
-                    <File Id="users.bat" Source="..\..\..\build\in\elasticsearch-6.3.1\bin\x-pack\users.bat" />
+                    <File Id="users.bat" Source="..\..\..\build\in\elasticsearch-6.3.0\bin\x-pack\users.bat" />
                   </Component>
 
                 </Directory>
@@ -220,31 +220,31 @@
                 </Component>
 
                 <Component Id="Component.elasticsearch.yml" Guid="daaa2cba-a1ed-4f29-afbf-547839fb66cf" Win64="yes">
-                  <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.3.1\config\elasticsearch.yml" />
+                  <File Id="elasticsearch.yml" Source="..\..\..\build\in\elasticsearch-6.3.0\config\elasticsearch.yml" />
                 </Component>
 
                 <Component Id="Component.jvm.options" Guid="daaa2cba-a1ed-4f29-afbf-547881624924" Win64="yes">
-                  <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.3.1\config\jvm.options" />
+                  <File Id="jvm.options" Source="..\..\..\build\in\elasticsearch-6.3.0\config\jvm.options" />
                 </Component>
 
                 <Component Id="Component.log4j2.properties" Guid="daaa2cba-a1ed-4f29-afbf-5478d3b0653b" Win64="yes">
-                  <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.3.1\config\log4j2.properties" />
+                  <File Id="log4j2.properties" Source="..\..\..\build\in\elasticsearch-6.3.0\config\log4j2.properties" />
                 </Component>
 
                 <Component Id="Component.roles.yml" Guid="daaa2cba-a1ed-4f29-afbf-54782aa20c3a" Win64="yes">
-                  <File Id="roles.yml" Source="..\..\..\build\in\elasticsearch-6.3.1\config\roles.yml" />
+                  <File Id="roles.yml" Source="..\..\..\build\in\elasticsearch-6.3.0\config\roles.yml" />
                 </Component>
 
                 <Component Id="Component.role_mapping.yml" Guid="daaa2cba-a1ed-4f29-afbf-5478f460c6c6" Win64="yes">
-                  <File Id="role_mapping.yml" Source="..\..\..\build\in\elasticsearch-6.3.1\config\role_mapping.yml" />
+                  <File Id="role_mapping.yml" Source="..\..\..\build\in\elasticsearch-6.3.0\config\role_mapping.yml" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-5478a07f444b" Win64="yes" Id="Component.INSTALLDIR_config.users">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\config\users" Id="INSTALLDIR_config.users" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\config\users" Id="INSTALLDIR_config.users" />
                 </Component>
 
                 <Component Id="Component.users_roles" Guid="daaa2cba-a1ed-4f29-afbf-547817163ccc" Win64="yes">
-                  <File Id="users_roles" Source="..\..\..\build\in\elasticsearch-6.3.1\config\users_roles" />
+                  <File Id="users_roles" Source="..\..\..\build\in\elasticsearch-6.3.0\config\users_roles" />
                 </Component>
 
               </Directory>
@@ -256,160 +256,160 @@
                   <RemoveFolder Id="INSTALLDIR.lib.dir" On="both" />
                 </Component>
 
-                <Component Id="Component.elasticsearch_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782dee4650" Win64="yes">
-                  <File Id="elasticsearch_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\elasticsearch-6.3.1.jar" />
+                <Component Id="Component.elasticsearch_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782dee462d" Win64="yes">
+                  <File Id="elasticsearch_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\elasticsearch-6.3.0.jar" />
                 </Component>
 
-                <Component Id="Component.elasticsearch_cli_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478880c88f6" Win64="yes">
-                  <File Id="elasticsearch_cli_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\elasticsearch-cli-6.3.1.jar" />
+                <Component Id="Component.elasticsearch_cli_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478880c8711" Win64="yes">
+                  <File Id="elasticsearch_cli_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\elasticsearch-cli-6.3.0.jar" />
                 </Component>
 
-                <Component Id="Component.elasticsearch_core_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547884c0121c" Win64="yes">
-                  <File Id="elasticsearch_core_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\elasticsearch-core-6.3.1.jar" />
+                <Component Id="Component.elasticsearch_core_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547884db121c" Win64="yes">
+                  <File Id="elasticsearch_core_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\elasticsearch-core-6.3.0.jar" />
                 </Component>
 
-                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ff610838" Win64="yes" Id="Component.INSTALLDIR_lib.elasticsearch_launchers_6.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\elasticsearch-launchers-6.3.1.jar" Id="INSTALLDIR_lib.elasticsearch_launchers_6.3.1.jar" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ff460838" Win64="yes" Id="Component.INSTALLDIR_lib.elasticsearch_launchers_6.3.0.jar">
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\elasticsearch-launchers-6.3.0.jar" Id="INSTALLDIR_lib.elasticsearch_launchers_6.3.0.jar" />
                 </Component>
 
-                <Component Guid="daaa2cba-a1ed-4f29-afbf-54786f019058" Win64="yes" Id="Component.INSTALLDIR_lib.elasticsearch_secure_sm_6.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\elasticsearch-secure-sm-6.3.1.jar" Id="INSTALLDIR_lib.elasticsearch_secure_sm_6.3.1.jar" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54786f209058" Win64="yes" Id="Component.INSTALLDIR_lib.elasticsearch_secure_sm_6.3.0.jar">
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\elasticsearch-secure-sm-6.3.0.jar" Id="INSTALLDIR_lib.elasticsearch_secure_sm_6.3.0.jar" />
                 </Component>
 
-                <Component Guid="daaa2cba-a1ed-4f29-afbf-54785cbf7d19" Win64="yes" Id="Component.INSTALLDIR_lib.elasticsearch_x_content_6.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\elasticsearch-x-content-6.3.1.jar" Id="INSTALLDIR_lib.elasticsearch_x_content_6.3.1.jar" />
+                <Component Guid="daaa2cba-a1ed-4f29-afbf-54785bde7d19" Win64="yes" Id="Component.INSTALLDIR_lib.elasticsearch_x_content_6.3.0.jar">
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\elasticsearch-x-content-6.3.0.jar" Id="INSTALLDIR_lib.elasticsearch_x_content_6.3.0.jar" />
                 </Component>
 
                 <Component Id="Component.HdrHistogram_2.1.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780dd2332f" Win64="yes">
-                  <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\HdrHistogram-2.1.9.jar" />
+                  <File Id="HdrHistogram_2.1.9.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\HdrHistogram-2.1.9.jar" />
                 </Component>
 
                 <Component Id="Component.hppc_0.7.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa74fa4a" Win64="yes">
-                  <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\hppc-0.7.1.jar" />
+                  <File Id="hppc_0.7.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\hppc-0.7.1.jar" />
                 </Component>
 
                 <Component Id="Component.jackson_core_2.8.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783ce13793" Win64="yes">
-                  <File Id="jackson_core_2.8.10.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jackson-core-2.8.10.jar" />
+                  <File Id="jackson_core_2.8.10.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jackson-core-2.8.10.jar" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-547831242213" Win64="yes" Id="Component.INSTALLDIR_lib.jackson_dataformat_cbor_2.8.10.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jackson-dataformat-cbor-2.8.10.jar" Id="INSTALLDIR_lib.jackson_dataformat_cbor_2.8.10.jar" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jackson-dataformat-cbor-2.8.10.jar" Id="INSTALLDIR_lib.jackson_dataformat_cbor_2.8.10.jar" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-5478787bcd26" Win64="yes" Id="Component.INSTALLDIR_lib.jackson_dataformat_smile_2.8.10.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jackson-dataformat-smile-2.8.10.jar" Id="INSTALLDIR_lib.jackson_dataformat_smile_2.8.10.jar" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jackson-dataformat-smile-2.8.10.jar" Id="INSTALLDIR_lib.jackson_dataformat_smile_2.8.10.jar" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-547826cb24bd" Win64="yes" Id="Component.INSTALLDIR_lib.jackson_dataformat_yaml_2.8.10.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jackson-dataformat-yaml-2.8.10.jar" Id="INSTALLDIR_lib.jackson_dataformat_yaml_2.8.10.jar" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jackson-dataformat-yaml-2.8.10.jar" Id="INSTALLDIR_lib.jackson_dataformat_yaml_2.8.10.jar" />
                 </Component>
 
                 <Component Id="Component.jna_4.5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547822baa1ca" Win64="yes">
-                  <File Id="jna_4.5.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jna-4.5.1.jar" />
+                  <File Id="jna_4.5.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jna-4.5.1.jar" />
                 </Component>
 
                 <Component Id="Component.joda_time_2.9.9.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d10c31b0" Win64="yes">
-                  <File Id="joda_time_2.9.9.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\joda-time-2.9.9.jar" />
+                  <File Id="joda_time_2.9.9.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\joda-time-2.9.9.jar" />
                 </Component>
 
                 <Component Id="Component.jopt_simple_5.0.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780c1170ff" Win64="yes">
-                  <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jopt-simple-5.0.2.jar" />
+                  <File Id="jopt_simple_5.0.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jopt-simple-5.0.2.jar" />
                 </Component>
 
                 <Component Id="Component.jts_core_1.15.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478cd9226ca" Win64="yes">
-                  <File Id="jts_core_1.15.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\jts-core-1.15.0.jar" />
+                  <File Id="jts_core_1.15.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\jts-core-1.15.0.jar" />
                 </Component>
 
                 <Component Id="Component.log4j_1.2_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547890a47e2d" Win64="yes">
-                  <File Id="log4j_1.2_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\log4j-1.2-api-2.9.1.jar" />
+                  <File Id="log4j_1.2_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\log4j-1.2-api-2.9.1.jar" />
                 </Component>
 
                 <Component Id="Component.log4j_api_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d6f021e" Win64="yes">
-                  <File Id="log4j_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\log4j-api-2.9.1.jar" />
+                  <File Id="log4j_api_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\log4j-api-2.9.1.jar" />
                 </Component>
 
                 <Component Id="Component.log4j_core_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e7d0b698" Win64="yes">
-                  <File Id="log4j_core_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\log4j-core-2.9.1.jar" />
+                  <File Id="log4j_core_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\log4j-core-2.9.1.jar" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-5478962f6964" Win64="yes" Id="Component.INSTALLDIR_lib.lucene_analyzers_common_7.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-analyzers-common-7.3.1.jar" Id="INSTALLDIR_lib.lucene_analyzers_common_7.3.1.jar" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-analyzers-common-7.3.1.jar" Id="INSTALLDIR_lib.lucene_analyzers_common_7.3.1.jar" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-5478d60b6110" Win64="yes" Id="Component.INSTALLDIR_lib.lucene_backward_codecs_7.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-backward-codecs-7.3.1.jar" Id="INSTALLDIR_lib.lucene_backward_codecs_7.3.1.jar" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-backward-codecs-7.3.1.jar" Id="INSTALLDIR_lib.lucene_backward_codecs_7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_core_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a12455f4" Win64="yes">
-                  <File Id="lucene_core_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-core-7.3.1.jar" />
+                  <File Id="lucene_core_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-core-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_grouping_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788f6cd50b" Win64="yes">
-                  <File Id="lucene_grouping_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-grouping-7.3.1.jar" />
+                  <File Id="lucene_grouping_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-grouping-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_highlighter_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ca090fdb" Win64="yes">
-                  <File Id="lucene_highlighter_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-highlighter-7.3.1.jar" />
+                  <File Id="lucene_highlighter_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-highlighter-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_join_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c83b475" Win64="yes">
-                  <File Id="lucene_join_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-join-7.3.1.jar" />
+                  <File Id="lucene_join_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-join-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_memory_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787f39eeea" Win64="yes">
-                  <File Id="lucene_memory_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-memory-7.3.1.jar" />
+                  <File Id="lucene_memory_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-memory-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_misc_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d5ecee14" Win64="yes">
-                  <File Id="lucene_misc_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-misc-7.3.1.jar" />
+                  <File Id="lucene_misc_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-misc-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_queries_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ee3b136d" Win64="yes">
-                  <File Id="lucene_queries_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-queries-7.3.1.jar" />
+                  <File Id="lucene_queries_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-queries-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_queryparser_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b150e130" Win64="yes">
-                  <File Id="lucene_queryparser_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-queryparser-7.3.1.jar" />
+                  <File Id="lucene_queryparser_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-queryparser-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_sandbox_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478e87da387" Win64="yes">
-                  <File Id="lucene_sandbox_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-sandbox-7.3.1.jar" />
+                  <File Id="lucene_sandbox_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-sandbox-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_spatial_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547871bceaf2" Win64="yes">
-                  <File Id="lucene_spatial_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-spatial-7.3.1.jar" />
+                  <File Id="lucene_spatial_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-spatial-7.3.1.jar" />
                 </Component>
 
                 <Component Guid="daaa2cba-a1ed-4f29-afbf-54783367caca" Win64="yes" Id="Component.INSTALLDIR_lib.lucene_spatial_extras_7.3.1.jar">
-                  <File Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-spatial-extras-7.3.1.jar" Id="INSTALLDIR_lib.lucene_spatial_extras_7.3.1.jar" />
+                  <File Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-spatial-extras-7.3.1.jar" Id="INSTALLDIR_lib.lucene_spatial_extras_7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_spatial3d_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826561cc7" Win64="yes">
-                  <File Id="lucene_spatial3d_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-spatial3d-7.3.1.jar" />
+                  <File Id="lucene_spatial3d_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-spatial3d-7.3.1.jar" />
                 </Component>
 
                 <Component Id="Component.lucene_suggest_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478acf9c821" Win64="yes">
-                  <File Id="lucene_suggest_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\lucene-suggest-7.3.1.jar" />
+                  <File Id="lucene_suggest_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\lucene-suggest-7.3.1.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_classloader_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bd3c9db8" Win64="yes">
-                  <File Id="plugin_classloader_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\plugin-classloader-6.3.1.jar" />
+                <Component Id="Component.plugin_classloader_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc5f9db8" Win64="yes">
+                  <File Id="plugin_classloader_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\plugin-classloader-6.3.0.jar" />
                 </Component>
 
-                <Component Id="Component.plugin_cli_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478aa2a650f" Win64="yes">
-                  <File Id="plugin_cli_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\plugin-cli-6.3.1.jar" />
+                <Component Id="Component.plugin_cli_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478aa0f650f" Win64="yes">
+                  <File Id="plugin_cli_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\plugin-cli-6.3.0.jar" />
                 </Component>
 
                 <Component Id="Component.snakeyaml_1.17.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780d9bea35" Win64="yes">
-                  <File Id="snakeyaml_1.17.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\snakeyaml-1.17.jar" />
+                  <File Id="snakeyaml_1.17.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\snakeyaml-1.17.jar" />
                 </Component>
 
                 <Component Id="Component.spatial4j_0.7.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c0fe38cd" Win64="yes">
-                  <File Id="spatial4j_0.7.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\spatial4j-0.7.jar" />
+                  <File Id="spatial4j_0.7.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\spatial4j-0.7.jar" />
                 </Component>
 
                 <Component Id="Component.t_digest_3.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547812cf2469" Win64="yes">
-                  <File Id="t_digest_3.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\lib\t-digest-3.2.jar" />
+                  <File Id="t_digest_3.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\lib\t-digest-3.2.jar" />
                 </Component>
 
               </Directory>
@@ -422,12 +422,12 @@
                     <RemoveFolder Id="INSTALLDIR.modules.aggs_matrix_stats.dir" On="both" />
                   </Component>
 
-                  <Component Id="Component.aggs_matrix_stats_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478830746c1" Win64="yes">
-                    <File Id="aggs_matrix_stats_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\aggs-matrix-stats\aggs-matrix-stats-6.3.1.jar" />
+                  <Component Id="Component.aggs_matrix_stats_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478830746e4" Win64="yes">
+                    <File Id="aggs_matrix_stats_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\aggs-matrix-stats\aggs-matrix-stats-6.3.0.jar" />
                   </Component>
 
                   <Component Id="Component.plugin_descriptor.properties" Guid="daaa2cba-a1ed-4f29-afbf-547893a03ecb" Win64="yes">
-                    <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\aggs-matrix-stats\plugin-descriptor.properties" />
+                    <File Id="plugin_descriptor.properties" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\aggs-matrix-stats\plugin-descriptor.properties" />
                   </Component>
 
                 </Directory>
@@ -439,12 +439,12 @@
                     <RemoveFolder Id="INSTALLDIR.modules.analysis_common.dir" On="both" />
                   </Component>
 
-                  <Component Id="Component.analysis_common_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547861de5aae" Win64="yes">
-                    <File Id="analysis_common_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\analysis-common\analysis-common-6.3.1.jar" />
+                  <Component Id="Component.analysis_common_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547813257973" Win64="yes">
+                    <File Id="analysis_common_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\analysis-common\analysis-common-6.3.0.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54786898f1bb" Win64="yes" Id="Component.INSTALLDIR_modules_analysis_common.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\analysis-common\plugin-descriptor.properties" Id="INSTALLDIR_modules_analysis_common.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\analysis-common\plugin-descriptor.properties" Id="INSTALLDIR_modules_analysis_common.plugin_descriptor.properties" />
                   </Component>
 
                 </Directory>
@@ -456,24 +456,24 @@
                     <RemoveFolder Id="INSTALLDIR.modules.ingest_common.dir" On="both" />
                   </Component>
 
-                  <Component Id="Component.elasticsearch_grok_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787a773f23" Win64="yes">
-                    <File Id="elasticsearch_grok_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\ingest-common\elasticsearch-grok-6.3.1.jar" />
+                  <Component Id="Component.elasticsearch_grok_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787a5c3f23" Win64="yes">
+                    <File Id="elasticsearch_grok_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\ingest-common\elasticsearch-grok-6.3.0.jar" />
                   </Component>
 
-                  <Component Id="Component.ingest_common_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786d445dce" Win64="yes">
-                    <File Id="ingest_common_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\ingest-common\ingest-common-6.3.1.jar" />
+                  <Component Id="Component.ingest_common_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786d445df1" Win64="yes">
+                    <File Id="ingest_common_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\ingest-common\ingest-common-6.3.0.jar" />
                   </Component>
 
                   <Component Id="Component.jcodings_1.0.12.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787d9200c1" Win64="yes">
-                    <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\ingest-common\jcodings-1.0.12.jar" />
+                    <File Id="jcodings_1.0.12.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\ingest-common\jcodings-1.0.12.jar" />
                   </Component>
 
                   <Component Id="Component.joni_2.1.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f85a6" Win64="yes">
-                    <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\ingest-common\joni-2.1.6.jar" />
+                    <File Id="joni_2.1.6.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\ingest-common\joni-2.1.6.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cdceb27e" Win64="yes" Id="Component.INSTALLDIR_modules_ingest_common.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\ingest-common\plugin-descriptor.properties" Id="INSTALLDIR_modules_ingest_common.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\ingest-common\plugin-descriptor.properties" Id="INSTALLDIR_modules_ingest_common.plugin_descriptor.properties" />
                   </Component>
 
                 </Directory>
@@ -486,35 +486,35 @@
                   </Component>
 
                   <Component Id="Component.antlr4_runtime_4.5.1_1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789ca4f8e5" Win64="yes">
-                    <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
+                    <File Id="antlr4_runtime_4.5.1_1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\antlr4-runtime-4.5.1-1.jar" />
                   </Component>
 
                   <Component Id="Component.asm_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478540b35bc" Win64="yes">
-                    <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\asm-5.0.4.jar" />
+                    <File Id="asm_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\asm-5.0.4.jar" />
                   </Component>
 
                   <Component Id="Component.asm_commons_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786365adc3" Win64="yes">
-                    <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\asm-commons-5.0.4.jar" />
+                    <File Id="asm_commons_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\asm-commons-5.0.4.jar" />
                   </Component>
 
                   <Component Id="Component.asm_tree_5.0.4.jar" Guid="daaa2cba-a1ed-4f29-afbf-547838441039" Win64="yes">
-                    <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\asm-tree-5.0.4.jar" />
+                    <File Id="asm_tree_5.0.4.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\asm-tree-5.0.4.jar" />
                   </Component>
 
-                  <Component Id="Component.lang_expression_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478386a3b92" Win64="yes">
-                    <File Id="lang_expression_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\lang-expression-6.3.1.jar" />
+                  <Component Id="Component.lang_expression_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ebb15a57" Win64="yes">
+                    <File Id="lang_expression_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\lang-expression-6.3.0.jar" />
                   </Component>
 
                   <Component Id="Component.lucene_expressions_7.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c3d226c8" Win64="yes">
-                    <File Id="lucene_expressions_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\lucene-expressions-7.3.1.jar" />
+                    <File Id="lucene_expressions_7.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\lucene-expressions-7.3.1.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54786e88142e" Win64="yes" Id="Component.INSTALLDIR_modules_lang_expression.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\plugin-descriptor.properties" Id="INSTALLDIR_modules_lang_expression.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\plugin-descriptor.properties" Id="INSTALLDIR_modules_lang_expression.plugin_descriptor.properties" />
                   </Component>
 
                   <Component Id="Component.plugin_security.policy" Guid="daaa2cba-a1ed-4f29-afbf-547883f186ed" Win64="yes">
-                    <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-expression\plugin-security.policy" />
+                    <File Id="plugin_security.policy" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-expression\plugin-security.policy" />
                   </Component>
 
                 </Directory>
@@ -527,19 +527,19 @@
                   </Component>
 
                   <Component Id="Component.compiler_0.9.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547820e67731" Win64="yes">
-                    <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-mustache\compiler-0.9.3.jar" />
+                    <File Id="compiler_0.9.3.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-mustache\compiler-0.9.3.jar" />
                   </Component>
 
-                  <Component Id="Component.lang_mustache_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547855ed9a19" Win64="yes">
-                    <File Id="lang_mustache_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-mustache\lang-mustache-6.3.1.jar" />
+                  <Component Id="Component.lang_mustache_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547855ed9afe" Win64="yes">
+                    <File Id="lang_mustache_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-mustache\lang-mustache-6.3.0.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54783505f1ef" Win64="yes" Id="Component.INSTALLDIR_modules_lang_mustache.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-mustache\plugin-descriptor.properties" Id="INSTALLDIR_modules_lang_mustache.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-mustache\plugin-descriptor.properties" Id="INSTALLDIR_modules_lang_mustache.plugin_descriptor.properties" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478793dab31" Win64="yes" Id="Component.INSTALLDIR_modules_lang_mustache.plugin_security.policy">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-mustache\plugin-security.policy" Id="INSTALLDIR_modules_lang_mustache.plugin_security.policy" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-mustache\plugin-security.policy" Id="INSTALLDIR_modules_lang_mustache.plugin_security.policy" />
                   </Component>
 
                 </Directory>
@@ -552,27 +552,27 @@
                   </Component>
 
                   <Component Id="Component.antlr4_runtime_4.5.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478082a7b0f" Win64="yes">
-                    <File Id="antlr4_runtime_4.5.3.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-painless\antlr4-runtime-4.5.3.jar" />
+                    <File Id="antlr4_runtime_4.5.3.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-painless\antlr4-runtime-4.5.3.jar" />
                   </Component>
 
                   <Component Id="Component.asm_debug_all_5.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547850638076" Win64="yes">
-                    <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-painless\asm-debug-all-5.1.jar" />
+                    <File Id="asm_debug_all_5.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-painless\asm-debug-all-5.1.jar" />
                   </Component>
 
-                  <Component Guid="daaa2cba-a1ed-4f29-afbf-547863d162b3" Win64="yes" Id="Component.INSTALLDIR_modules_lang_painless.elasticsearch_scripting_painless_spi_6.3.1.jar">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-painless\elasticsearch-scripting-painless-spi-6.3.1.jar" Id="INSTALLDIR_modules_lang_painless.elasticsearch_scripting_painless_spi_6.3.1.jar" />
+                  <Component Guid="daaa2cba-a1ed-4f29-afbf-547863d16398" Win64="yes" Id="Component.INSTALLDIR_modules_lang_painless.elasticsearch_scripting_painless_spi_6.3.0.jar">
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-painless\elasticsearch-scripting-painless-spi-6.3.0.jar" Id="INSTALLDIR_modules_lang_painless.elasticsearch_scripting_painless_spi_6.3.0.jar" />
                   </Component>
 
-                  <Component Id="Component.lang_painless_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782ff5b6f7" Win64="yes">
-                    <File Id="lang_painless_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-painless\lang-painless-6.3.1.jar" />
+                  <Component Id="Component.lang_painless_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782ff5b616" Win64="yes">
+                    <File Id="lang_painless_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-painless\lang-painless-6.3.0.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-547827a70713" Win64="yes" Id="Component.INSTALLDIR_modules_lang_painless.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-painless\plugin-descriptor.properties" Id="INSTALLDIR_modules_lang_painless.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-painless\plugin-descriptor.properties" Id="INSTALLDIR_modules_lang_painless.plugin_descriptor.properties" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478270aa1e6" Win64="yes" Id="Component.INSTALLDIR_modules_lang_painless.plugin_security.policy">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\lang-painless\plugin-security.policy" Id="INSTALLDIR_modules_lang_painless.plugin_security.policy" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\lang-painless\plugin-security.policy" Id="INSTALLDIR_modules_lang_painless.plugin_security.policy" />
                   </Component>
 
                 </Directory>
@@ -584,12 +584,12 @@
                     <RemoveFolder Id="INSTALLDIR.modules.mapper_extras.dir" On="both" />
                   </Component>
 
-                  <Component Id="Component.mapper_extras_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478723bd2fe" Win64="yes">
-                    <File Id="mapper_extras_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\mapper-extras\mapper-extras-6.3.1.jar" />
+                  <Component Id="Component.mapper_extras_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478723bd21d" Win64="yes">
+                    <File Id="mapper_extras_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\mapper-extras\mapper-extras-6.3.0.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-547881266ec4" Win64="yes" Id="Component.INSTALLDIR_modules_mapper_extras.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\mapper-extras\plugin-descriptor.properties" Id="INSTALLDIR_modules_mapper_extras.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\mapper-extras\plugin-descriptor.properties" Id="INSTALLDIR_modules_mapper_extras.plugin_descriptor.properties" />
                   </Component>
 
                 </Directory>
@@ -601,12 +601,12 @@
                     <RemoveFolder Id="INSTALLDIR.modules.parent_join.dir" On="both" />
                   </Component>
 
-                  <Component Id="Component.parent_join_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478dac59156" Win64="yes">
-                    <File Id="parent_join_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\parent-join\parent-join-6.3.1.jar" />
+                  <Component Id="Component.parent_join_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789de0a025" Win64="yes">
+                    <File Id="parent_join_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\parent-join\parent-join-6.3.0.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cc9a0e01" Win64="yes" Id="Component.INSTALLDIR_modules_parent_join.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\parent-join\plugin-descriptor.properties" Id="INSTALLDIR_modules_parent_join.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\parent-join\plugin-descriptor.properties" Id="INSTALLDIR_modules_parent_join.plugin_descriptor.properties" />
                   </Component>
 
                 </Directory>
@@ -618,12 +618,12 @@
                     <RemoveFolder Id="INSTALLDIR.modules.percolator.dir" On="both" />
                   </Component>
 
-                  <Component Id="Component.percolator_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787691ddf2" Win64="yes">
-                    <File Id="percolator_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\percolator\percolator-6.3.1.jar" />
+                  <Component Id="Component.percolator_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547876b0ddf2" Win64="yes">
+                    <File Id="percolator_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\percolator\percolator-6.3.0.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54783c020d67" Win64="yes" Id="Component.INSTALLDIR_modules_percolator.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\percolator\plugin-descriptor.properties" Id="INSTALLDIR_modules_percolator.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\percolator\plugin-descriptor.properties" Id="INSTALLDIR_modules_percolator.plugin_descriptor.properties" />
                   </Component>
 
                 </Directory>
@@ -636,11 +636,11 @@
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478bdac0056" Win64="yes" Id="Component.INSTALLDIR_modules_rank_eval.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\rank-eval\plugin-descriptor.properties" Id="INSTALLDIR_modules_rank_eval.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\rank-eval\plugin-descriptor.properties" Id="INSTALLDIR_modules_rank_eval.plugin_descriptor.properties" />
                   </Component>
 
-                  <Component Id="Component.rank_eval_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784cdedc70" Win64="yes">
-                    <File Id="rank_eval_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\rank-eval\rank-eval-6.3.1.jar" />
+                  <Component Id="Component.rank_eval_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784cdedc51" Win64="yes">
+                    <File Id="rank_eval_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\rank-eval\rank-eval-6.3.0.jar" />
                   </Component>
 
                 </Directory>
@@ -653,43 +653,43 @@
                   </Component>
 
                   <Component Id="Component.commons_codec_1.10.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478796f5d50" Win64="yes">
-                    <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\commons-codec-1.10.jar" />
+                    <File Id="commons_codec_1.10.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\commons-codec-1.10.jar" />
                   </Component>
 
                   <Component Id="Component.commons_logging_1.1.3.jar" Guid="daaa2cba-a1ed-4f29-afbf-547868ab35a8" Win64="yes">
-                    <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\commons-logging-1.1.3.jar" />
+                    <File Id="commons_logging_1.1.3.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\commons-logging-1.1.3.jar" />
                   </Component>
 
-                  <Component Guid="daaa2cba-a1ed-4f29-afbf-547824d6ed5a" Win64="yes" Id="Component.INSTALLDIR_modules_reindex.elasticsearch_rest_client_6.3.1.jar">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\elasticsearch-rest-client-6.3.1.jar" Id="INSTALLDIR_modules_reindex.elasticsearch_rest_client_6.3.1.jar" />
+                  <Component Guid="daaa2cba-a1ed-4f29-afbf-5478439bed5a" Win64="yes" Id="Component.INSTALLDIR_modules_reindex.elasticsearch_rest_client_6.3.0.jar">
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\elasticsearch-rest-client-6.3.0.jar" Id="INSTALLDIR_modules_reindex.elasticsearch_rest_client_6.3.0.jar" />
                   </Component>
 
                   <Component Id="Component.httpasyncclient_4.1.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547826e95944" Win64="yes">
-                    <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\httpasyncclient-4.1.2.jar" />
+                    <File Id="httpasyncclient_4.1.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\httpasyncclient-4.1.2.jar" />
                   </Component>
 
                   <Component Id="Component.httpclient_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783b3be93b" Win64="yes">
-                    <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\httpclient-4.5.2.jar" />
+                    <File Id="httpclient_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\httpclient-4.5.2.jar" />
                   </Component>
 
                   <Component Id="Component.httpcore_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-547841525bd1" Win64="yes">
-                    <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\httpcore-4.4.5.jar" />
+                    <File Id="httpcore_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\httpcore-4.4.5.jar" />
                   </Component>
 
                   <Component Id="Component.httpcore_nio_4.4.5.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fc877082" Win64="yes">
-                    <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\httpcore-nio-4.4.5.jar" />
+                    <File Id="httpcore_nio_4.4.5.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\httpcore-nio-4.4.5.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54783811755c" Win64="yes" Id="Component.INSTALLDIR_modules_reindex.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\plugin-descriptor.properties" Id="INSTALLDIR_modules_reindex.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\plugin-descriptor.properties" Id="INSTALLDIR_modules_reindex.plugin_descriptor.properties" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478e1e4083f" Win64="yes" Id="Component.INSTALLDIR_modules_reindex.plugin_security.policy">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\plugin-security.policy" Id="INSTALLDIR_modules_reindex.plugin_security.policy" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\plugin-security.policy" Id="INSTALLDIR_modules_reindex.plugin_security.policy" />
                   </Component>
 
-                  <Component Id="Component.reindex_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b4e105eb" Win64="yes">
-                    <File Id="reindex_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\reindex\reindex-6.3.1.jar" />
+                  <Component Id="Component.reindex_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478dc8a5244" Win64="yes">
+                    <File Id="reindex_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\reindex\reindex-6.3.0.jar" />
                   </Component>
 
                 </Directory>
@@ -702,15 +702,15 @@
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478d7ea2190" Win64="yes" Id="Component.INSTALLDIR_modules_repository_url.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\repository-url\plugin-descriptor.properties" Id="INSTALLDIR_modules_repository_url.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\repository-url\plugin-descriptor.properties" Id="INSTALLDIR_modules_repository_url.plugin_descriptor.properties" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478c5d6e5ed" Win64="yes" Id="Component.INSTALLDIR_modules_repository_url.plugin_security.policy">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\repository-url\plugin-security.policy" Id="INSTALLDIR_modules_repository_url.plugin_security.policy" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\repository-url\plugin-security.policy" Id="INSTALLDIR_modules_repository_url.plugin_security.policy" />
                   </Component>
 
-                  <Component Id="Component.repository_url_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547837d959b5" Win64="yes">
-                    <File Id="repository_url_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\repository-url\repository-url-6.3.1.jar" />
+                  <Component Id="Component.repository_url_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478379e59b5" Win64="yes">
+                    <File Id="repository_url_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\repository-url\repository-url-6.3.0.jar" />
                   </Component>
 
                 </Directory>
@@ -723,43 +723,43 @@
                   </Component>
 
                   <Component Id="Component.netty_buffer_4.1.16.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788135113a" Win64="yes">
-                    <File Id="netty_buffer_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-buffer-4.1.16.Final.jar" />
+                    <File Id="netty_buffer_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-buffer-4.1.16.Final.jar" />
                   </Component>
 
                   <Component Id="Component.netty_codec_4.1.16.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478841c2eca" Win64="yes">
-                    <File Id="netty_codec_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-codec-4.1.16.Final.jar" />
+                    <File Id="netty_codec_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-codec-4.1.16.Final.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478fc4c8cfb" Win64="yes" Id="Component.INSTALLDIR_modules_transport_netty4.netty_codec_http_4.1.16.Final.jar">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-codec-http-4.1.16.Final.jar" Id="INSTALLDIR_modules_transport_netty4.netty_codec_http_4.1.16.Final.jar" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-codec-http-4.1.16.Final.jar" Id="INSTALLDIR_modules_transport_netty4.netty_codec_http_4.1.16.Final.jar" />
                   </Component>
 
                   <Component Id="Component.netty_common_4.1.16.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bc7fc943" Win64="yes">
-                    <File Id="netty_common_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-common-4.1.16.Final.jar" />
+                    <File Id="netty_common_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-common-4.1.16.Final.jar" />
                   </Component>
 
                   <Component Id="Component.netty_handler_4.1.16.Final.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ed87ab4a" Win64="yes">
-                    <File Id="netty_handler_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-handler-4.1.16.Final.jar" />
+                    <File Id="netty_handler_4.1.16.Final.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-handler-4.1.16.Final.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54788a86d7eb" Win64="yes" Id="Component.INSTALLDIR_modules_transport_netty4.netty_resolver_4.1.16.Final.jar">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-resolver-4.1.16.Final.jar" Id="INSTALLDIR_modules_transport_netty4.netty_resolver_4.1.16.Final.jar" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-resolver-4.1.16.Final.jar" Id="INSTALLDIR_modules_transport_netty4.netty_resolver_4.1.16.Final.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54787c7488b7" Win64="yes" Id="Component.INSTALLDIR_modules_transport_netty4.netty_transport_4.1.16.Final.jar">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\netty-transport-4.1.16.Final.jar" Id="INSTALLDIR_modules_transport_netty4.netty_transport_4.1.16.Final.jar" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\netty-transport-4.1.16.Final.jar" Id="INSTALLDIR_modules_transport_netty4.netty_transport_4.1.16.Final.jar" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54781f779de5" Win64="yes" Id="Component.INSTALLDIR_modules_transport_netty4.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\plugin-descriptor.properties" Id="INSTALLDIR_modules_transport_netty4.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\plugin-descriptor.properties" Id="INSTALLDIR_modules_transport_netty4.plugin_descriptor.properties" />
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54781012e0c9" Win64="yes" Id="Component.INSTALLDIR_modules_transport_netty4.plugin_security.policy">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\plugin-security.policy" Id="INSTALLDIR_modules_transport_netty4.plugin_security.policy" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\plugin-security.policy" Id="INSTALLDIR_modules_transport_netty4.plugin_security.policy" />
                   </Component>
 
-                  <Component Id="Component.transport_netty4_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ec921d4e" Win64="yes">
-                    <File Id="transport_netty4_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\transport-netty4\transport-netty4-6.3.1.jar" />
+                  <Component Id="Component.transport_netty4_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780a571d4e" Win64="yes">
+                    <File Id="transport_netty4_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\transport-netty4\transport-netty4-6.3.0.jar" />
                   </Component>
 
                 </Directory>
@@ -772,11 +772,11 @@
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-54787fb009d7" Win64="yes" Id="Component.INSTALLDIR_modules_tribe.plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\tribe\plugin-descriptor.properties" Id="INSTALLDIR_modules_tribe.plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\tribe\plugin-descriptor.properties" Id="INSTALLDIR_modules_tribe.plugin_descriptor.properties" />
                   </Component>
 
-                  <Component Id="Component.tribe_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782d180d6d" Win64="yes">
-                    <File Id="tribe_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\tribe\tribe-6.3.1.jar" />
+                  <Component Id="Component.tribe_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782d180d90" Win64="yes">
+                    <File Id="tribe_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\tribe\tribe-6.3.0.jar" />
                   </Component>
 
                 </Directory>
@@ -789,7 +789,7 @@
                   </Component>
 
                   <Component Guid="daaa2cba-a1ed-4f29-afbf-5478eae9ed3f" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack.meta_plugin_descriptor.properties">
-                    <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\meta-plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack.meta_plugin_descriptor.properties" />
+                    <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\meta-plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack.meta_plugin_descriptor.properties" />
                   </Component>
 
                   <Directory Id="INSTALLDIR.modules.x_pack.x_pack_core" Name="x-pack-core">
@@ -800,91 +800,91 @@
                     </Component>
 
                     <Component Id="Component.bcpkix_jdk15on_1.58.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789a09f690" Win64="yes">
-                      <File Id="bcpkix_jdk15on_1.58.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\bcpkix-jdk15on-1.58.jar" />
+                      <File Id="bcpkix_jdk15on_1.58.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\bcpkix-jdk15on-1.58.jar" />
                     </Component>
 
                     <Component Id="Component.bcprov_jdk15on_1.58.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789cbc634e" Win64="yes">
-                      <File Id="bcprov_jdk15on_1.58.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\bcprov-jdk15on-1.58.jar" />
+                      <File Id="bcprov_jdk15on_1.58.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\bcprov-jdk15on-1.58.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478e9cb61da" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.commons_codec_1.10.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\commons-codec-1.10.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.commons_codec_1.10.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\commons-codec-1.10.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.commons_codec_1.10.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54780156a0d6" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.commons_logging_1.1.3.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\commons-logging-1.1.3.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.commons_logging_1.1.3.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\commons-logging-1.1.3.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.commons_logging_1.1.3.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54786e87cfcd" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.httpasyncclient_4.1.2.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\httpasyncclient-4.1.2.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpasyncclient_4.1.2.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\httpasyncclient-4.1.2.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpasyncclient_4.1.2.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547857116a27" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.httpclient_4.5.2.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\httpclient-4.5.2.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpclient_4.5.2.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\httpclient-4.5.2.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpclient_4.5.2.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478015b86ff" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.httpcore_4.4.5.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\httpcore-4.4.5.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpcore_4.4.5.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\httpcore-4.4.5.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpcore_4.4.5.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478bde3e084" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.httpcore_nio_4.4.5.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\httpcore-nio-4.4.5.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpcore_nio_4.4.5.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\httpcore-nio-4.4.5.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.httpcore_nio_4.4.5.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478e810d7cb" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_core.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_core.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478439f286c" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_buffer_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-buffer-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_buffer_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-buffer-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_buffer_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ef853545" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_codec_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-codec-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_codec_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-codec-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_codec_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54782166b092" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_codec_http_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-codec-http-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_codec_http_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-codec-http-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_codec_http_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547887680348" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_common_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-common-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_common_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-common-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_common_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54781b13d43a" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_handler_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-handler-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_handler_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-handler-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_handler_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54788dd8814f" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_resolver_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-resolver-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_resolver_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-resolver-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_resolver_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478a6db1348" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.netty_transport_4.1.16.Final.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\netty-transport-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_transport_4.1.16.Final.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\netty-transport-4.1.16.Final.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.netty_transport_4.1.16.Final.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54786ca23c64" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_core.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_core.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54785d7263e3" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_core.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_core.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547889e8d155" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_core.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_core.plugin_security.policy" />
                     </Component>
 
-                    <Component Guid="daaa2cba-a1ed-4f29-afbf-54780d748ffe" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.transport_netty4_6.3.1.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\transport-netty4-6.3.1.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.transport_netty4_6.3.1.jar" />
+                    <Component Guid="daaa2cba-a1ed-4f29-afbf-54780d518ffe" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.transport_netty4_6.3.0.jar">
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\transport-netty4-6.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_core.transport_netty4_6.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.unboundid_ldapsdk_3.2.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bd2f074d" Win64="yes">
-                      <File Id="unboundid_ldapsdk_3.2.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\unboundid-ldapsdk-3.2.0.jar" />
+                      <File Id="unboundid_ldapsdk_3.2.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\unboundid-ldapsdk-3.2.0.jar" />
                     </Component>
 
-                    <Component Id="Component.x_pack_core_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547829fae675" Win64="yes">
-                      <File Id="x_pack_core_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-core\x-pack-core-6.3.1.jar" />
+                    <Component Id="Component.x_pack_core_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547866dfd7a6" Win64="yes">
+                      <File Id="x_pack_core_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-core\x-pack-core-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -897,23 +897,23 @@
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547861aa6008" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-deprecation\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-deprecation\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478644c81fa" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-deprecation\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-deprecation\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54781a7fc708" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-deprecation\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-deprecation\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f7c02fde" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-deprecation\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-deprecation\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_deprecation_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478deb1c3b2" Win64="yes">
-                      <File Id="x_pack_deprecation_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-deprecation\x-pack-deprecation-6.3.1.jar" />
+                    <Component Id="Component.x_pack_deprecation_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478ddd4c3b2" Win64="yes">
+                      <File Id="x_pack_deprecation_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-deprecation\x-pack-deprecation-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -926,23 +926,23 @@
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547807d34f4e" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-graph\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_graph.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-graph\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_graph.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54787d126d0b" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-graph\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_graph.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-graph\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_graph.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54784dd5b4a9" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-graph\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_graph.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-graph\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_graph.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478e9fb9915" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-graph\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_graph.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-graph\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_graph.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_graph_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d8892477" Win64="yes">
-                      <File Id="x_pack_graph_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-graph\x-pack-graph-6.3.1.jar" />
+                    <Component Id="Component.x_pack_graph_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547854c42477" Win64="yes">
+                      <File Id="x_pack_graph_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-graph\x-pack-graph-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -955,23 +955,23 @@
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ca0c48a9" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-logstash\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-logstash\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478fc19d059" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-logstash\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-logstash\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f73b0776" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-logstash\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-logstash\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478ec824a63" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-logstash\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-logstash\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_logstash_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547882f9ca16" Win64="yes">
-                      <File Id="x_pack_logstash_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-logstash\x-pack-logstash-6.3.1.jar" />
+                    <Component Id="Component.x_pack_logstash_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54783440e8db" Win64="yes">
+                      <File Id="x_pack_logstash_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-logstash\x-pack-logstash-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -984,27 +984,27 @@
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547804d94223" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_ml.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_ml.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478952954b1" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_ml.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_ml.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478d5ecff0c" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_ml.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_ml.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478b7935ce4" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_ml.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_ml.plugin_security.policy" />
                     </Component>
 
                     <Component Id="Component.super_csv_2.4.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547815b5c367" Win64="yes">
-                      <File Id="super_csv_2.4.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\super-csv-2.4.0.jar" />
+                      <File Id="super_csv_2.4.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\super-csv-2.4.0.jar" />
                     </Component>
 
-                    <Component Id="Component.x_pack_ml_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547843b591c4" Win64="yes">
-                      <File Id="x_pack_ml_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\x-pack-ml-6.3.1.jar" />
+                    <Component Id="Component.x_pack_ml_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547843b591a9" Win64="yes">
+                      <File Id="x_pack_ml_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\x-pack-ml-6.3.0.jar" />
                     </Component>
 
                     <Directory Id="INSTALLDIR.modules.x_pack.x_pack_ml.platform" Name="platform">
@@ -1017,23 +1017,23 @@
                           </Component>
 
                           <Component Id="Component.autoconfig" Guid="daaa2cba-a1ed-4f29-afbf-547826fe753a" Win64="yes">
-                            <File Id="autoconfig" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\autoconfig" />
+                            <File Id="autoconfig" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\autoconfig" />
                           </Component>
 
                           <Component Id="Component.autodetect" Guid="daaa2cba-a1ed-4f29-afbf-5478feba7df5" Win64="yes">
-                            <File Id="autodetect" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\autodetect" />
+                            <File Id="autodetect" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\autodetect" />
                           </Component>
 
                           <Component Id="Component.categorize" Guid="daaa2cba-a1ed-4f29-afbf-5478e7a42ada" Win64="yes">
-                            <File Id="categorize" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\categorize" />
+                            <File Id="categorize" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\categorize" />
                           </Component>
 
                           <Component Id="Component.controller" Guid="daaa2cba-a1ed-4f29-afbf-54784703b026" Win64="yes">
-                            <File Id="controller" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\controller" />
+                            <File Id="controller" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\controller" />
                           </Component>
 
                           <Component Id="Component.normalize" Guid="daaa2cba-a1ed-4f29-afbf-5478bcf41229" Win64="yes">
-                            <File Id="normalize" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\normalize" />
+                            <File Id="normalize" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\bin\normalize" />
                           </Component>
 
                         </Directory>
@@ -1046,55 +1046,55 @@
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-547887c8dcfe" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_date_time_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_date_time-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_date_time_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_date_time-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_date_time_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478c351e5d8" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_filesystem_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_filesystem-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_filesystem_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_filesystem-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_filesystem_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-547863e349f7" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_iostreams_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_iostreams-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_iostreams_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_iostreams-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_iostreams_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478bbc98da8" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_program_options_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_program_options-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_program_options_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_program_options-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_program_options_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478bfe6f1ea" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_regex_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_regex-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_regex_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_regex-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_regex_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54785aa79f1b" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_system_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_system-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_system_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_system-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_system_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-547804c31d78" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_thread_clang_darwin42_mt_1_65_1.dylib">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_thread-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_thread_clang_darwin42_mt_1_65_1.dylib" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libboost_thread-clang-darwin42-mt-1_65_1.dylib" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_darwin_x86_64_lib.libboost_thread_clang_darwin42_mt_1_65_1.dylib" />
                           </Component>
 
                           <Component Id="Component.liblog4cxx.10.dylib" Guid="daaa2cba-a1ed-4f29-afbf-547864d86e7c" Win64="yes">
-                            <File Id="liblog4cxx.10.dylib" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\liblog4cxx.10.dylib" />
+                            <File Id="liblog4cxx.10.dylib" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\liblog4cxx.10.dylib" />
                           </Component>
 
                           <Component Id="Component.libMlApi.dylib" Guid="daaa2cba-a1ed-4f29-afbf-5478299a0253" Win64="yes">
-                            <File Id="libMlApi.dylib" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlApi.dylib" />
+                            <File Id="libMlApi.dylib" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlApi.dylib" />
                           </Component>
 
                           <Component Id="Component.libMlConfig.dylib" Guid="daaa2cba-a1ed-4f29-afbf-5478b457e860" Win64="yes">
-                            <File Id="libMlConfig.dylib" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlConfig.dylib" />
+                            <File Id="libMlConfig.dylib" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlConfig.dylib" />
                           </Component>
 
                           <Component Id="Component.libMlCore.dylib" Guid="daaa2cba-a1ed-4f29-afbf-5478a1f88982" Win64="yes">
-                            <File Id="libMlCore.dylib" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlCore.dylib" />
+                            <File Id="libMlCore.dylib" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlCore.dylib" />
                           </Component>
 
                           <Component Id="Component.libMlMaths.dylib" Guid="daaa2cba-a1ed-4f29-afbf-5478f8b39bb7" Win64="yes">
-                            <File Id="libMlMaths.dylib" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlMaths.dylib" />
+                            <File Id="libMlMaths.dylib" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlMaths.dylib" />
                           </Component>
 
                           <Component Id="Component.libMlModel.dylib" Guid="daaa2cba-a1ed-4f29-afbf-5478a86495ac" Win64="yes">
-                            <File Id="libMlModel.dylib" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlModel.dylib" />
+                            <File Id="libMlModel.dylib" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\darwin-x86_64\lib\libMlModel.dylib" />
                           </Component>
 
                         </Directory>
@@ -1109,23 +1109,23 @@
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-547847528da0" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.autoconfig">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\autoconfig" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.autoconfig" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\autoconfig" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.autoconfig" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54784d00b713" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.autodetect">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\autodetect" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.autodetect" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\autodetect" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.autodetect" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478785c8a69" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.categorize">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\categorize" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.categorize" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\categorize" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.categorize" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54781242bbef" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.controller">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\controller" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.controller" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\controller" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.controller" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478db7ee2f4" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.normalize">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\normalize" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.normalize" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\bin\normalize" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_bin.normalize" />
                           </Component>
 
                         </Directory>
@@ -1138,79 +1138,79 @@
                           </Component>
 
                           <Component Id="Component.libapr_1.so.0_" Guid="daaa2cba-a1ed-4f29-afbf-547862405283" Win64="yes">
-                            <File Id="libapr_1.so.0_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libapr-1.so.0" />
+                            <File Id="libapr_1.so.0_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libapr-1.so.0" />
                           </Component>
 
                           <Component Id="Component.libaprutil_1.so.0_" Guid="daaa2cba-a1ed-4f29-afbf-5478f006383b" Win64="yes">
-                            <File Id="libaprutil_1.so.0_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libaprutil-1.so.0" />
+                            <File Id="libaprutil_1.so.0_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libaprutil-1.so.0" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-547840f50756" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_date_time_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_date_time-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_date_time_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_date_time-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_date_time_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478a58328ef" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_filesystem_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_filesystem-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_filesystem_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_filesystem-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_filesystem_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cb85758e" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_iostreams_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_iostreams-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_iostreams_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_iostreams-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_iostreams_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478045ae7da" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_program_options_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_program_options-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_program_options_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_program_options-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_program_options_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478de5d51ef" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_regex_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_regex-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_regex_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_regex-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_regex_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478526aad12" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_system_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_system-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_system_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_system-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_system_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54785a34f463" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_thread_gcc62_mt_1_65_1.so.1.65.1">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_thread-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_thread_gcc62_mt_1_65_1.so.1.65.1" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libboost_thread-gcc62-mt-1_65_1.so.1.65.1" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_linux_x86_64_lib.libboost_thread_gcc62_mt_1_65_1.so.1.65.1" />
                           </Component>
 
                           <Component Id="Component.libexpat.so.0_" Guid="daaa2cba-a1ed-4f29-afbf-5478309733b9" Win64="yes">
-                            <File Id="libexpat.so.0_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libexpat.so.0" />
+                            <File Id="libexpat.so.0_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libexpat.so.0" />
                           </Component>
 
                           <Component Id="Component.libgcc_s.so.1_" Guid="daaa2cba-a1ed-4f29-afbf-5478ea3348f6" Win64="yes">
-                            <File Id="libgcc_s.so.1_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libgcc_s.so.1" />
+                            <File Id="libgcc_s.so.1_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libgcc_s.so.1" />
                           </Component>
 
                           <Component Id="Component.liblog4cxx.so.10_" Guid="daaa2cba-a1ed-4f29-afbf-547821d893e0" Win64="yes">
-                            <File Id="liblog4cxx.so.10_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\liblog4cxx.so.10" />
+                            <File Id="liblog4cxx.so.10_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\liblog4cxx.so.10" />
                           </Component>
 
                           <Component Id="Component.libMlApi.so" Guid="daaa2cba-a1ed-4f29-afbf-5478a29936fb" Win64="yes">
-                            <File Id="libMlApi.so" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlApi.so" />
+                            <File Id="libMlApi.so" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlApi.so" />
                           </Component>
 
                           <Component Id="Component.libMlConfig.so" Guid="daaa2cba-a1ed-4f29-afbf-5478401243e4" Win64="yes">
-                            <File Id="libMlConfig.so" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlConfig.so" />
+                            <File Id="libMlConfig.so" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlConfig.so" />
                           </Component>
 
                           <Component Id="Component.libMlCore.so" Guid="daaa2cba-a1ed-4f29-afbf-547899dc5837" Win64="yes">
-                            <File Id="libMlCore.so" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlCore.so" />
+                            <File Id="libMlCore.so" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlCore.so" />
                           </Component>
 
                           <Component Id="Component.libMlMaths.so" Guid="daaa2cba-a1ed-4f29-afbf-547891376441" Win64="yes">
-                            <File Id="libMlMaths.so" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlMaths.so" />
+                            <File Id="libMlMaths.so" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlMaths.so" />
                           </Component>
 
                           <Component Id="Component.libMlModel.so" Guid="daaa2cba-a1ed-4f29-afbf-5478793349da" Win64="yes">
-                            <File Id="libMlModel.so" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlModel.so" />
+                            <File Id="libMlModel.so" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libMlModel.so" />
                           </Component>
 
                           <Component Id="Component.libstdc__.so.6_" Guid="daaa2cba-a1ed-4f29-afbf-5478966bd1b5" Win64="yes">
-                            <File Id="libstdc__.so.6_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libstdc++.so.6" />
+                            <File Id="libstdc__.so.6_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libstdc++.so.6" />
                           </Component>
 
                           <Component Id="Component.libxml2.so.2_" Guid="daaa2cba-a1ed-4f29-afbf-5478d448d0f9" Win64="yes">
-                            <File Id="libxml2.so.2_" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libxml2.so.2" />
+                            <File Id="libxml2.so.2_" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\linux-x86_64\lib\libxml2.so.2" />
                           </Component>
 
                         </Directory>
@@ -1225,107 +1225,107 @@
                           </Component>
 
                           <Component Id="Component.autoconfig.exe" Guid="daaa2cba-a1ed-4f29-afbf-54786173363d" Win64="yes">
-                            <File Id="autoconfig.exe" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\autoconfig.exe" />
+                            <File Id="autoconfig.exe" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\autoconfig.exe" />
                           </Component>
 
                           <Component Id="Component.autodetect.exe" Guid="daaa2cba-a1ed-4f29-afbf-547808510c94" Win64="yes">
-                            <File Id="autodetect.exe" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\autodetect.exe" />
+                            <File Id="autodetect.exe" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\autodetect.exe" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f23965d3" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_chrono_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_chrono-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_chrono_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_chrono-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_chrono_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478e1edbcc9" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_date_time_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_date_time-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_date_time_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_date_time-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_date_time_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54782a6370f6" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_filesystem_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_filesystem-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_filesystem_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_filesystem-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_filesystem_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54780e5c3ec3" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_iostreams_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_iostreams-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_iostreams_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_iostreams-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_iostreams_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-5478735c93d8" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_program_options_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_program_options-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_program_options_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_program_options-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_program_options_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-547861164c30" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_regex_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_regex-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_regex_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_regex-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_regex_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54784b1423ca" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_system_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_system-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_system_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_system-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_system_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Guid="daaa2cba-a1ed-4f29-afbf-54781c7eeb09" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_thread_vc120_mt_1_65_1.dll">
-                            <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_thread-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_thread_vc120_mt_1_65_1.dll" />
+                            <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\boost_thread-vc120-mt-1_65_1.dll" Id="INSTALLDIR_modules_x_pack_x_pack_ml_platform_windows_x86_64_bin.boost_thread_vc120_mt_1_65_1.dll" />
                           </Component>
 
                           <Component Id="Component.categorize.exe" Guid="daaa2cba-a1ed-4f29-afbf-547849559d1c" Win64="yes">
-                            <File Id="categorize.exe" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\categorize.exe" />
+                            <File Id="categorize.exe" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\categorize.exe" />
                           </Component>
 
                           <Component Id="Component.controller.exe" Guid="daaa2cba-a1ed-4f29-afbf-5478cda8370e" Win64="yes">
-                            <File Id="controller.exe" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\controller.exe" />
+                            <File Id="controller.exe" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\controller.exe" />
                           </Component>
 
                           <Component Id="Component.libapr_1.dll" Guid="daaa2cba-a1ed-4f29-afbf-547813c1dc6e" Win64="yes">
-                            <File Id="libapr_1.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libapr-1.dll" />
+                            <File Id="libapr_1.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libapr-1.dll" />
                           </Component>
 
                           <Component Id="Component.libapriconv_1.dll" Guid="daaa2cba-a1ed-4f29-afbf-54785beaac1a" Win64="yes">
-                            <File Id="libapriconv_1.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libapriconv-1.dll" />
+                            <File Id="libapriconv_1.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libapriconv-1.dll" />
                           </Component>
 
                           <Component Id="Component.libaprutil_1.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478aad792f7" Win64="yes">
-                            <File Id="libaprutil_1.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libaprutil-1.dll" />
+                            <File Id="libaprutil_1.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libaprutil-1.dll" />
                           </Component>
 
                           <Component Id="Component.libMlApi.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478fa2c36fc" Win64="yes">
-                            <File Id="libMlApi.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlApi.dll" />
+                            <File Id="libMlApi.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlApi.dll" />
                           </Component>
 
                           <Component Id="Component.libMlConfig.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478d8097e6e" Win64="yes">
-                            <File Id="libMlConfig.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlConfig.dll" />
+                            <File Id="libMlConfig.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlConfig.dll" />
                           </Component>
 
                           <Component Id="Component.libMlCore.dll" Guid="daaa2cba-a1ed-4f29-afbf-54784ea8d4f5" Win64="yes">
-                            <File Id="libMlCore.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlCore.dll" />
+                            <File Id="libMlCore.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlCore.dll" />
                           </Component>
 
                           <Component Id="Component.libMlMaths.dll" Guid="daaa2cba-a1ed-4f29-afbf-54783f95d8dc" Win64="yes">
-                            <File Id="libMlMaths.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlMaths.dll" />
+                            <File Id="libMlMaths.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlMaths.dll" />
                           </Component>
 
                           <Component Id="Component.libMlModel.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478ba62d53f" Win64="yes">
-                            <File Id="libMlModel.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlModel.dll" />
+                            <File Id="libMlModel.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libMlModel.dll" />
                           </Component>
 
                           <Component Id="Component.libxml2.dll" Guid="daaa2cba-a1ed-4f29-afbf-547850aa3f1a" Win64="yes">
-                            <File Id="libxml2.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libxml2.dll" />
+                            <File Id="libxml2.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\libxml2.dll" />
                           </Component>
 
                           <Component Id="Component.log4cxx.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478cfed95c6" Win64="yes">
-                            <File Id="log4cxx.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\log4cxx.dll" />
+                            <File Id="log4cxx.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\log4cxx.dll" />
                           </Component>
 
                           <Component Id="Component.msvcp120.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478ecef1365" Win64="yes">
-                            <File Id="msvcp120.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\msvcp120.dll" />
+                            <File Id="msvcp120.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\msvcp120.dll" />
                           </Component>
 
                           <Component Id="Component.msvcr120.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478517d50ef" Win64="yes">
-                            <File Id="msvcr120.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\msvcr120.dll" />
+                            <File Id="msvcr120.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\msvcr120.dll" />
                           </Component>
 
                           <Component Id="Component.normalize.exe" Guid="daaa2cba-a1ed-4f29-afbf-547871210e87" Win64="yes">
-                            <File Id="normalize.exe" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\normalize.exe" />
+                            <File Id="normalize.exe" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\normalize.exe" />
                           </Component>
 
                           <Component Id="Component.zlib1.dll" Guid="daaa2cba-a1ed-4f29-afbf-5478ef1288d0" Win64="yes">
-                            <File Id="zlib1.dll" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\zlib1.dll" />
+                            <File Id="zlib1.dll" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\platform\windows-x86_64\bin\zlib1.dll" />
                           </Component>
 
                         </Directory>
@@ -1340,11 +1340,11 @@
                       </Component>
 
                       <Component Id="Component.date_time_zonespec.csv" Guid="daaa2cba-a1ed-4f29-afbf-5478199abff4" Win64="yes">
-                        <File Id="date_time_zonespec.csv" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\resources\date_time_zonespec.csv" />
+                        <File Id="date_time_zonespec.csv" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\resources\date_time_zonespec.csv" />
                       </Component>
 
                       <Component Id="Component.ml_en.dict" Guid="daaa2cba-a1ed-4f29-afbf-5478982d5c0f" Win64="yes">
-                        <File Id="ml_en.dict" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-ml\resources\ml-en.dict" />
+                        <File Id="ml_en.dict" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-ml\resources\ml-en.dict" />
                       </Component>
 
                     </Directory>
@@ -1357,32 +1357,32 @@
                       <RemoveFolder Id="INSTALLDIR.modules.x_pack.x_pack_monitoring.dir" On="both" />
                     </Component>
 
-                    <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f9627a7d" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_6.3.1.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\elasticsearch-rest-client-6.3.1.jar" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_6.3.1.jar" />
+                    <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f9627a5a" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_6.3.0.jar">
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\elasticsearch-rest-client-6.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_6.3.0.jar" />
                     </Component>
 
-                    <Component Guid="daaa2cba-a1ed-4f29-afbf-5478b8186045" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_sniffer_6.3.1.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\elasticsearch-rest-client-sniffer-6.3.1.jar" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_sniffer_6.3.1.jar" />
+                    <Component Guid="daaa2cba-a1ed-4f29-afbf-5478b8186026" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_sniffer_6.3.0.jar">
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\elasticsearch-rest-client-sniffer-6.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_sniffer_6.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478a96feeb4" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f3a686bb" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54782ce57c85" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54789eb605b6" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_monitoring_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547807d307b2" Win64="yes">
-                      <File Id="x_pack_monitoring_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-monitoring\x-pack-monitoring-6.3.1.jar" />
+                    <Component Id="Component.x_pack_monitoring_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547807d3078f" Win64="yes">
+                      <File Id="x_pack_monitoring_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-monitoring\x-pack-monitoring-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -1395,23 +1395,23 @@
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478f70892e4" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-rollup\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-rollup\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54787d063ccb" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-rollup\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-rollup\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478be2b5e25" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-rollup\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-rollup\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478321dd184" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-rollup\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-rollup\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_rollup_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c76539d" Win64="yes">
-                      <File Id="x_pack_rollup_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-rollup\x-pack-rollup-6.3.1.jar" />
+                    <Component Id="Component.x_pack_rollup_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54784c765482" Win64="yes">
+                      <File Id="x_pack_rollup_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-rollup\x-pack-rollup-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -1424,115 +1424,115 @@
                     </Component>
 
                     <Component Id="Component.cryptacular_1.2.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547829eb899d" Win64="yes">
-                      <File Id="cryptacular_1.2.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\cryptacular-1.2.0.jar" />
+                      <File Id="cryptacular_1.2.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\cryptacular-1.2.0.jar" />
                     </Component>
 
                     <Component Id="Component.guava_19.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478fa95e3c5" Win64="yes">
-                      <File Id="guava_19.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\guava-19.0.jar" />
+                      <File Id="guava_19.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\guava-19.0.jar" />
                     </Component>
 
                     <Component Id="Component.httpclient_cache_4.5.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-547849cc6660" Win64="yes">
-                      <File Id="httpclient_cache_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\httpclient-cache-4.5.2.jar" />
+                      <File Id="httpclient_cache_4.5.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\httpclient-cache-4.5.2.jar" />
                     </Component>
 
                     <Component Id="Component.java_support_7.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547891b51edc" Win64="yes">
-                      <File Id="java_support_7.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\java-support-7.3.0.jar" />
+                      <File Id="java_support_7.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\java-support-7.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547868e0b570" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_security.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_security.LICENSE.txt" />
                     </Component>
 
                     <Component Id="Component.log4j_slf4j_impl_2.9.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54782dc2f4dc" Win64="yes">
-                      <File Id="log4j_slf4j_impl_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\log4j-slf4j-impl-2.9.1.jar" />
+                      <File Id="log4j_slf4j_impl_2.9.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\log4j-slf4j-impl-2.9.1.jar" />
                     </Component>
 
                     <Component Id="Component.metrics_core_3.2.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54780db95ad8" Win64="yes">
-                      <File Id="metrics_core_3.2.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\metrics-core-3.2.2.jar" />
+                      <File Id="metrics_core_3.2.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\metrics-core-3.2.2.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547870da210a" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_security.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_security.NOTICE.txt" />
                     </Component>
 
                     <Component Id="Component.opensaml_core_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54785e85a946" Win64="yes">
-                      <File Id="opensaml_core_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-core-3.3.0.jar" />
+                      <File Id="opensaml_core_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-core-3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54781f7f8a73" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.opensaml_messaging_api_3.3.0.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-messaging-api-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_messaging_api_3.3.0.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-messaging-api-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_messaging_api_3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547887869b6a" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.opensaml_messaging_impl_3.3.0.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-messaging-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_messaging_impl_3.3.0.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-messaging-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_messaging_impl_3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_profile_api_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478722f8806" Win64="yes">
-                      <File Id="opensaml_profile_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-profile-api-3.3.0.jar" />
+                      <File Id="opensaml_profile_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-profile-api-3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478573a2439" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.opensaml_profile_impl_3.3.0.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-profile-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_profile_impl_3.3.0.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-profile-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_profile_impl_3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_saml_api_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478f2666730" Win64="yes">
-                      <File Id="opensaml_saml_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-saml-api-3.3.0.jar" />
+                      <File Id="opensaml_saml_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-saml-api-3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_saml_impl_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478bb3a2cd2" Win64="yes">
-                      <File Id="opensaml_saml_impl_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-saml-impl-3.3.0.jar" />
+                      <File Id="opensaml_saml_impl_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-saml-impl-3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547855705871" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.opensaml_security_api_3.3.0.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-security-api-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_security_api_3.3.0.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-security-api-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_security_api_3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cb9fd177" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.opensaml_security_impl_3.3.0.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-security-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_security_impl_3.3.0.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-security-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_security_impl_3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_soap_api_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d606456b" Win64="yes">
-                      <File Id="opensaml_soap_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-soap-api-3.3.0.jar" />
+                      <File Id="opensaml_soap_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-soap-api-3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_soap_impl_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b84c3e12" Win64="yes">
-                      <File Id="opensaml_soap_impl_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-soap-impl-3.3.0.jar" />
+                      <File Id="opensaml_soap_impl_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-soap-impl-3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_storage_api_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478b9af870a" Win64="yes">
-                      <File Id="opensaml_storage_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-storage-api-3.3.0.jar" />
+                      <File Id="opensaml_storage_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-storage-api-3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478258f8207" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.opensaml_storage_impl_3.3.0.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-storage-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_storage_impl_3.3.0.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-storage-impl-3.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_security.opensaml_storage_impl_3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_xmlsec_api_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54787e9d61d3" Win64="yes">
-                      <File Id="opensaml_xmlsec_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-xmlsec-api-3.3.0.jar" />
+                      <File Id="opensaml_xmlsec_api_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-xmlsec-api-3.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.opensaml_xmlsec_impl_3.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547806e26f57" Win64="yes">
-                      <File Id="opensaml_xmlsec_impl_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\opensaml-xmlsec-impl-3.3.0.jar" />
+                      <File Id="opensaml_xmlsec_impl_3.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\opensaml-xmlsec-impl-3.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54781ff870c1" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_security.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_security.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547834ac79c8" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_security.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_security.plugin_security.policy" />
                     </Component>
 
                     <Component Id="Component.slf4j_api_1.6.2.jar" Guid="daaa2cba-a1ed-4f29-afbf-54789449d25b" Win64="yes">
-                      <File Id="slf4j_api_1.6.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\slf4j-api-1.6.2.jar" />
+                      <File Id="slf4j_api_1.6.2.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\slf4j-api-1.6.2.jar" />
                     </Component>
 
-                    <Component Id="Component.x_pack_security_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547896bec7b6" Win64="yes">
-                      <File Id="x_pack_security_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\x-pack-security-6.3.1.jar" />
+                    <Component Id="Component.x_pack_security_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478d3a3b8e7" Win64="yes">
+                      <File Id="x_pack_security_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\x-pack-security-6.3.0.jar" />
                     </Component>
 
                     <Component Id="Component.xmlsec_2.0.8.jar" Guid="daaa2cba-a1ed-4f29-afbf-54781447d85b" Win64="yes">
-                      <File Id="xmlsec_2.0.8.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-security\xmlsec-2.0.8.jar" />
+                      <File Id="xmlsec_2.0.8.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-security\xmlsec-2.0.8.jar" />
                     </Component>
 
                   </Directory>
@@ -1544,36 +1544,36 @@
                       <RemoveFolder Id="INSTALLDIR.modules.x_pack.x_pack_sql.dir" On="both" />
                     </Component>
 
-                    <Component Guid="daaa2cba-a1ed-4f29-afbf-547802687699" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.aggs_matrix_stats_6.3.1.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\aggs-matrix-stats-6.3.1.jar" Id="INSTALLDIR_modules_x_pack_x_pack_sql.aggs_matrix_stats_6.3.1.jar" />
+                    <Component Guid="daaa2cba-a1ed-4f29-afbf-547802877699" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.aggs_matrix_stats_6.3.0.jar">
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\aggs-matrix-stats-6.3.0.jar" Id="INSTALLDIR_modules_x_pack_x_pack_sql.aggs_matrix_stats_6.3.0.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478a1676a0a" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.antlr4_runtime_4.5.3.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\antlr4-runtime-4.5.3.jar" Id="INSTALLDIR_modules_x_pack_x_pack_sql.antlr4_runtime_4.5.3.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\antlr4-runtime-4.5.3.jar" Id="INSTALLDIR_modules_x_pack_x_pack_sql.antlr4_runtime_4.5.3.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478baeb68c2" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_sql.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_sql.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547827773d38" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_sql.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_sql.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478cd309282" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_sql.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_sql.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54781f8897e7" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_sql.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_sql.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.sql_proto_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547806ead45f" Win64="yes">
-                      <File Id="sql_proto_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\sql-proto-6.3.1.jar" />
+                    <Component Id="Component.sql_proto_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-547806ead440" Win64="yes">
+                      <File Id="sql_proto_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\sql-proto-6.3.0.jar" />
                     </Component>
 
-                    <Component Id="Component.x_pack_sql_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547869673248" Win64="yes">
-                      <File Id="x_pack_sql_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-sql\x-pack-sql-6.3.1.jar" />
+                    <Component Id="Component.x_pack_sql_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-54786a443248" Win64="yes">
+                      <File Id="x_pack_sql_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-sql\x-pack-sql-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -1586,23 +1586,23 @@
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54784933ded0" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-upgrade\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-upgrade\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-547814c1a732" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-upgrade\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-upgrade\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54781ee5e012" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-upgrade\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-upgrade\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54784a91c0ea" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-upgrade\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-upgrade\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_upgrade_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c7a87e23" Win64="yes">
-                      <File Id="x_pack_upgrade_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-upgrade\x-pack-upgrade-6.3.1.jar" />
+                    <Component Id="Component.x_pack_upgrade_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478c7897e23" Win64="yes">
+                      <File Id="x_pack_upgrade_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-upgrade\x-pack-upgrade-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -1615,39 +1615,39 @@
                     </Component>
 
                     <Component Id="Component.activation_1.1.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-547869f63d42" Win64="yes">
-                      <File Id="activation_1.1.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\activation-1.1.1.jar" />
+                      <File Id="activation_1.1.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\activation-1.1.1.jar" />
                     </Component>
 
                     <Component Id="Component.guava_16.0.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-54788a231011" Win64="yes">
-                      <File Id="guava_16.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\guava-16.0.1.jar" />
+                      <File Id="guava_16.0.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\guava-16.0.1.jar" />
                     </Component>
 
                     <Component Id="Component.javax.mail_1.5.6.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478604d2e08" Win64="yes">
-                      <File Id="javax.mail_1.5.6.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\javax.mail-1.5.6.jar" />
+                      <File Id="javax.mail_1.5.6.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\javax.mail-1.5.6.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478310775ab" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.LICENSE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.LICENSE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\LICENSE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.LICENSE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478d0d4cf11" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.NOTICE.txt">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.NOTICE.txt" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\NOTICE.txt" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.NOTICE.txt" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478b1efb6ed" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.owasp_java_html_sanitizer_r239.jar">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\owasp-java-html-sanitizer-r239.jar" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.owasp_java_html_sanitizer_r239.jar" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\owasp-java-html-sanitizer-r239.jar" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.owasp_java_html_sanitizer_r239.jar" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-54785b38fa0e" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_descriptor.properties">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_descriptor.properties" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\plugin-descriptor.properties" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_descriptor.properties" />
                     </Component>
 
                     <Component Guid="daaa2cba-a1ed-4f29-afbf-5478de0d210a" Win64="yes" Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_security.policy">
-                      <File Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_security.policy" />
+                      <File Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\plugin-security.policy" Id="INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_security.policy" />
                     </Component>
 
-                    <Component Id="Component.x_pack_watcher_6.3.1.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a0cb71e3" Win64="yes">
-                      <File Id="x_pack_watcher_6.3.1.jar" Source="..\..\..\build\in\elasticsearch-6.3.1\modules\x-pack\x-pack-watcher\x-pack-watcher-6.3.1.jar" />
+                    <Component Id="Component.x_pack_watcher_6.3.0.jar" Guid="daaa2cba-a1ed-4f29-afbf-5478a0ea71e3" Win64="yes">
+                      <File Id="x_pack_watcher_6.3.0.jar" Source="..\..\..\build\in\elasticsearch-6.3.0\modules\x-pack\x-pack-watcher\x-pack-watcher-6.3.0.jar" />
                     </Component>
 
                   </Directory>
@@ -1710,8 +1710,8 @@
     </UI>
 
     <Upgrade Id="daaa2cba-a1ed-4f29-afbf-5478617b00f6">
-      <UpgradeVersion Minimum="0.0.0.0" Maximum="6.3.1" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
-      <UpgradeVersion Minimum="6.3.1" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
+      <UpgradeVersion Minimum="0.0.0.0" Maximum="6.3.0" IncludeMinimum="yes" IncludeMaximum="no" Property="UPGRADEFOUND" />
+      <UpgradeVersion Minimum="6.3.0" IncludeMinimum="no" Property="NEWPRODUCTFOUND" />
     </Upgrade>
 
     <Icon Id="app_icon.ico" SourceFile="Resources\elasticsearch.ico" />
@@ -1760,7 +1760,7 @@
     <Binary Id="ElasticsearchUninstallDirectoriesAction_File" SourceFile="%this%.CA.dll" />
 
     <Property Id="ElasticProduct" Value="Elasticsearch" />
-    <Property Id="CurrentVersion" Value="6.3.1" />
+    <Property Id="CurrentVersion" Value="6.3.0" />
     <Property Id="MsiLogging" Value="voicewarmup" />
     <Property Id="ARPNOREPAIR" Value="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" />
@@ -1815,7 +1815,7 @@
       <ComponentRef Id="Component.elasticsearch_plugin.bat" />
       <ComponentRef Id="Component.INSTALLDIR_bin.elasticsearch_saml_metadata.bat" />
       <ComponentRef Id="Component.INSTALLDIR_bin.elasticsearch_setup_passwords.bat" />
-      <ComponentRef Id="Component.INSTALLDIR_bin.elasticsearch_sql_cli_6.3.1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_bin.elasticsearch_sql_cli_6.3.0.jar" />
       <ComponentRef Id="Component.elasticsearch_sql_cli.bat" />
       <ComponentRef Id="Component.elasticsearch_syskeygen.bat" />
       <ComponentRef Id="Component.elasticsearch_translog.bat" />
@@ -1849,12 +1849,12 @@
       <ComponentRef Id="Component.role_mapping.yml" />
       <ComponentRef Id="Component.INSTALLDIR_config.users" />
       <ComponentRef Id="Component.users_roles" />
-      <ComponentRef Id="Component.elasticsearch_6.3.1.jar" />
-      <ComponentRef Id="Component.elasticsearch_cli_6.3.1.jar" />
-      <ComponentRef Id="Component.elasticsearch_core_6.3.1.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_lib.elasticsearch_launchers_6.3.1.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_lib.elasticsearch_secure_sm_6.3.1.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_lib.elasticsearch_x_content_6.3.1.jar" />
+      <ComponentRef Id="Component.elasticsearch_6.3.0.jar" />
+      <ComponentRef Id="Component.elasticsearch_cli_6.3.0.jar" />
+      <ComponentRef Id="Component.elasticsearch_core_6.3.0.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_lib.elasticsearch_launchers_6.3.0.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_lib.elasticsearch_secure_sm_6.3.0.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_lib.elasticsearch_x_content_6.3.0.jar" />
       <ComponentRef Id="Component.HdrHistogram_2.1.9.jar" />
       <ComponentRef Id="Component.hppc_0.7.1.jar" />
       <ComponentRef Id="Component.jackson_core_2.8.10.jar" />
@@ -1883,17 +1883,17 @@
       <ComponentRef Id="Component.INSTALLDIR_lib.lucene_spatial_extras_7.3.1.jar" />
       <ComponentRef Id="Component.lucene_spatial3d_7.3.1.jar" />
       <ComponentRef Id="Component.lucene_suggest_7.3.1.jar" />
-      <ComponentRef Id="Component.plugin_classloader_6.3.1.jar" />
-      <ComponentRef Id="Component.plugin_cli_6.3.1.jar" />
+      <ComponentRef Id="Component.plugin_classloader_6.3.0.jar" />
+      <ComponentRef Id="Component.plugin_cli_6.3.0.jar" />
       <ComponentRef Id="Component.snakeyaml_1.17.jar" />
       <ComponentRef Id="Component.spatial4j_0.7.jar" />
       <ComponentRef Id="Component.t_digest_3.2.jar" />
-      <ComponentRef Id="Component.aggs_matrix_stats_6.3.1.jar" />
+      <ComponentRef Id="Component.aggs_matrix_stats_6.3.0.jar" />
       <ComponentRef Id="Component.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.analysis_common_6.3.1.jar" />
+      <ComponentRef Id="Component.analysis_common_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_analysis_common.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.elasticsearch_grok_6.3.1.jar" />
-      <ComponentRef Id="Component.ingest_common_6.3.1.jar" />
+      <ComponentRef Id="Component.elasticsearch_grok_6.3.0.jar" />
+      <ComponentRef Id="Component.ingest_common_6.3.0.jar" />
       <ComponentRef Id="Component.jcodings_1.0.12.jar" />
       <ComponentRef Id="Component.joni_2.1.6.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_ingest_common.plugin_descriptor.properties" />
@@ -1901,41 +1901,41 @@
       <ComponentRef Id="Component.asm_5.0.4.jar" />
       <ComponentRef Id="Component.asm_commons_5.0.4.jar" />
       <ComponentRef Id="Component.asm_tree_5.0.4.jar" />
-      <ComponentRef Id="Component.lang_expression_6.3.1.jar" />
+      <ComponentRef Id="Component.lang_expression_6.3.0.jar" />
       <ComponentRef Id="Component.lucene_expressions_7.3.1.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_lang_expression.plugin_descriptor.properties" />
       <ComponentRef Id="Component.plugin_security.policy" />
       <ComponentRef Id="Component.compiler_0.9.3.jar" />
-      <ComponentRef Id="Component.lang_mustache_6.3.1.jar" />
+      <ComponentRef Id="Component.lang_mustache_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_lang_mustache.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_lang_mustache.plugin_security.policy" />
       <ComponentRef Id="Component.antlr4_runtime_4.5.3.jar" />
       <ComponentRef Id="Component.asm_debug_all_5.1.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_modules_lang_painless.elasticsearch_scripting_painless_spi_6.3.1.jar" />
-      <ComponentRef Id="Component.lang_painless_6.3.1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_modules_lang_painless.elasticsearch_scripting_painless_spi_6.3.0.jar" />
+      <ComponentRef Id="Component.lang_painless_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_lang_painless.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_lang_painless.plugin_security.policy" />
-      <ComponentRef Id="Component.mapper_extras_6.3.1.jar" />
+      <ComponentRef Id="Component.mapper_extras_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_mapper_extras.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.parent_join_6.3.1.jar" />
+      <ComponentRef Id="Component.parent_join_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_parent_join.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.percolator_6.3.1.jar" />
+      <ComponentRef Id="Component.percolator_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_percolator.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_rank_eval.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.rank_eval_6.3.1.jar" />
+      <ComponentRef Id="Component.rank_eval_6.3.0.jar" />
       <ComponentRef Id="Component.commons_codec_1.10.jar" />
       <ComponentRef Id="Component.commons_logging_1.1.3.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_modules_reindex.elasticsearch_rest_client_6.3.1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_modules_reindex.elasticsearch_rest_client_6.3.0.jar" />
       <ComponentRef Id="Component.httpasyncclient_4.1.2.jar" />
       <ComponentRef Id="Component.httpclient_4.5.2.jar" />
       <ComponentRef Id="Component.httpcore_4.4.5.jar" />
       <ComponentRef Id="Component.httpcore_nio_4.4.5.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_reindex.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_reindex.plugin_security.policy" />
-      <ComponentRef Id="Component.reindex_6.3.1.jar" />
+      <ComponentRef Id="Component.reindex_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_repository_url.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_repository_url.plugin_security.policy" />
-      <ComponentRef Id="Component.repository_url_6.3.1.jar" />
+      <ComponentRef Id="Component.repository_url_6.3.0.jar" />
       <ComponentRef Id="Component.netty_buffer_4.1.16.Final.jar" />
       <ComponentRef Id="Component.netty_codec_4.1.16.Final.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_transport_netty4.netty_codec_http_4.1.16.Final.jar" />
@@ -1945,9 +1945,9 @@
       <ComponentRef Id="Component.INSTALLDIR_modules_transport_netty4.netty_transport_4.1.16.Final.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_transport_netty4.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_transport_netty4.plugin_security.policy" />
-      <ComponentRef Id="Component.transport_netty4_6.3.1.jar" />
+      <ComponentRef Id="Component.transport_netty4_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_tribe.plugin_descriptor.properties" />
-      <ComponentRef Id="Component.tribe_6.3.1.jar" />
+      <ComponentRef Id="Component.tribe_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack.meta_plugin_descriptor.properties" />
       <ComponentRef Id="Component.bcpkix_jdk15on_1.58.jar" />
       <ComponentRef Id="Component.bcprov_jdk15on_1.58.jar" />
@@ -1968,30 +1968,30 @@
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.plugin_security.policy" />
-      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.transport_netty4_6.3.1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_core.transport_netty4_6.3.0.jar" />
       <ComponentRef Id="Component.unboundid_ldapsdk_3.2.0.jar" />
-      <ComponentRef Id="Component.x_pack_core_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_core_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_deprecation.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_deprecation_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_deprecation_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_graph.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_graph_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_graph_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_logstash.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_logstash_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_logstash_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_ml.plugin_security.policy" />
       <ComponentRef Id="Component.super_csv_2.4.0.jar" />
-      <ComponentRef Id="Component.x_pack_ml_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_ml_6.3.0.jar" />
       <ComponentRef Id="Component.autoconfig" />
       <ComponentRef Id="Component.autodetect" />
       <ComponentRef Id="Component.categorize" />
@@ -2062,18 +2062,18 @@
       <ComponentRef Id="Component.zlib1.dll" />
       <ComponentRef Id="Component.date_time_zonespec.csv" />
       <ComponentRef Id="Component.ml_en.dict" />
-      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_6.3.1.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_sniffer_6.3.1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_6.3.0.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.elasticsearch_rest_client_sniffer_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_monitoring.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_monitoring_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_monitoring_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_rollup.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_rollup_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_rollup_6.3.0.jar" />
       <ComponentRef Id="Component.cryptacular_1.2.0.jar" />
       <ComponentRef Id="Component.guava_19.0.jar" />
       <ComponentRef Id="Component.httpclient_cache_4.5.2.jar" />
@@ -2100,21 +2100,21 @@
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_security.plugin_security.policy" />
       <ComponentRef Id="Component.slf4j_api_1.6.2.jar" />
-      <ComponentRef Id="Component.x_pack_security_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_security_6.3.0.jar" />
       <ComponentRef Id="Component.xmlsec_2.0.8.jar" />
-      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.aggs_matrix_stats_6.3.1.jar" />
+      <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.aggs_matrix_stats_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.antlr4_runtime_4.5.3.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_sql.plugin_security.policy" />
-      <ComponentRef Id="Component.sql_proto_6.3.1.jar" />
-      <ComponentRef Id="Component.x_pack_sql_6.3.1.jar" />
+      <ComponentRef Id="Component.sql_proto_6.3.0.jar" />
+      <ComponentRef Id="Component.x_pack_sql_6.3.0.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.LICENSE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.NOTICE.txt" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_upgrade.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_upgrade_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_upgrade_6.3.0.jar" />
       <ComponentRef Id="Component.activation_1.1.1.jar" />
       <ComponentRef Id="Component.guava_16.0.1.jar" />
       <ComponentRef Id="Component.javax.mail_1.5.6.jar" />
@@ -2123,7 +2123,7 @@
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.owasp_java_html_sanitizer_r239.jar" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_descriptor.properties" />
       <ComponentRef Id="Component.INSTALLDIR_modules_x_pack_x_pack_watcher.plugin_security.policy" />
-      <ComponentRef Id="Component.x_pack_watcher_6.3.1.jar" />
+      <ComponentRef Id="Component.x_pack_watcher_6.3.0.jar" />
       <ComponentRef Id="Registry1" />
       <ComponentRef Id="Registry2" />
       <ComponentRef Id="Registry3" />

--- a/src/Installer/Elastic.Installer.UI/EmbeddedUI.cs
+++ b/src/Installer/Elastic.Installer.UI/EmbeddedUI.cs
@@ -92,7 +92,8 @@ namespace Elastic.Installer.UI
 			if (!this._session.TryGetValue("ElasticProduct", out var product))
 				throw new Exception("ElasticProduct not found in session state.");
 
-			this._mainWindow = GetMainWindow(product, new WixStateProvider(GetProduct(product), version), new SessionWrapper(_session));
+			var wixStateProvider = new WixStateProvider(GetProduct(product), version, installationInProgress: false);
+			this._mainWindow = GetMainWindow(product, wixStateProvider, new SessionWrapper(_session));
 
 			Application.ResourceAssembly = _mainWindow.GetType().Assembly;
 			this._app.Run(this._mainWindow as Window);

--- a/src/InstallerHosts/Elastic.InstallerHosts.Kibana/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Kibana/App.xaml.cs
@@ -25,6 +25,8 @@ namespace Elastic.InstallerHosts.Kibana
 			public SemVersion CurrentVersion => "5.0.0";
 
 			public SemVersion UpgradeFromVersion => null;
+
+			public bool InstallationInProgress => false;
 		}
 
 		public void Application_Startup(object sender, StartupEventArgs e)

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/ElasticsearchInstallationTaskBase.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/ElasticsearchInstallationTaskBase.cs
@@ -12,8 +12,10 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks
 	{
 		protected ElasticsearchInstallationModel InstallationModel => this.Model as ElasticsearchInstallationModel;
 
-		protected ElasticsearchInstallationTaskBase(string[] args, ISession session)
-			: this(ElasticsearchInstallationModel.Create(new WixStateProvider(Product.Elasticsearch, Guid.Parse(session.Get<string>("ProductCode"))), session, args), session, new FileSystem())
+		protected ElasticsearchInstallationTaskBase(string[] args, ISession session, bool installationInProgress = true)
+			: this(ElasticsearchInstallationModel.Create(
+				new WixStateProvider(Product.Elasticsearch, Guid.Parse(session.Get<string>("ProductCode")), installationInProgress), session, args), session, new FileSystem()
+			)
 		{
 			this.Args = args;
 		}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Immediate/ValidateArgumentsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Immediate/ValidateArgumentsTask.cs
@@ -7,7 +7,7 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Immediate
 {
 	public class ValidateArgumentsTask : ElasticsearchInstallationTaskBase
 	{
-		public ValidateArgumentsTask(string[] args, ISession session) : base(args, session) { }
+		public ValidateArgumentsTask(string[] args, ISession session) : base(args, session, installationInProgress: false) { }
 
 		protected override bool ExecuteTask()
 		{

--- a/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/KibanaInstallationTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/KibanaInstallationTask.cs
@@ -12,8 +12,10 @@ namespace Elastic.InstallerHosts.Kibana.Tasks
 	{
 		protected KibanaInstallationModel InstallationModel => this.Model as KibanaInstallationModel;
 
-		protected KibanaInstallationTask(string[] args, ISession session)
-			: this(KibanaInstallationModel.Create(new WixStateProvider(Product.Kibana, Guid.Parse(session.Get<string>("ProductCode"))), session, args), session, new FileSystem())
+		protected KibanaInstallationTask(string[] args, ISession session, bool installationInProgress = true)
+			: this(KibanaInstallationModel.Create(
+				new WixStateProvider(Product.Kibana, Guid.Parse(session.Get<string>("ProductCode")), installationInProgress), session, args), session, new FileSystem()
+			)
 		{
 			this.Args = args;
 		}

--- a/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/ValidateArgumentsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Kibana/Tasks/ValidateArgumentsTask.cs
@@ -6,7 +6,7 @@ namespace Elastic.InstallerHosts.Kibana.Tasks
 {
 	public class ValidateArgumentsTask : KibanaInstallationTask
 	{
-		public ValidateArgumentsTask(string[] args, ISession session) : base(args, session) { }
+		public ValidateArgumentsTask(string[] args, ISession session) : base(args, session, installationInProgress: false) { }
 
 		protected override bool ExecuteTask()
 		{

--- a/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts.Elasticsearch/Properties/AssemblyInfo.cs
@@ -6,25 +6,25 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescriptionAttribute("Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.")]
 [assembly: GuidAttribute("d4fb307f-cb1d-4026-bd28-ca1d0016d709")]
 [assembly: AssemblyProductAttribute("Elasticsearch")]
-[assembly: AssemblyMetadataAttribute("GitBuildHash","421ea6")]
+[assembly: AssemblyMetadataAttribute("GitBuildHash","177c13")]
 [assembly: AssemblyCompanyAttribute("Elasticsearch BV")]
 [assembly: AssemblyCopyrightAttribute("Apache License, version 2 (ALv2). Copyright Elasticsearch.")]
 [assembly: AssemblyTrademarkAttribute("Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.")]
-[assembly: AssemblyVersionAttribute("6.3.1")]
-[assembly: AssemblyFileVersionAttribute("6.3.1")]
-[assembly: AssemblyInformationalVersionAttribute("6.3.1")]
+[assembly: AssemblyVersionAttribute("6.3.0")]
+[assembly: AssemblyFileVersionAttribute("6.3.0")]
+[assembly: AssemblyInformationalVersionAttribute("6.3.0")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Elasticsearch, you know for search!";
         internal const System.String AssemblyDescription = "Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data so you can discover the expected and uncover the unexpected.";
         internal const System.String Guid = "d4fb307f-cb1d-4026-bd28-ca1d0016d709";
         internal const System.String AssemblyProduct = "Elasticsearch";
-        internal const System.String AssemblyMetadata_GitBuildHash = "421ea6";
+        internal const System.String AssemblyMetadata_GitBuildHash = "177c13";
         internal const System.String AssemblyCompany = "Elasticsearch BV";
         internal const System.String AssemblyCopyright = "Apache License, version 2 (ALv2). Copyright Elasticsearch.";
         internal const System.String AssemblyTrademark = "Elasticsearch is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.";
-        internal const System.String AssemblyVersion = "6.3.1";
-        internal const System.String AssemblyFileVersion = "6.3.1";
-        internal const System.String AssemblyInformationalVersion = "6.3.1";
+        internal const System.String AssemblyVersion = "6.3.0";
+        internal const System.String AssemblyFileVersion = "6.3.0";
+        internal const System.String AssemblyInformationalVersion = "6.3.0";
     }
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockWixStateProvider.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/MockWixStateProvider.cs
@@ -13,5 +13,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 		public SemVersion UpgradeFromVersion { get; set; }
 
 		public SemVersion CurrentVersion { get; set; }
+
+		public bool InstallationInProgress { get; set; }
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/TestSetupStateProvider.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/Mocks/TestSetupStateProvider.cs
@@ -54,9 +54,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks
 			return this.SessionFromWix();
 		}
 
-		public TestSetupStateProvider Wix(bool alreadyInstalled, string existingInstallDir = null)
+		public TestSetupStateProvider Wix(bool alreadyInstalled, string existingInstallDir = null, bool installationInProgress = false)
 		{
-			this.WixState = new MockWixStateProvider() { CurrentVersion = DefaultTestVersion };
+			this.WixState = new MockWixStateProvider() { CurrentVersion = DefaultTestVersion, InstallationInProgress = installationInProgress};
 			if (!alreadyInstalled) return this.SessionFromWix();
 			this.WixState.UpgradeFromVersion = DefaultTestVersion;
 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/DiscoveryTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/DiscoveryTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 
 		public DiscoveryTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.ConfigurationModel);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/IdentifiersTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/IdentifiersTests.cs
@@ -9,7 +9,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 
 		public IdentifiersTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.ConfigurationModel);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/MemoryTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/MemoryTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 
 		public MemoryTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.ConfigurationModel);
@@ -64,7 +64,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 			));
 
 
-		[Fact] void RespectsJvmOptsFile() => WithValidPreflightChecks(s => s
+		[Fact] void RespectsJvmOptsFile() => DefaultValidModel(s => s
 				.Wix(alreadyInstalled: true)
 				.Elasticsearch(e => e
 					.EsHomeMachineVariable(LocationsModel.DefaultProgramFiles)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/NetworkTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/NetworkTests.cs
@@ -10,7 +10,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 
 		public NetworkTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.ConfigurationModel);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/RolesTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/RolesTests.cs
@@ -9,7 +9,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Configuration
 
 		public RolesTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.IsValidOnStep(m => m.ConfigurationModel);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelArgumentsTestsBase.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelArgumentsTestsBase.cs
@@ -15,7 +15,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 		protected void Argument<T>(string key, T value, Action<ElasticsearchInstallationModel, T> assert)
 		{
-			var model = WithValidPreflightChecks().InstallationModel;
+			var model = DefaultValidModel().InstallationModel;
 			string msiParams = AssertParser(model, key, value, assert);
 			var msiParamString = model.ParsedArguments.MsiString(value);
 
@@ -24,7 +24,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 		protected void Argument<T>(string key, T value, string msiParam, Action<ElasticsearchInstallationModel, T> assert)
 		{
-			var model = WithValidPreflightChecks().InstallationModel;
+			var model = DefaultValidModel().InstallationModel;
 			string msiParams = AssertParser(model, key, value, assert);
 			msiParams.Should().Contain($"{key.ToUpperInvariant()}=\"{msiParam}\"");
 		}
@@ -44,13 +44,13 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 		protected MultipleArgumentsTester Argument<T>(string key, T value)
 		{
-			var model = WithValidPreflightChecks().InstallationModel;
+			var model = DefaultValidModel().InstallationModel;
 			return new MultipleArgumentsTester(model).Argument(key, value);
 		}
 
 		protected MultipleArgumentsTester Argument<T>(string key, T value, string msiParam)
 		{
-			var model = WithValidPreflightChecks().InstallationModel;
+			var model = DefaultValidModel().InstallationModel;
 			return new MultipleArgumentsTester(model).Argument(key, value, msiParam);
 		}
 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTestBase.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTestBase.cs
@@ -12,10 +12,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		
 		protected InstallationModelTester Pristine() => InstallationModelTester.New();
 
-		protected InstallationModelTester WithValidPreflightChecks() => 
-			InstallationModelTester.ValidPreflightChecks();
+		protected InstallationModelTester DefaultValidModel() => InstallationModelTester.ValidPreflightChecks();
 
-		protected InstallationModelTester WithValidPreflightChecks(Func<TestSetupStateProvider, TestSetupStateProvider> selector)  =>
+		protected InstallationModelTester DefaultValidModel(Func<TestSetupStateProvider, TestSetupStateProvider> selector)  =>
 			InstallationModelTester.ValidPreflightChecks(selector);
 
 		protected InstallationModelTester WithExistingElasticsearchYaml(string yamlContents)  =>
@@ -31,6 +30,11 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 					return f;
 				})
 			);
+		
+		protected InstallationModelTester DefaultValidModelForTasks() => DefaultValidModelForTasks(s=>s);
+
+		protected InstallationModelTester DefaultValidModelForTasks(Func<TestSetupStateProvider, TestSetupStateProvider> selector)  =>
+			InstallationModelTester.ValidPreflightChecksForTasks(selector);
 	}
 }
 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTester.cs
@@ -16,6 +16,7 @@ using Elastic.Installer.Domain.Model.Elasticsearch.Closing;
 using Elastic.Installer.Domain.Model.Elasticsearch.Notice;
 using Elastic.Installer.Domain.Tests.Elasticsearch.Configuration.Mocks;
 using Elastic.InstallerHosts.Elasticsearch.Tasks;
+using Elastic.InstallerHosts.Elasticsearch.Tasks.Immediate;
 using FluentAssertions;
 using FluentValidation.Results;
 
@@ -239,6 +240,11 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		);
 
 		public static InstallationModelTester ValidPreflightChecks(Func<TestSetupStateProvider, TestSetupStateProvider> selector) => New(s => selector(s
+			.Wix(alreadyInstalled: false, installationInProgress: true)
+			.Java(j => j.JavaHomeMachineVariable(@"C:\Java"))
+			)
+		);
+		public static InstallationModelTester ValidPreflightChecksForTasks(Func<TestSetupStateProvider, TestSetupStateProvider> selector) => New(s => selector(s
 			.Wix(alreadyInstalled: false)
 			.Java(j => j.JavaHomeMachineVariable(@"C:\Java"))
 			)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InstallationModelTests.cs
@@ -24,13 +24,13 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 			);
 	
 		/* A model with all preflight checks set is valid */
-		[Fact] void CanClickNextWhenValid() => WithValidPreflightChecks()
+		[Fact] void CanClickNextWhenValid() => DefaultValidModel()
 			.IsValidOnFirstStep()
 			.CanClickNext();
 
 		/* When the first step is valid and we go to the next step and back
 		* the model should still be valid and not reset */
-		[Fact] public void ClickingBackDoesNotReset() => WithValidPreflightChecks()
+		[Fact] public void ClickingBackDoesNotReset() => DefaultValidModel()
 			.IsValidOnFirstStep()
 			.ClickNext()
 			.IsValidOnStep(m => m.ServiceModel)
@@ -41,7 +41,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 
 
 		/** Make sure that the active step never exceeds the first step with errors */
-		[Fact] public void ActiveStepFollowsFirstViewModelWithErrors() => WithValidPreflightChecks()
+		[Fact] public void ActiveStepFollowsFirstViewModelWithErrors() => DefaultValidModel()
 			.IsValidOnFirstStep()
 			.ClickNext()
 			.ClickNext()
@@ -54,7 +54,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		All the other step models are valid by default and we can click next untill we get to the install phase */
 		[Fact] public void GivenValidPreflightChecksCanClickNextTillInstall()
 		{
-			var tester = WithValidPreflightChecks();
+			var tester = DefaultValidModel();
 			tester.IsValidOnFirstStep();
 			tester.InstallationModel.NextButtonText.Should().Be(TextResources.SetupView_NextText);
 			tester.ClickNext();
@@ -78,7 +78,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		
 		[Fact] public void WhenPreviousVersionHadXPackInstalledSkipXPackStep()
 		{
-			var tester = WithValidPreflightChecks(t=>t
+			var tester = DefaultValidModel(t=>t
 				.Wix(current: "6.3.0", upgradeFrom: "6.2.0")
 				.PreviouslyInstalledPlugins("x-pack")
 			);
@@ -101,7 +101,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		
 		[Fact] public void WhenPreviousVersionOlderThan630DoesNotHaveXPackInstalledShowIt()
 		{
-			var tester = WithValidPreflightChecks(t=>t
+			var tester = DefaultValidModel(t=>t
 				.Wix(current: "6.3.0", upgradeFrom: "6.2.0")
 			);
 			tester.IsValidOnFirstStep();
@@ -124,7 +124,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models
 		}
 		[Fact] public void WhenPreviousVersionNewerOrEqualTo630AlwaysShowXpack()
 		{
-			var tester = WithValidPreflightChecks(t=>t
+			var tester = DefaultValidModel(t=>t
 				.Wix(current: "6.3.1", upgradeFrom: "6.3.0")
 			);
 			tester.IsValidOnFirstStep();

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InvalidExternalStates/JavaStateTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InvalidExternalStates/JavaStateTests.cs
@@ -7,7 +7,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.InvalidExternalSta
 {
 	public class JavaStateTests : InstallationModelTestBase
 	{
-		private InstallationModelTester EmptyJavaModel(Func<TestSetupStateProvider, TestSetupStateProvider> selector) => WithValidPreflightChecks(s => selector(s
+		private InstallationModelTester EmptyJavaModel(Func<TestSetupStateProvider, TestSetupStateProvider> selector) => DefaultValidModel(s => selector(s
 			.Java(j => j
 				.JavaHomeMachineVariable(null)
 				.JavaHomeUserVariable(null)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InvalidExternalStates/WixStateTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/InvalidExternalStates/WixStateTests.cs
@@ -6,9 +6,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.InvalidExternalSta
 	public class WixStateTests : InstallationModelTestBase
 	{
 		private InstallationModelTester WixModel(string currentVersion, string previousVersion) => 
-			WithValidPreflightChecks(s => s.Wix(currentVersion, previousVersion));
+			DefaultValidModel(s => s.Wix(currentVersion, previousVersion));
 
-		private InstallationModelTester WixModel(bool alreadyInstalled) => WithValidPreflightChecks(s => s.Wix(alreadyInstalled));
+		private InstallationModelTester WixModel(bool alreadyInstalled) => DefaultValidModel(s => s.Wix(alreadyInstalled));
 
 		[Fact] public void PatchUpgrade() => WixModel("5.0.1", "5.0.0")
 			.IsValidOnFirstStep();

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationModelTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 
 		public LocationModelTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.IsValidOnFirstStep();
 		}
 
@@ -60,7 +60,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 				step.PreviousInstallationDirectory.Should().BeNullOrEmpty();
 			});
 		
-		[Fact] void ValidLocationUsingPreviousVersion6X() => WithValidPreflightChecks(s=>s.Wix("6.1.0", "6.0.0"))
+		[Fact] void ValidLocationUsingPreviousVersion6X() => DefaultValidModel(s=>s.Wix("6.1.0", "6.0.0"))
 			.IsValidOnFirstStep()
             .OnStep(m => m.LocationsModel, step =>
             {
@@ -73,7 +73,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
                 step.PreviousInstallationDirectory.Should().Be(Path.Combine(CustomInstallationFolder, "6.0.0"));
             });
 		
-		[Fact] void ValidLocationUsingPreviousVersion5X() => WithValidPreflightChecks(s=>s.Wix("6.0.0", "5.0.0", CustomInstallationFolder))
+		[Fact] void ValidLocationUsingPreviousVersion5X() => DefaultValidModel(s=>s.Wix("6.0.0", "5.0.0", CustomInstallationFolder))
 			.IsValidOnFirstStep()
             .OnStep(m => m.LocationsModel, step =>
             {

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsFlagTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/LocationsFlagTests.cs
@@ -21,7 +21,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 
 		public LocationsFlagTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.IsValidOnFirstStep();
 		}
 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/SeedLocationsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/SeedLocationsTests.cs
@@ -11,7 +11,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 		private string _customHome = "C:\\Elasticsearch";
 		private string _customConfig = "C:\\MyConfigLocation";
 
-		[Fact] void InstallationDirectoryReflectsES_HOME() => WithValidPreflightChecks(s => s
+		[Fact] void InstallationDirectoryReflectsES_HOME() => DefaultValidModel(s => s
 			.Elasticsearch(e => e
 				.EsHomeMachineVariable(_customHome)
 			))
@@ -22,7 +22,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 				step.ConfigureLocations.Should().BeTrue();
 			});
 
-		[Fact] void ConfigDirectoryReflectsES_PATH_CONF() => WithValidPreflightChecks(s => s
+		[Fact] void ConfigDirectoryReflectsES_PATH_CONF() => DefaultValidModel(s => s
 			.Elasticsearch(e => e
 				.EsConfigMachineVariable(_customConfig)
 			))
@@ -32,7 +32,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 				step.ConfigureLocations.Should().BeTrue();
 			});
 
-		[Fact] void DataDirectoryIsReadFromElasticsearchYaml() => WithValidPreflightChecks(s => s
+		[Fact] void DataDirectoryIsReadFromElasticsearchYaml() => DefaultValidModel(s => s
 			.Elasticsearch(e => e
 				.EsHomeMachineVariable(_customHome)
 				.EsConfigMachineVariable(_customConfig)
@@ -48,7 +48,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 				step.DataDirectory.Should().Be($"{_customHome}\\MyDataFolder");
 			});
 
-		[Fact] void LogsDirectoryIsReadFromElasticsearchYaml() => WithValidPreflightChecks(s => s
+		[Fact] void LogsDirectoryIsReadFromElasticsearchYaml() => DefaultValidModel(s => s
 			.Elasticsearch(e => e
 				.EsHomeMachineVariable(_customHome)
 				.EsConfigMachineVariable(_customConfig)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/WritableLocationsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Location/WritableLocationsTests.cs
@@ -15,7 +15,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Location
 
 		public WritableLocationsTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.IsValidOnStep(m => m.LocationsModel);
 		}
 

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Notice/NoticeModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Notice/NoticeModelTests.cs
@@ -17,33 +17,33 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Notice
 			);
 
 		[Fact]
-		public void CanClickNextWhenValid() => WithValidPreflightChecks()
+		public void CanClickNextWhenValid() => DefaultValidModel()
 			.IsValidOnStep(m => m.LocationsModel)
 			.CanClickNext();
 
 		[Fact]
-		public void MajorDowngradeShowsNotice() => WithValidPreflightChecks(f => f.Wix("5.0.0", upgradeFrom: "6.0.0"))
+		public void MajorDowngradeShowsNotice() => DefaultValidModel(f => f.Wix("5.0.0", upgradeFrom: "6.0.0"))
 			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
-		[Fact] public void MajorUpgradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("6.0.0", upgradeFrom: "5.0.0"))
+		[Fact] public void MajorUpgradeShowsNotice() => DefaultValidModel(f=>f.Wix("6.0.0", upgradeFrom: "5.0.0"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
-		[Fact] public void MinorDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0", upgradeFrom: "5.1.0"))
+		[Fact] public void MinorDowngradeShowsNotice() => DefaultValidModel(f=>f.Wix("5.0.0", upgradeFrom: "5.1.0"))
 			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
-		[Fact] public void MinorUpgradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.1.0", upgradeFrom: "5.0.0"))
+		[Fact] public void MinorUpgradeShowsNotice() => DefaultValidModel(f=>f.Wix("5.1.0", upgradeFrom: "5.0.0"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
-		[Fact] public void PatchDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.1.0", upgradeFrom: "5.1.1"))
+		[Fact] public void PatchDowngradeShowsNotice() => DefaultValidModel(f=>f.Wix("5.1.0", upgradeFrom: "5.1.1"))
 			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
-		[Fact] public void PatchUpgradeDoesNotShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.1.1", upgradeFrom: "5.1.0"))
+		[Fact] public void PatchUpgradeDoesNotShowsNotice() => DefaultValidModel(f=>f.Wix("5.1.1", upgradeFrom: "5.1.0"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
-		[Fact] public void PatchUpgradeNextScreenIsConfigurationScreen() => WithValidPreflightChecks(f=>f
+		[Fact] public void PatchUpgradeNextScreenIsConfigurationScreen() => DefaultValidModel(f=>f
 				.Wix("5.1.1", upgradeFrom: "5.1.0")
 				.ServicePreviouslyInstalled()
 			)
@@ -52,17 +52,17 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Notice
 			.IsValidOnStep(m => m.ConfigurationModel)
 			.CanClickNext();
 
-		[Fact] public void PrereleaseShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-alpha4", upgradeFrom: "5.0.0-alpha2"))
+		[Fact] public void PrereleaseShowsNotice() => DefaultValidModel(f=>f.Wix("5.0.0-alpha4", upgradeFrom: "5.0.0-alpha2"))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 
-		[Fact] public void PrereleaseDowngradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-rc2", upgradeFrom: "5.0.0"))
+		[Fact] public void PrereleaseDowngradeShowsNotice() => DefaultValidModel(f=>f.Wix("5.0.0-rc2", upgradeFrom: "5.0.0"))
 			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
-		[Fact] public void PrereleaseUpgradeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-rc2", upgradeFrom: "5.0.0"))
+		[Fact] public void PrereleaseUpgradeShowsNotice() => DefaultValidModel(f=>f.Wix("5.0.0-rc2", upgradeFrom: "5.0.0"))
 			.HasSetupValidationFailures(e => e.ShouldHaveErrors(TextResources.NoticeModelValidator_HigherVersionInstalled));
 
-		[Fact] public void InstallingPrereleaseFirstTimeShowsNotice() => WithValidPreflightChecks(f=>f.Wix("5.0.0-beta2", upgradeFrom: null))
+		[Fact] public void InstallingPrereleaseFirstTimeShowsNotice() => DefaultValidModel(f=>f.Wix("5.0.0-beta2", upgradeFrom: null))
 			.IsValidOnStep(m => m.NoticeModel)
 			.CanClickNext();
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 
 		public PluginsTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.ClickNext()

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Service/RunAsTests .cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Service/RunAsTests .cs
@@ -10,7 +10,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Service
 
 		public RunAsTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.IsValidOnStep(m => m.ServiceModel);
 		}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Service/ServiceTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Service/ServiceTests.cs
@@ -9,7 +9,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Service
 
 		public ServiceTests()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.IsValidOnStep(m => m.ServiceModel);
 		}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Commit/CleanUpInstallTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Commit/CleanUpInstallTaskTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Commit
 {
 	public class CleanUpInstallTaskTests : InstallationModelTestBase
 	{
-		[Fact] void CleansProductInstallTempDirectory() => WithValidPreflightChecks()
+		[Fact] void CleansProductInstallTempDirectory() => DefaultValidModelForTasks()
 			.AssertTask(
 				(m, s, fs) =>
 				{

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/CreateDirectoriesTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/CreateDirectoriesTaskTests.cs
@@ -16,7 +16,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 		private readonly string EsLogs = @"c:\es-logs";
 		
 		[Fact]
-		void CreatesDefaultDirectories() => WithValidPreflightChecks()
+		void CreatesDefaultDirectories() => DefaultValidModelForTasks()
 			.AssertTask(
 				(m, s, fs) =>
 				{
@@ -35,7 +35,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 			);
 
 		[Fact]
-		void CreatesUserDirectories() => WithValidPreflightChecks(s => s
+		void CreatesUserDirectories() => DefaultValidModelForTasks(s => s
 				.SetupArgument(nameof(LocationsModel.DataDirectory), EsData)
 				.SetupArgument(nameof(LocationsModel.ConfigDirectory), EsConfig)
 				.SetupArgument(nameof(LocationsModel.LogsDirectory), EsLogs)
@@ -61,7 +61,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 			);
 
 		[Fact]
-		void ExisitingDirectoriesAreReused() => WithValidPreflightChecks(s => s
+		void ExisitingDirectoriesAreReused() => DefaultValidModelForTasks(s => s
 				.SetupArgument(nameof(LocationsModel.DataDirectory), EsData)
 				.SetupArgument(nameof(LocationsModel.ConfigDirectory), EsConfig)
 				.SetupArgument(nameof(LocationsModel.LogsDirectory), EsLogs)
@@ -87,7 +87,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 			);
 
 		[Fact]
-		void DefaultConfigContentsCopied() => WithValidPreflightChecks(s => s
+		void DefaultConfigContentsCopied() => DefaultValidModelForTasks(s => s
 				.SetupArgument(nameof(LocationsModel.DataDirectory), EsData)
 				.SetupArgument(nameof(LocationsModel.ConfigDirectory), EsConfig)
 				.SetupArgument(nameof(LocationsModel.LogsDirectory), EsLogs)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlConfigurationModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlConfigurationModelTaskTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 {
 	public class EditElasticsearchYamlConfigurationModelTaskTests : InstallationModelTestBase
 	{
-		[Fact] void CustomConfigValues() => WithValidPreflightChecks(s => s
+		[Fact] void CustomConfigValues() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlServiceModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlServiceModelTaskTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 {
 	public class EditElasticsearchYamlServiceModelTaskTests : InstallationModelTestBase
 	{
-		[Fact] void DefaultMaxLocalStorageNodesNotService() => WithValidPreflightChecks(s => s
+		[Fact] void DefaultMaxLocalStorageNodesNotService() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -38,7 +38,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 
-		[Fact] void MaxLocalStorageNodesShouldBeSetWhenInstallingAsService() => WithValidPreflightChecks(s => s
+		[Fact] void MaxLocalStorageNodesShouldBeSetWhenInstallingAsService() => DefaultValidModelForTasks(s => s
 				.Elasticsearch(es => es
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlTaskTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 {
 	public class EditElasticsearchYamlTaskTests : InstallationModelTestBase
 	{
-		[Fact] void PicksUpExistingConfiguration() => WithValidPreflightChecks(s => s
+		[Fact] void PicksUpExistingConfiguration() => DefaultValidModelForTasks(s => s
 				.Elasticsearch(e => e
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)
@@ -39,7 +39,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 
-		[Fact] void WritesExpectedDefauts() => WithValidPreflightChecks(s => s
+		[Fact] void WritesExpectedDefauts() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -76,7 +76,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 
-		[Fact] void DefaultMaxLocalStorageNodesNotService() => WithValidPreflightChecks(s => s
+		[Fact] void DefaultMaxLocalStorageNodesNotService() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -102,7 +102,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 
-		[Fact] void CustomConfigValues() => WithValidPreflightChecks(s => s
+		[Fact] void CustomConfigValues() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlXPackModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlXPackModelTaskTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 {
 	public class EditElasticsearchYamlXPackModelTaskTests : InstallationModelTestBase
 	{
-		[Fact] void WritesExpectedDefaults() => WithValidPreflightChecks(s => s
+		[Fact] void WritesExpectedDefaults() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -39,7 +39,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 
-		[Fact] void SelectingXPackPluginDefaultsToWritingLicenseType() => WithValidPreflightChecks(s => s
+		[Fact] void SelectingXPackPluginDefaultsToWritingLicenseType() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -64,7 +64,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 		
-		[Fact] void SelectingTrialWritesSecurityEnabled() => WithValidPreflightChecks(s => s
+		[Fact] void SelectingTrialWritesSecurityEnabled() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -90,7 +90,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 		
-		[Fact] void DeselectingSecurityWritesFalseToYamlFile() => WithValidPreflightChecks(s => s
+		[Fact] void DeselectingSecurityWritesFalseToYamlFile() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)
@@ -120,7 +120,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 		
-		[Fact] void XPackSettingsAlreadyInPlaceAreNotOverwritten() => WithValidPreflightChecks(s => s
+		[Fact] void XPackSettingsAlreadyInPlaceAreNotOverwritten() => DefaultValidModelForTasks(s => s
 			.Elasticsearch(es => es
 				.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 			)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditJvmOptionTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditJvmOptionTaskTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 	public class EditJvmOptionsTaskTests : InstallationModelTestBase
 	{
 		[Fact]
-		void PicksUpExistingConfiguration() => WithValidPreflightChecks(s => s
+		void PicksUpExistingConfiguration() => DefaultValidModelForTasks(s => s
 				.Elasticsearch(e => e
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)
@@ -41,7 +41,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 			);
 
 		[Fact]
-		void WritesExpectedDefaults() => WithValidPreflightChecks(s => s
+		void WritesExpectedDefaults() => DefaultValidModelForTasks(s => s
 				.Elasticsearch(es => es
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)
@@ -68,7 +68,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 			);
 
 		[Fact]
-		void WritesConfiguredMemory() => WithValidPreflightChecks(s => s
+		void WritesConfiguredMemory() => DefaultValidModelForTasks(s => s
 				.Elasticsearch(es => es
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/InstallPluginsTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/InstallPluginsTaskTests.cs
@@ -8,7 +8,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 	{
 		[Fact] void InstallByDefault()
 		{
-			var model = WithValidPreflightChecks();
+			var model = DefaultValidModelForTasks();
 			model.AssertTask(
 				(m, s, fs) => new InstallPluginsTask(m, s, fs),
 				(m, t) =>
@@ -19,7 +19,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 		}
 		[Fact] void PreviouslyInstalledPluginSelectionCarriesOver()
 		{
-			var model = WithValidPreflightChecks(s=>s
+			var model = DefaultValidModelForTasks(s=>s
 				.Wix("5.1.0", "5.0.0")
 				.PreviouslyInstalledPlugins("ingest-geoip", "analysis-kuromoji")
 			);
@@ -37,7 +37,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 		}
 		[Fact] void PreviouslyInstalledPluginSelectionCarriesOverEvenWhenEmpty()
 		{
-			var model = WithValidPreflightChecks(s=>s
+			var model = DefaultValidModelForTasks(s=>s
 				.Wix("5.1.0", "5.0.0")
 				.PreviouslyInstalledPlugins()
 			);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/PreserveInstallTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/PreserveInstallTaskTests.cs
@@ -13,7 +13,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 {
 	public class PreserveInstallTaskTests : InstallationModelTestBase
 	{
-		[Fact] void DoesNotRemoveTempDirectoryIfNotEmpty() => WithValidPreflightChecks()
+		[Fact] void DoesNotRemoveTempDirectoryIfNotEmpty() => DefaultValidModelForTasks()
 			.AssertTask(
 				(m, s, fs) =>
 				{
@@ -39,7 +39,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 				}
 			);
 		
-		[Fact] void DeletesConfigFolderIfOneIsSomehowPreset() => WithValidPreflightChecks()
+		[Fact] void DeletesConfigFolderIfOneIsSomehowPreset() => DefaultValidModelForTasks()
 			.AssertTask(
 				(m, s, fs) =>
 				{
@@ -63,7 +63,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 				}
 			);
 
-		[Fact] void CopiesExistingConfigDirectory() => WithValidPreflightChecks(s => s
+		[Fact] void CopiesExistingConfigDirectory() => DefaultValidModelForTasks(s => s
 				.FileSystem(fs =>
 				{
 					fs.AddDirectory(LocationsModel.DefaultConfigDirectory);
@@ -103,7 +103,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 				}
 			);
 		
-		[Fact] void MovesPluginFolder() => WithValidPreflightChecks(s => s
+		[Fact] void MovesPluginFolder() => DefaultValidModelForTasks(s => s
 				.FileSystem(fs =>
 				{
 					var pluginFolder = Path.Combine(VersionSpecificInstallDirectory, "plugins");

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/SetupXPackPasswordsTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/SetupXPackPasswordsTaskTests.cs
@@ -8,7 +8,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install
 	public class SetupXPackPasswordsTaskTests : InstallationModelTestBase
 	{
 		[Fact(Skip = "need an integration test for this")]
-		void InstallByDefault() => WithValidPreflightChecks()
+		void InstallByDefault() => DefaultValidModelForTasks()
 			.OnStep(m=>m.XPackModel, step =>
 			{
 				step.XPackLicense = XPackLicenseMode.Trial;

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Rollback/RollbackDeleteDirectoriesTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Rollback/RollbackDeleteDirectoriesTaskTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Rollback
 	public class RollbackDeleteDirectoriesTaskTests : InstallationModelTestBase
 	{
 		[Fact] void RollbackNewInstallationRemovesDirectories() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Session(rollback: true, uninstalling: false)
 			)
 			.AssertTask((m, s, fs) =>
@@ -38,7 +38,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Rollback
 			fs.AllPaths.Aggregate(new StringBuilder().AppendLine("FileSystem:"), (sb, s) => sb.AppendLine($" {s}"), sb => sb.ToString());
 
 		[Fact] void RollbackToPreviousInstallationDoesNotRemoveDirectories() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Wix(current: "5.6.0", upgradeFrom: "5.5.0")
 				.Session(rollback: true, uninstalling: false)
 			)
@@ -60,7 +60,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Rollback
 		);
 		
 		[Fact] void RollbackToPreviousInstallationDoesNotRemoveDirectoriesWhenSessionVariablesAreSet() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Wix(current: "5.6.0", upgradeFrom: "5.5.0")
 				.Session(rollback: true, uninstalling: false, sessionVariables: new Dictionary<string, string>
 					{

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Uninstall/UninstallDeleteDirectoriesTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Uninstall/UninstallDeleteDirectoriesTaskTests.cs
@@ -10,7 +10,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Uninstall
 	public class UninstallDeleteDirectoriesTaskTests : InstallationModelTestBase
 	{
 		[Fact] void RemoveDirectoriesOnUninstall() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Session(uninstalling: true, rollback: false)
 			)
 			.AssertTask((m, s, fs) =>
@@ -33,7 +33,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Uninstall
 		);
 		
 		[Fact] void RemovesParentInstallationFoldersWhenEmpty() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Session(uninstalling: true, rollback: false)
 			)
 			.AssertTask((m, s, fs) =>
@@ -54,7 +54,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Uninstall
 		);
 
 		[Fact] void LeavesParentFolderAloneIfOtherProductIsInstalled() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Session(uninstalling: true, rollback: false)
 			)
 			.AssertTask((m, s, fs) =>
@@ -76,7 +76,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Uninstall
 		);
 		
 		[Fact] void LeavesCompanyDataDirectoryAloneIfOtherProductUsesIt() =>
-			WithValidPreflightChecks(s => s
+			DefaultValidModelForTasks(s => s
 				.Session(uninstalling: true, rollback: false)
 			)
 			.AssertTask((m, s, fs) =>

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/BasicLicenseModelTests.cs
@@ -12,7 +12,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 		
 		public BasicLicenseModelTester()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.ClickNext()

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/XPack/TrialLicenseModelTests.cs
@@ -11,7 +11,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.XPack
 		
 		public TrialLicenseModelTester()
 		{
-			this._model = WithValidPreflightChecks()
+			this._model = DefaultValidModel()
 				.ClickNext()
 				.ClickNext()
 				.ClickNext()


### PR DESCRIPTION
ElasticsearchInstallationModel now exposes a InstallationInProgress bool
which indicates wheter the model was instantiated during an in progress
installation.

The check for `ES_HOME` will now never occur in any of the tasks.

ValidateArgumentsTasks will still validate this though