### PR TITLE
Pass config directory to JvmOptionsParser

### DIFF
--- a/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
+++ b/src/ProcessHosts/Elastic.ProcessHosts/Elasticsearch/Process/ElasticsearchProcess.cs
@@ -124,10 +124,9 @@ namespace Elastic.ProcessHosts.Elasticsearch.Process
 			
 			if (!this.JavaVersionChecker.Start(null, out var javaVersionOut))
 				throw new StartupException($"Invalid Java version reported: {javaVersionOut}");
-
-			var jvmOptionsFile = Path.Combine(this.ConfigDirectory, "jvm.options");
-			if (!this.JvmOptionsParser.Start(new [] { $"\"{jvmOptionsFile}\"" }, out var jvmOptionsLine) || string.IsNullOrWhiteSpace(jvmOptionsLine)) 
-				throw new StartupException($"Could not evaluate jvm.options file: {jvmOptionsFile} result: {jvmOptionsLine}");
+			
+			if (!this.JvmOptionsParser.Start(new [] { $"\"{this.ConfigDirectory}\"" }, out var jvmOptionsLine) || string.IsNullOrWhiteSpace(jvmOptionsLine)) 
+				throw new StartupException($"Could not evaluate jvm.options file. result: {jvmOptionsLine}");
 			jvmOptionsLine = jvmOptionsLine.Replace("${ES_TMPDIR}", this.PrivateTempDirectory).Replace("\n", "").Replace("\r", "");
 
 			return new []


### PR DESCRIPTION
Relates: elastic/elasticsearch#51882

With the introduction of jvm.options.d directory for customizing
jvm.options, the config directory path is now passed to jvm.options
parser tool instead of the jvm.options path. See the elasticsearch.bat
change for comparison:

https://github.com/elastic/elasticsearch/pull/51882/files#diff-6c06e8a0d0742dc053b8afcbfb2b4201R76

Fixes #363