### PR TITLE
fix #263, remove ingest-geoip plugin from 6.7.0 onwards 

### DIFF
--- a/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/Plugin.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/Plugin.cs
@@ -39,7 +39,7 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 			get => _selected;
 			set => this.RaiseAndSetIfChanged(ref _selected, value);
 		}
-
+		
 		/// <summary>
 		/// The type of plugin
 		/// </summary>

--- a/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Base/Plugins/PluginsModelBase.cs
@@ -33,7 +33,7 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 		protected string PreviousInstallDirectory { get; set; }
 		protected string ConfigDirectory { get; set; }
 
-		protected abstract IEnumerable<Plugin> GetPlugins();
+		protected abstract IEnumerable<Plugin> GetPlugins(SemVersion version);
 
 		protected virtual Dictionary<string,string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
 
@@ -94,7 +94,7 @@ namespace Elastic.Installer.Domain.Model.Base.Plugins
 		{
 			this.AvailablePlugins.Clear();
 			this.InstalledPlugins.Clear();
-			this.AvailablePlugins.AddRange(this.GetPlugins());
+			this.AvailablePlugins.AddRange(this.GetPlugins(this._version));
 
 			var installedPlugins = !this.AlreadyInstalled || string.IsNullOrEmpty(this.PreviousInstallDirectory)
 				? null

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Plugins/PluginsModel.cs
@@ -161,7 +161,7 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 			set => this.RaiseAndSetIfChanged(ref this.pluginsStaging, value);
 		}
 
-		protected override IEnumerable<Plugin> GetPlugins()
+		protected override IEnumerable<Plugin> GetPlugins(SemVersion version)
 		{
 			yield return new Plugin
 			{
@@ -170,14 +170,15 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Plugins
 				DisplayName = "Ingest Attachment Processor",
 				Description = TextResources.PluginsModel_IngestAttachment,
 			};
-
-			yield return new Plugin
-			{
-				PluginType = PluginType.Ingest,
-				Url = "ingest-geoip",
-				DisplayName = "Ingest GeoIP Processor",
-				Description = TextResources.PluginsModel_IngestGeoIP,
-			};
+			
+			if (version < "6.7.0")
+                yield return new Plugin
+                {
+                    PluginType = PluginType.Ingest,
+                    Url = "ingest-geoip",
+                    DisplayName = "Ingest GeoIP Processor",
+                    Description = TextResources.PluginsModel_IngestGeoIP,
+                };
 
 			yield return new Plugin
 			{

--- a/src/Installer/Elastic.Installer.Domain/Model/Kibana/Plugins/PluginsModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Kibana/Plugins/PluginsModel.cs
@@ -24,6 +24,6 @@ namespace Elastic.Installer.Domain.Model.Kibana.Plugins
 			});
 		}
 
-		protected override IEnumerable<Plugin> GetPlugins() => new List<Plugin>();
+		protected override IEnumerable<Plugin> GetPlugins(SemVersion version) => new List<Plugin>();
 	}
 }

--- a/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts.Elasticsearch/App.xaml.cs
@@ -36,9 +36,9 @@ namespace Elastic.InstallerHosts.Elasticsearch
 			);
 			
 			var state = InstallationModelTester.ValidPreflightChecks(s => s
-				.Wix(current: "6.3.1")
+				.Wix(current: "6.7.0")
 			);
-			var model = upgradeState.InstallationModel;
+			var model = state.InstallationModel;
 
 			var window = new MainWindow(model, new ManualResetEvent(false));
 			model.InstallUITask = async () =>

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Plugins/PluginsTests.cs
@@ -33,6 +33,20 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Plugins
 
 			})
 			.CanClickNext();
+		
+		[Fact] void IngestGeoIpAvailableBefore670() => DefaultValidModel(s=>s.Wix(current: "6.6.0"))
+			.OnStep(m => m.PluginsModel, step => 
+			{
+				step.AvailablePlugins.Should().Contain(a => a.Url == "ingest-geoip");
+			})
+			.CanClickNext();
+		
+		[Fact] void IngestGeoIpNotAvailableAfter670() => DefaultValidModel(s=>s.Wix(current: "6.7.0"))
+			.OnStep(m => m.PluginsModel, step => 
+			{
+				step.AvailablePlugins.Should().NotContain(a => a.Url == "ingest-geoip");
+			})
+			.CanClickNext();
 
 		[Fact] void IngestPluginsNotSelectedByDefault() => this._model
 			.OnStep(m => m.PluginsModel, step =>


### PR DESCRIPTION
as its now a module in elasticsearch.


relates: https://github.com/elastic/elasticsearch/pull/36898

port to `6.x` `7.0` `7.x` and `master`