### PR TITLE
Ensure snapshots run on CI

### DIFF
--- a/build/scripts/Build.fsx
+++ b/build/scripts/Build.fsx
@@ -1,6 +1,7 @@
 ﻿#I "../../packages/build/FAKE.x64/tools"
 
 #r "FakeLib.dll"
+#load "Paths.fsx"
 #load "Products.fsx"
 #load "BuildConfig.fsx"
 
@@ -16,7 +17,7 @@ open Fake.FileHelper
 open Fake.Git
 open Fake.Testing.XUnit2
 open Products.Products
-open Products.Paths
+open Paths.Paths
 open Products
 
 module Builder =

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -6,6 +6,7 @@
 #r "Fsharp.Data.dll"
 #r "Fsharp.Text.RegexProvider.dll"
 #r "System.Xml.Linq.dll"
+#load "Paths.fsx"
 #load "Products.fsx"
 #load "Snapshots.fsx"
 
@@ -18,11 +19,10 @@ open Fake
 open FSharp.Data
 open FSharp.Text.RegexProvider
 open Products.Products
-open Products.Paths
+open Paths.Paths
 open Snapshots
 
 ServicePointManager.SecurityProtocol <- SecurityProtocolType.Ssl3 ||| SecurityProtocolType.Tls ||| SecurityProtocolType.Tls11 ||| SecurityProtocolType.Tls12;
-ServicePointManager.ServerCertificateValidationCallback <- (fun _ _ _ _ -> true)
 
 module Commandline =
 
@@ -361,13 +361,20 @@ Integration tests against a local vagrant provider support several switches
                            setBuildParam "testtargets" testTargets
                            setBuildParam "vagrantprovider" provider
                            products |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
-                       | ["integrate"; IsProductList products; IsVersionList versions; testTargets] ->
-                           setBuildParam "testtargets" testTargets
-                           products |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
                            
                        | ["integrate"; IsProductList products; IsVersionList versions; IsVagrantProvider provider] ->
                            setBuildParam "vagrantprovider" provider
                            products |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
+                           
+                       | ["integrate"; IsProductList products; IsVersionList versions; testTargets] ->
+                           setBuildParam "testtargets" testTargets
+                           products |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
+                           
+                       | ["integrate"; IsProductList products; IsVagrantProvider provider; testTargets] ->
+                           setBuildParam "testtargets" testTargets
+                           setBuildParam "vagrantprovider" provider
+                           products |> List.map (ProductVersions.CreateFromProduct lastVersion)    
+                           
                        | ["integrate"; IsProductList products; IsVersionList versions] ->
                            products |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
                            
@@ -375,37 +382,39 @@ Integration tests against a local vagrant provider support several switches
                            setBuildParam "testtargets" testTargets
                            setBuildParam "vagrantprovider" provider
                            All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)                       
-                       | ["integrate"; IsVersionList versions; testTargets] ->
-                           setBuildParam "testtargets" testTargets
-                           All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
-                           
-                       | ["integrate"; IsProductList products; IsVagrantProvider provider; testTargets] ->
-                           setBuildParam "testtargets" testTargets
-                           setBuildParam "vagrantprovider" provider
-                           products |> List.map (ProductVersions.CreateFromProduct lastVersion)                           
-                       | ["integrate"; IsProductList products; testTargets] ->
-                           setBuildParam "testtargets" testTargets
-                           products |> List.map (ProductVersions.CreateFromProduct lastVersion)                    
+                                                                                     
                        | ["integrate"; IsProductList products; IsVagrantProvider provider] ->
+                           trace "Hit expected pattern"
                            setBuildParam "vagrantprovider" provider
                            products |> List.map (ProductVersions.CreateFromProduct lastVersion) 
-                       | ["integrate"; IsProductList products] ->
-                           products |> List.map (ProductVersions.CreateFromProduct lastVersion)        
+                           
                        | ["integrate"; IsVersionList versions; IsVagrantProvider provider] ->
                            setBuildParam "vagrantprovider" provider
-                           All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)                       
-                       | ["integrate"; IsVersionList versions] ->
-                           All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
+                           All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)  
+                           
+                       | ["integrate"; IsProductList products; testTargets] ->
+                           setBuildParam "testtargets" testTargets
+                           products |> List.map (ProductVersions.CreateFromProduct lastVersion)   
+                                                
                        | ["integrate"; IsVagrantProvider provider; testTargets] ->
                            setBuildParam "testtargets" testTargets
                            setBuildParam "vagrantprovider" provider
