### PR TITLE
Do not build snapshot hashes in prerelease property

### DIFF
--- a/build/scripts/Products.fsx
+++ b/build/scripts/Products.fsx
@@ -66,6 +66,7 @@ module Products =
     }
 
     let lastSnapshotVersionAsset (product:Product, version:Version) =
+        tracefn "%O %O" product version
         let latestAsset = Snapshots.GetVersionsFiltered version.Major version.Minor version.Patch version.Prerelease
                             |> Seq.map (fun x -> (x, (Snapshots.GetSnapshotBuilds x) |> Seq.head))
                             |> Seq.map (fun xy -> Snapshots.GetSnapshotBuildAssets product.Name (fst xy) (snd xy))
@@ -139,8 +140,10 @@ module Products =
                     if (Directory.Exists(extractedDirectory)) then
                         tracefn "Deleting snapshot existing directory: %s" extractedDirectory
                         Directory.Delete(extractedDirectory, true)
+                        
+                let url = this.DownloadUrl version
 
-                match (this.DownloadUrl version, zipFile) with
+                match (url, zipFile) with
                 | (_, file) when fileExists file ->
                     tracefn "Already downloaded %s to %s" this.Name file
                 | (url, file) ->

--- a/build/scripts/config.yaml
+++ b/build/scripts/config.yaml
@@ -143,6 +143,10 @@ elasticsearch:
       guid: 0b5a3943-37c7-47f3-af9d-16e7c93b5060
     - version: 7.0.0-alpha1
       guid: 303b8268-6caa-4b82-aa3a-2b3e7197a0a3
+    - version: 7.0.0-f9710adc
+      guid: a422e744-a745-4cc4-9cd7-51cd61f7ee28
+    - version: 7.0.0
+      guid: e801e31b-ecf2-40c5-a79c-05e26bdcc83a
 kibana:
   upgrade_code: 6a2e6f51-5145-4c1a-8d05-2190ae213367
   known_versions:


### PR DESCRIPTION
Our latest snapshots builds were failing because when we get the latest snapshots using

```
> build downloadproducts skiptests es --snapshots
```

However specifying 7.0.0 in combination with `--snapshots` works:

```
> build downloadproducts skiptests es 7.0.0 --snapshots
```
When no version number is specified we take the latest moniker from:
 
https://artifacts-api.elastic.co/v1/versions

and use that to build the url the get the version specific latest snapshot. 

https://artifacts-api.elastic.co/v1/versions/7.0.0-SNAPSHOT/builds

The build hashes were used as prerelease.
