### PR TITLE
Parse version from Windows distribution

### DIFF
--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -211,7 +211,7 @@ Integration tests against a local vagrant provider support several switches
 
     let private versionFromInDir (product : Product) =
         let extractVersion (fileInfo:FileInfo) =
-            Regex.Replace(fileInfo.Name, "^" + product.Name + "\-(.*)\.zip$", "$1")
+            Regex.Replace(fileInfo.Name, "^" + product.Name + "\-(.*?)(\-windows\-x86_64)?\.zip$", "$1")
         let zips = InDir
                    |> directoryInfo
                    |> filesInDirMatching (product.Name + "*.zip")

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -211,7 +211,7 @@ Integration tests against a local vagrant provider support several switches
 
     let private versionFromInDir (product : Product) =
         let extractVersion (fileInfo:FileInfo) =
-            Regex.Replace(fileInfo.Name, "^" + product.Name + "\-(.*?)(\-windows\-x86_64)?\.zip$", "$1")
+            Regex.Replace(fileInfo.Name, "^" + product.Name + "\-(.*?)(?:\-windows\-x86_64)?\.zip$", "$1")
         let zips = InDir
                    |> directoryInfo
                    |> filesInDirMatching (product.Name + "*.zip")


### PR DESCRIPTION
This PR updates the regex used to parse the version from the file info name, to exclude the
-windows-x86_64 suffix from being included in the capture group.