-                           All |> List.map (ProductVersions.CreateFromProduct lastVersion)      
+                           All |> List.map (ProductVersions.CreateFromProduct lastVersion)    
+
+                       | ["integrate"; IsProductList products] ->
+                           products |> List.map (ProductVersions.CreateFromProduct lastVersion)
+                           
+                       | ["integrate"; IsVersionList versions] ->
+                           All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)
+                             
                        | ["integrate"; IsVagrantProvider provider] ->
                            setBuildParam "vagrantprovider" provider
-                           All |> List.map (ProductVersions.CreateFromProduct lastVersion)                
+                           All |> List.map (ProductVersions.CreateFromProduct lastVersion)    
+                                       
                        | ["integrate"; testTargets] ->
                            setBuildParam "testtargets" testTargets
                            All |> List.map (ProductVersions.CreateFromProduct lastVersion)
+                           
                        | [IsProductList products; IsVersionList versions] ->
                            products |> List.map(ProductVersions.CreateFromProduct <| fun _ -> versions)
                        | [IsProductList products] ->

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -384,7 +384,6 @@ Integration tests against a local vagrant provider support several switches
                            All |> List.map (ProductVersions.CreateFromProduct <| fun _ -> versions)                       
                                                                                      
                        | ["integrate"; IsProductList products; IsVagrantProvider provider] ->
-                           trace "Hit expected pattern"
                            setBuildParam "vagrantprovider" provider
                            products |> List.map (ProductVersions.CreateFromProduct lastVersion) 
                            

--- a/build/scripts/Paths.fsx
+++ b/build/scripts/Paths.fsx
@@ -1,0 +1,32 @@
+#I "../../packages/build/FAKE.x64/tools"
+
+#r "FakeLib.dll"
+
+open Fake
+
+module Paths =
+    let BuildDir = "./build/"
+    let ToolsDir = BuildDir @@ "tools/"
+    let InDir = BuildDir @@ "in/"
+    let OutDir = BuildDir @@ "out/"
+    let ResultsDir = BuildDir @@ "results/"
+
+    let SrcDir = "./src/"
+    let ProcessHostsDir = SrcDir @@ "ProcessHosts/"
+    let MsiDir = SrcDir @@ "Installer/Elastic.Installer.Msi/"
+    let MsiBuildDir = MsiDir @@ "bin/Release/"
+
+    let IntegrationTestsDir = FullName "./src/Tests/Elastic.Installer.Integration.Tests"
+    let UnitTestsDir = "src/Tests/Elastic.Domain.Tests"
+
+    let ArtifactDownloadsUrl = "https://artifacts.elastic.co/downloads"
+    
+    let ArtifactVersionsUrl = "https://artifacts-api.elastic.co/v1/versions"  
+    let ArtifactVersionBuildsUrl version = sprintf "%s/%s/builds" ArtifactVersionsUrl version    
+    let ArtifactVersionBuildUrl version build = sprintf "%s/%s/builds/%s" ArtifactVersionsUrl version build
+
+    let StagingDownloadsUrl product hash fullVersion = 
+        sprintf "https://staging.elastic.co/%s-%s/downloads/%s/%s-%s.msi" fullVersion hash product product fullVersion
+
+    let SnapshotDownloadsUrl product versionNumber hash fullVersion =
+        sprintf "https://snapshots.elastic.co/%s-%s/downloads/%s/%s-%s.msi" versionNumber hash product product fullVersion

--- a/build/scripts/Products.fsx
+++ b/build/scripts/Products.fsx
@@ -1,6 +1,7 @@
 ﻿#I "../../packages/build/FAKE.x64/tools"
 
 #r "FakeLib.dll"
+#load "Paths.fsx"
 #load "Snapshots.fsx"
 
 open System
@@ -8,33 +9,10 @@ open System.Globalization
 open System.IO
 open Fake
 open Fake.FileHelper
+open Paths.Paths
 open Snapshots
 
