### PR TITLE
Fix integration tests for sub directories

### DIFF
--- a/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-WritableLocationsInSamePath/SilentInstall-WritableLocationsInSamePath.Tests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Tests/SilentInstall-WritableLocationsInSamePath/SilentInstall-WritableLocationsInSamePath.Tests.ps1
@@ -14,6 +14,9 @@ $DataDir = "C:\temp dir\Elasticsearch\$($($Global:Version).FullVersion)\data_dat
 $ConfigDir = "C:\temp dir\Elasticsearch\$($($Global:Version).FullVersion)\config_config"
 $LogsDir = "C:\temp dir\Elasticsearch\$($($Global:Version).FullVersion)\logs_logs"
 
+$version = $Global:Version
+$640Release = ConvertTo-SemanticVersion "6.4.0"
+
 Describe "Silent Install with same install locations $(($Global:Version).Description)" {
 
     $ExeArgs = @(
@@ -23,54 +26,94 @@ Describe "Silent Install with same install locations $(($Global:Version).Descrip
 		"LOGSDIRECTORY=$LogsDir"
 		"PLACEWRITABLELOCATIONSINSAMEPATH=true")
 
-    Invoke-SilentInstall -ExeArgs $ExeArgs
+	if ($version.SourceType -eq "Compile" -or (Compare-SemanticVersion $Version $640Release) -ge 0) {
+		$startDate = Get-Date
 
-    Context-ElasticsearchService
+		Context "Failed installation" {
+			$exitCode = Invoke-SilentInstall -Exeargs $ExeArgs
 
-    Context-PingNode
+			It "Exit code is 1603" {
+				$exitCode | Should Be 1603
+			}
+		}
 
-    Context-EsHomeEnvironmentVariable -Expected $InstallDir
+		Context-EventContainsFailedInstallMessage -StartDate $startDate -Version $version.FullVersion
 
-    Context-EsConfigEnvironmentVariable -Expected @{  
-		Path = $ConfigDir
+		Context-NodeNotRunning
+
+		Context-EsConfigEnvironmentVariableNull
+
+		Context-EsHomeEnvironmentVariableNull
+
+		Context-MsiNotRegistered
+
+		Context-ElasticsearchServiceNotInstalled
+
+		$ProgramFiles = Get-ProgramFilesFolder
+		$ExpectedHomeFolder = Join-Path -Path $ProgramFiles -ChildPath "Elastic\Elasticsearch\"
+
+		Context-EmptyInstallDirectory -Path $ExpectedHomeFolder
+
+		$configDirectory = "C:\ProgramData\Elastic\Elasticsearch\config"
+		$dataDirectory = $configDirectory | Split-Path | Join-Path -ChildPath "data"
+		$logsDirectory = $configDirectory | Split-Path | Join-Path -ChildPath "logs"
+
+		Context-DirectoryNotExist -Path $configDirectory -DeleteAfter
+		Context-DirectoryNotExist -Path $dataDirectory -DeleteAfter
+		Context-DirectoryNotExist -Path $logsDirectory -DeleteAfter
 	}
+	else {
+		Invoke-SilentInstall -ExeArgs $ExeArgs
 
-    Context-PluginsInstalled
+		Context-ElasticsearchService
 
-    Context-MsiRegistered
+		Context-PingNode
 
-    Context-ServiceRunningUnderAccount -Expected "LocalSystem"
+		Context-EsHomeEnvironmentVariable -Expected $InstallDir
 
-    Context-EmptyEventLog
+		Context-EsConfigEnvironmentVariable -Expected @{  
+			Path = $ConfigDir
+		}
+
+		Context-PluginsInstalled
+
+		Context-MsiRegistered
+
+		Context-ServiceRunningUnderAccount -Expected "LocalSystem"
+
+		Context-EmptyEventLog
   
-    Context-ClusterNameAndNodeName
+		Context-ClusterNameAndNodeName
 
-    Context-ElasticsearchConfiguration -Expected @{
-		Data = $DataDir 
-		Logs = $LogsDir 
+		Context-ElasticsearchConfiguration -Expected @{
+			Data = $DataDir 
+			Logs = $LogsDir 
+		}
+
+		Context-JvmOptions
+
+		Copy-ElasticsearchLogToOut -Path "$LogsDir\elasticsearch.log"
 	}
-
-    Context-JvmOptions
-
-	Copy-ElasticsearchLogToOut -Path "$LogsDir\elasticsearch.log"
 }
 
-Describe "Silent Uninstall with same install locations $(($Global:Version).Description)" {
+if ($version.SourceType -ne "Compile" -and (Compare-SemanticVersion $Version $640Release) -lt 0) {
+	Describe "Silent Uninstall with same install locations $(($Global:Version).Description)" {
 
-    Invoke-SilentUninstall
+		Invoke-SilentUninstall
 
-	Context-NodeNotRunning
+		Context-NodeNotRunning
 
-	Context-EsConfigEnvironmentVariableNull
+		Context-EsConfigEnvironmentVariableNull
 
-	Context-EsHomeEnvironmentVariableNull
+		Context-EsHomeEnvironmentVariableNull
 
-	Context-MsiNotRegistered
+		Context-MsiNotRegistered
 
-	Context-ElasticsearchServiceNotInstalled
+		Context-ElasticsearchServiceNotInstalled
 
-	# install dir still exists because data, logs and config dirs exist within
-	Context-DirectoryExists -Path $InstallDir
+		# install dir still exists because data, logs and config dirs exist within
+		Context-DirectoryExists -Path $InstallDir
 
-	Context-DataDirectories -Path @($ConfigDir, $DataDir, $LogsDir) -DeleteAfter
+		Context-DataDirectories -Path @($ConfigDir, $DataDir, $LogsDir) -DeleteAfter
+	}
 }


### PR DESCRIPTION
This commit fixes integration tests to handle cases where

- a version to upgrade from allows config/data/logs to be installed as sub
  directories of the home directory
- a version to install does not allow config/data/logs to be installed as sub
  directories of the home directory