### PR TITLE
Allow command line builds with VS2019

### DIFF
--- a/build/scripts/Build.fsx
+++ b/build/scripts/Build.fsx
@@ -20,16 +20,14 @@ open Versions
 
 // use vswhere to set MSBuild location, if it exists. 
 // Allows FAKE MsBuildHelper.MsBuildRelease to work with Visual Studio 2019
-let vsWhere = Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%") </> @"Microsoft Visual Studio\Installer\vswhere.exe"
+let private vsWhere = Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%") </> @"Microsoft Visual Studio\Installer\vswhere.exe"
 if fileExists vsWhere then
     let result = ExecProcessAndReturnMessages (fun p -> 
                     p.FileName <- vsWhere
-                    p.Arguments <- @"-latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe"
+                    p.Arguments <- @"-latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe"
                  ) (TimeSpan.FromSeconds 5.)
 
-    if result.ExitCode = 0 then 
-        setEnvironVar "MSBuild" result.Messages.[0]
-
+    if result.ExitCode = 0 then setEnvironVar "MSBuild" result.Messages.[0]
 
 /// Signs a file using a certificate
 let sign file productTitle =

--- a/build/scripts/Build.fsx
+++ b/build/scripts/Build.fsx
@@ -18,6 +18,19 @@ open Paths
 open Products
 open Versions
 
+// use vswhere to set MSBuild location, if it exists. 
+// Allows FAKE MsBuildHelper.MsBuildRelease to work with Visual Studio 2019
+let vsWhere = Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%") </> @"Microsoft Visual Studio\Installer\vswhere.exe"
+if fileExists vsWhere then
+    let result = ExecProcessAndReturnMessages (fun p -> 
+                    p.FileName <- vsWhere
+                    p.Arguments <- @"-latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe"
+                 ) (TimeSpan.FromSeconds 5.)
+
+    if result.ExitCode = 0 then 
+        setEnvironVar "MSBuild" result.Messages.[0]
+
+
 /// Signs a file using a certificate
 let sign file productTitle =
     let release = getBuildParam "release" = "1"


### PR DESCRIPTION
This commit updates Build.fsx to allow command line builds when only Visual Studio 2019 is installed.
FAKE's MSBuildRelease function does not know where to look for VS2019, so MSBuild environment variable
can be set using vswhere to point to where to find it. Without this, MsBuildRelease ends up using a version
of MsBuild that it does find, which may use a version of csc.exe too old to understand newer C# language features used.