-module Paths =
-    let BuildDir = "./build/"
-    let ToolsDir = BuildDir @@ "tools/"
-    let InDir = BuildDir @@ "in/"
-    let OutDir = BuildDir @@ "out/"
-    let ResultsDir = BuildDir @@ "results/"
-
-    let SrcDir = "./src/"
-    let ProcessHostsDir = SrcDir @@ "ProcessHosts/"
-    let MsiDir = SrcDir @@ "Installer/Elastic.Installer.Msi/"
-    let MsiBuildDir = MsiDir @@ "bin/Release/"
-
-    let IntegrationTestsDir = FullName "./src/Tests/Elastic.Installer.Integration.Tests"
-    let UnitTestsDir = "src/Tests/Elastic.Domain.Tests"
-
-    let ArtifactDownloadsUrl = "https://artifacts.elastic.co/downloads"
-
-    let StagingDownloadsUrl product hash fullVersion = 
-        sprintf "https://staging.elastic.co/%s-%s/downloads/%s/%s-%s.msi" fullVersion hash product product fullVersion
-
-    let SnapshotDownloadsUrl product versionNumber hash fullVersion =
-        sprintf "https://snapshots.elastic.co/%s-%s/downloads/%s/%s-%s.msi" versionNumber hash product product fullVersion
-
 module Products =
-    open Paths
 
     type Product =
         | Elasticsearch

--- a/build/scripts/Snapshots.fsx
+++ b/build/scripts/Snapshots.fsx
@@ -6,60 +6,55 @@
 #r "Fsharp.Data.dll"
 #r "Fsharp.Text.RegexProvider.dll"
 #r "System.Xml.Linq.dll"
+#load "Paths.fsx"
 
 open System
 open System.Net
 open FSharp.Data
 open Fake
+open Paths.Paths
 
 ServicePointManager.SecurityProtocol <- SecurityProtocolType.Ssl3 ||| SecurityProtocolType.Tls ||| SecurityProtocolType.Tls11 ||| SecurityProtocolType.Tls12;
-ServicePointManager.ServerCertificateValidationCallback <- (fun _ _ _ _ -> true)
 
 module Snapshots =
 
-    let private urlBase = "https://artifacts-api.elastic.co/v1/versions"
+    let private downloadJson (url:string) =
+        use webClient = new WebClient()
+        webClient.DownloadString url |> JsonValue.Parse
 
-    let GetVersions() =
-        use webClient = new System.Net.WebClient()
-        let versions = webClient.DownloadString urlBase |> JsonValue.Parse
+    let GetVersions () =
+        let versions = ArtifactVersionsUrl |> downloadJson
         let arrayValue = versions.GetProperty "versions"
         arrayValue.AsArray()
         |> Seq.rev
         |> Seq.map (fun x -> x.AsString())
 
-    let getPrerelease (prerelease:string) =
+    let getPrerelease prerelease =
         (splitStr "-" prerelease) |> Seq.head
     
     let getSnapshotName major minor patch prerelease =
-        if isNullOrWhiteSpace (prerelease) then
+        if isNullOrWhiteSpace prerelease then
             sprintf "%d.%d.%d-SNAPSHOT" major minor patch
         else
             let prerelease = getPrerelease prerelease
             sprintf "%d.%d.%d-%s-SNAPSHOT" major minor patch prerelease
 
     let GetVersionsFiltered major minor patch prerelease =
-        use webClient = new System.Net.WebClient()
-        let versions = webClient.DownloadString urlBase |> JsonValue.Parse
+        let versions = ArtifactVersionsUrl |> downloadJson
         let arrayValue = versions.GetProperty "versions"
         arrayValue.AsArray()
         |> Seq.rev
         |> Seq.map (fun x -> x.AsString())
         |> Seq.filter (fun x -> x = getSnapshotName major minor patch prerelease)
 
-    let GetSnapshotBuilds version = (
-       use webClient = new System.Net.WebClient()
-       let url = sprintf "%s/%s/builds" urlBase version
-       let versions = webClient.DownloadString url |> JsonValue.Parse
+    let GetSnapshotBuilds version =
+       let versions = ArtifactVersionBuildsUrl version |> downloadJson
        let arrayValue = versions.GetProperty "builds"
        arrayValue.AsArray()
        |> Seq.map (fun x -> x.AsString())
-    )
 
-    let GetSnapshotBuildAssets product version build = (
-       use webClient = new System.Net.WebClient()
-       let url = sprintf "%s/%s/builds/%s" urlBase version build
-       let versions = webClient.DownloadString url |> JsonValue.Parse
+    let GetSnapshotBuildAssets product version build =
+       let versions = ArtifactVersionBuildUrl version build |> downloadJson
        let assets = ((((versions.GetProperty "build").GetProperty "projects").GetProperty product).GetProperty "packages")
        let asset = sprintf "%s-%s.zip" product version
        ((assets.GetProperty asset).GetProperty "url").InnerText()
-    )

