### PR TITLE
Ensure logs directory is present within the home directory

### DIFF
--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
@@ -21,6 +21,7 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 		private IElasticsearchTool JavaVersionChecker { get;  }
 		
 		private string PrivateTempDirectory { get; }
+		private string GCLogsDirectory { get; set; }
 
 		public ElasticsearchProcess(ManualResetEvent completedHandle, IEnumerable<string> args)
 			: this(
@@ -61,6 +62,7 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 			this.HomeDirectory = homeDirectory;
 			this.ConfigDirectory = configDirectory;
 			this.PrivateTempDirectory = env.PrivateTempDirectory;
+			this.GCLogsDirectory = Path.Combine(homeDirectory, "logs");
 
 			var parsedArguments = this.ParseArguments(args);
 
@@ -188,6 +190,9 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 		{
 			if (!this.FileSystem.Directory.Exists(this.PrivateTempDirectory))
 				this.FileSystem.Directory.CreateDirectory(this.PrivateTempDirectory);
+
+			if (!this.FileSystem.Directory.Exists(this.GCLogsDirectory))
+				this.FileSystem.Directory.CreateDirectory(this.GCLogsDirectory);
 
 			base.Start();
 		}


### PR DESCRIPTION
Ensure logs directory is present within the home directory so that the `gc.log` file can be written. This allows for the `elasticsearch.exe` to launch with JDK 9+ in a similar manner to the bat file.

Fixes: https://github.com/elastic/windows-installers/issues/249