### PR TITLE
Include empty directories in MSI and add ES_HOME as cwd for Elasticsearch tools

### DIFF
--- a/src/Installer/Elastic.Installer.Msi/Product.cs
+++ b/src/Installer/Elastic.Installer.Msi/Product.cs
@@ -33,9 +33,14 @@ namespace Elastic.Installer.Msi
 
 		public List<Dir> Files(string path) =>
 			Directory.GetDirectories(path)
-				.Where(directory => Directory.EnumerateFileSystemEntries(directory).Any())
-				.Select(Path.GetFileName)
-				.Select(directoryName => new Dir(directoryName, new Files(path + $@"\{directoryName}\*.*")))
+				.Select(Path.GetFullPath)
+				.Select(fullPath =>
+				{
+					var name = Path.GetFileName(fullPath);
+					return Directory.EnumerateFileSystemEntries(fullPath).Any()
+						? new Dir(name, new Files(path + $@"\{name}\*"))
+						: new Dir(name);
+				})
 				.ToList();
 
 		public virtual void PatchWixSource(XDocument document) { }

--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
@@ -191,9 +191,6 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 			if (!this.FileSystem.Directory.Exists(this.PrivateTempDirectory))
 				this.FileSystem.Directory.CreateDirectory(this.PrivateTempDirectory);
 
-			if (!this.FileSystem.Directory.Exists(this.GCLogsDirectory))
-				this.FileSystem.Directory.CreateDirectory(this.GCLogsDirectory);
-
 			base.Start();
 		}
 	}

--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
@@ -21,7 +21,6 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 		private IElasticsearchTool JavaVersionChecker { get;  }
 		
 		private string PrivateTempDirectory { get; }
-		private string GCLogsDirectory { get; set; }
 
 		public ElasticsearchProcess(ManualResetEvent completedHandle, IEnumerable<string> args)
 			: this(
@@ -62,7 +61,6 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 			this.HomeDirectory = homeDirectory;
 			this.ConfigDirectory = configDirectory;
 			this.PrivateTempDirectory = env.PrivateTempDirectory;
-			this.GCLogsDirectory = Path.Combine(homeDirectory, "logs");
 
 			var parsedArguments = this.ParseArguments(args);
 
@@ -126,7 +124,7 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 		{
 			var libFolder = Path.Combine(this.HomeDirectory, "lib");
 			if (!FileSystem.Directory.Exists(libFolder)) throw new StartupException($"Expected a 'lib' directory inside: {this.HomeDirectory}");
-			var classPath = $"{Path.Combine(libFolder, "*")}";
+			var classPath = Path.Combine(libFolder, "*");
 			
 			if (!this.JavaVersionChecker.Start(null, out var javaVersionOut)) throw new StartupException($"Invalid Java version reported: {javaVersionOut}");
 

--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchTool.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchTool.cs
@@ -33,6 +33,8 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 			                    ?? throw new StartupException(
 				                    $"No {ElasticsearchEnvironmentStateProvider.EsHome} variable set and no home directory could be inferred from the executable location");
 
+			this.WorkingDirectory = homeDirectory;
+
 			var javaHome = java.JavaHomeCanonical;
 			if (javaHome == null)
 				throw new StartupException("JAVA_HOME is not set and no Java installation could be found in the windows registry!");
@@ -66,6 +68,8 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 
 		private string ProcessExe { get; }
 
+		private string WorkingDirectory { get; }
+
 		public bool Start(string[] arguments, out string output) => this.Start(arguments, TimeSpan.FromMinutes(1), out output);
 
 		public bool Start(string[] arguments, TimeSpan timeout, out string output)
@@ -80,6 +84,7 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 				StartInfo =
 				{
 					FileName = this.ProcessExe,
+					WorkingDirectory = this.WorkingDirectory,
 					Arguments = args,
 					CreateNoWindow = true,
 					ErrorDialog = false,

--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchTool.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchTool.cs
@@ -45,7 +45,7 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 
 			var libFolder = Path.Combine(homeDirectory, "lib");
 			if (!fileSystem.Directory.Exists(libFolder)) throw new StartupException($"Expected a 'lib' directory inside: {homeDirectory}");
-			var classPath = $"{Path.Combine(libFolder, "*")}";
+			var classPath = Path.Combine(libFolder, "*");
 
 			this.ProcessVariables = new Dictionary<string, string>
 			{


### PR DESCRIPTION
Relates: #312, #313, #315

This PR includes empty directories in the MSI. By default, Wix does not include empty directories. To support an empty directory, a `Component` must be included inside a `Directory` element, and inside of this must be a `CreateFolder` element. For example

```xml
<Directory Id="INSTALLDIR.plugins" Name="plugins">
  <Component Id="plugins.EmptyDirectory" Guid="daaa2cba-a1ed-4f29-afbf-5478e5d5da07" KeyPath="yes" Win64="yes">
    <CreateFolder />
    <RemoveFolder Id="INSTALLDIR.plugins" On="uninstall" />
  </Component>
</Directory>
```

will include an empty plugins directory on install, and remove on uninstall, if empty. Updated Files() implementation in Product to include empty directories, which WixSharp will create the necessary elements to create an empty directory for.

Remove the logs directory fix introduced in #260. This fix worked for Elasticsearch < 7.2.0, but does not work going forward because the JvmOptionsParser tool runs a java process that uses jvm.options _before_ the logs directory referenced for logs/gc.log is created:

https://github.com/elastic/elasticsearch/blob/970a2254c3c623dc92fa2e19c6956606e4a128d4/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java#L84-L115

Set the working directory for Java tools to the ES_HOME directory. This allows the invocation of JvmOptionsParser as part of Windows Service startup to correctly find the logs directory referenced by logs/gc.log in the jvm.options file in the config directory.