--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -3,6 +3,7 @@
 
 #r "FakeLib.dll"
 #r "System.Management.Automation.dll"
+#load "Paths.fsx"
 #load "Products.fsx"
 #load "Build.fsx"
 #load "BuildConfig.fsx"
@@ -15,9 +16,8 @@ open Fake
 open Fake.FileHelper
 open Scripts
 open Fake.Testing.XUnit2
-open Products
 open Products.Products
-open Products.Paths
+open Paths.Paths
 open Build.Builder
 open Commandline
 
@@ -107,12 +107,12 @@ Target "Integrate" (fun () ->
         |> List.map(fun v ->  Commandline.parseVersion v)
         |> List.collect(fun s ->
             pluginNames 
-            |> Array.map(fun p -> Paths.InDir </> (sprintf "%s-%s.zip" p s.FullVersion))
+            |> Array.map(fun p -> InDir </> (sprintf "%s-%s.zip" p s.FullVersion))
             |> Array.toList
         )
         |> List.iter(fun p ->
             match fileExists p with
-            | true -> CopyFile Paths.OutDir p
+            | true -> CopyFile OutDir p
             | false -> traceFAKE "%s does not exist. Will install from public url" p 
         )
 

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <None Include="BuildConfig.fsx" />
     <None Include="Commandline.fsx" />
+    <None Include="Paths.fsx" />
     <None Include="Targets.fsx" />
     <None Include="config.yaml" />
     <None Include="Build.fsx" />

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/CommonTests.ps1
@@ -93,9 +93,9 @@ function Context-PingNode([switch]$XPackSecurityInstalled) {
             $Response.Success | Should Be $true
         }
 
-        $XPackSecurityIsInstalled = "X-Pack Security is installed"
+        $XPackSecurityIsInstalled = "X-Pack Security is installed/enabled"
         if (! ($XPackSecurityInstalled)) {
-            $XPackSecurityIsInstalled = "X-Pack Security is not installed"
+            $XPackSecurityIsInstalled = "X-Pack Security is not installed/enabled"
         }
 
         It $XPackSecurityIsInstalled {

--- a/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
+++ b/src/Tests/Elastic.Installer.Integration.Tests/Common/Utils.ps1
@@ -506,17 +506,30 @@ function Invoke-SilentInstall {
 		}
 		$Exeargs = $Newargs
 	}
+	
+	$pluginsStaging = $null
 
 	if ($Version.Source) {
-        if (!$Exeargs) {
-            $Exeargs = @("PLUGINSSTAGING=$($Version.Source)")
-        }
-        elseif (-not ($Exeargs | ?{$_ -like "PLUGINSSTAGING=*" })) {
-            $Exeargs.Add("PLUGINSSTAGING=$($Version.Source)") | Out-Null
-        }
-    }
-
-
+        $pluginsStaging = $Version.Source
+    } 
+	elseif ($Version.Prerelease) {
+		# prelease may be a snapshot with a suffix e.g. 7.0.0-alpha1-ea57ee52
+		$preleaseParts = $Version.Prerelease[0].Split('-', [StringSplitOptions]::RemoveEmptyEntries)
+		if ($preleaseParts.Length -gt 1) {
+			$pluginsStaging = $preleaseParts[1]
+		}
+	}
+	
+	if ($pluginsStaging -ne $null)
+	{
+		if (!$Exeargs) {
+			$Exeargs = @("PLUGINSSTAGING=$pluginsStaging")
+		}
+		elseif (-not($Exeargs | ?{ $_ -like "PLUGINSSTAGING=*" })) {
+			$Exeargs.Add("PLUGINSSTAGING=$pluginsStaging") | Out-Null
+		}
+	}
+	
     $QuotedArgs = Add-Quotes $Exeargs
     $Exe = Get-Installer -Version $Version
 	if ($Upgrade) {


### PR DESCRIPTION
This commit fixes an issue where snapshot builds were not running on CI.
The command line pattern passed was matching a pattern where the
Vagrant provider was interpreted as a test target. Order of patterns is important,
so those patterns containing partial Active Patterns should come before patterns
that do not have constraints.

Separate out Paths module to separate file and move Snapshot Artifacts Urls out
into Paths module, to simplify the Snapshots module.

When a version has a prerelease suffix, check to see if it contains a snapshot hash.
If it does, pass this as the value for PLUGINSSTAGING, to allow snapshot plugins
to be installed.