### PR TITLE
Do not use XPackModel.IsRelevant in custom actions

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Notice/NoticeModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Notice/NoticeModel.cs
@@ -112,7 +112,10 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Notice
 		{
 			var sb = new StringBuilder();
 			sb.AppendLine(nameof(NoticeModel));
-			sb.AppendLine($"- {nameof(IsValid)} = " + IsValid);
+			sb.AppendLine($"- {nameof(CurrentVersion)} = {CurrentVersion}");
+			sb.AppendLine($"- {nameof(ExistingVersion)} = {ExistingVersion}");
+			sb.AppendLine($"- {nameof(ExistingVersionInstalled)} = {ExistingVersionInstalled}");
+			sb.AppendLine($"- {nameof(IsValid)} = {IsValid}");
 			return sb.ToString();
 		}
 	}

--- a/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchSetupXPackPasswordsAction.cs
+++ b/src/Installer/Elastic.Installer.Msi/Elasticsearch/CustomActions/Install/ElasticsearchSetupXPackPasswordsAction.cs
@@ -14,7 +14,7 @@ namespace Elastic.Installer.Msi.Elasticsearch.CustomActions.Install
 		public override int Order => (int)ElasticsearchCustomActionOrder.SetupXPackPasswords;
 		public override Condition Condition => 
 			new Condition($"(NOT Installed) AND {nameof(XPackModel.XPackSecurityEnabled).ToUpperInvariant()}~=\"true\" " +
-			              $"AND {nameof(XPackModel.XPackLicense).ToUpperInvariant()}~=\"Trial\" " +
+			              $"AND {nameof(XPackModel.XPackLicense).ToUpperInvariant()}~=\"{nameof(XPackLicenseMode.Trial)}\" " +
 			              $"AND {nameof(XPackModel.SkipSettingPasswords).ToUpperInvariant()}~=\"false\"");
 		public override Return Return => Return.check;
 		public override Sequence Sequence => Sequence.InstallExecuteSequence;

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Immediate/ValidateArgumentsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Immediate/ValidateArgumentsTask.cs
@@ -11,9 +11,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Immediate
 
 		protected override bool ExecuteTask()
 		{
-			this.Session.Log($"Existing Version Installed: {this.InstallationModel.NoticeModel.ExistingVersionInstalled}");
-			this.Session.Log($"Current Version: {this.InstallationModel.NoticeModel.CurrentVersion}");
-			this.Session.Log($"Existing Version: {this.InstallationModel.NoticeModel.ExistingVersion}");
 			this.Session.Log($"Session Installing: {this.Session.IsInstalling}");
 			this.Session.Log($"Session Uninstalling: {this.Session.IsUninstalling}");
 			this.Session.Log($"Session Rollback: {this.Session.IsRollback}");

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordPropertyTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordPropertyTask.cs
@@ -24,9 +24,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 
 		protected override bool ExecuteTask()
 		{
-			var xPackModel = this.InstallationModel.XPackModel;
-			if (!xPackModel.IsRelevant) return true;
-
 			const int length = 20;
 			var password = new StringBuilder();
 			var property = nameof(XPackModel.BootstrapPassword).ToUpperInvariant();

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetBootstrapPasswordTask.cs
@@ -20,9 +20,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 		{
 			var xPackModel = this.InstallationModel.XPackModel;
 			var locationsModel = this.InstallationModel.LocationsModel;
-			
-			if (!xPackModel.IsRelevant) return true;
-
 			var installationDir = locationsModel.InstallDir;
 			var password = xPackModel.BootstrapPassword;
 			var binary = this.FileSystem.Path.Combine(installationDir, "bin", "elasticsearch-keystore.bat");

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetupXPackPasswordsTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/SetupXPackPasswordsTask.cs
@@ -22,9 +22,6 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 
 		protected override bool ExecuteTask()
 		{
-			var xPackModel = this.InstallationModel.XPackModel;
-			if (!xPackModel.IsRelevant || !xPackModel.NeedsPasswords) return true;
-
 			this.Session.SendActionStart(TotalTicks, ActionName, "Setting up X-Pack passwords", "Setting up X-Pack passwords: [1]");
 
 			var password = this.InstallationModel.XPackModel.BootstrapPassword;


### PR DESCRIPTION
Do not use XPackModel.IsRelevant in custom actions

This PR updates custom actions to not use `XPackModel.IsRelevant`
to determine if the body of a custom action should run. The semantics for `IsRelevant` have changed based on whether the existing version is before 6.3.0 and X-Pack was installed, and used to determine whether the X-Pack tab should be shown.