### PR TITLE
Ensures node.max_local_storage_nodes is no longer set

### DIFF
--- a/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
+++ b/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using SharpYaml.Serialization;
 
@@ -51,6 +52,7 @@ namespace Elastic.Configuration.FileBased.Yaml
 		[DefaultValue(null)]
 		public List<string> InitialMasterNodes { get; set; }
 
+		[Obsolete("Removed in Elasticsearch 8.0, still here to ensure upgraded unset it")]
 		[YamlMember("node.max_local_storage_nodes")]
 		[DefaultValue(null)]
 		public int? MaxLocalStorageNodes { get; set; }

--- a/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/EditElasticsearchYamlTask.cs
+++ b/src/InstallerHosts/Elastic.InstallerHosts/Elasticsearch/Tasks/Install/EditElasticsearchYamlTask.cs
@@ -54,7 +54,10 @@ namespace Elastic.InstallerHosts.Elasticsearch.Tasks.Install
 		private void ApplyServiceModel(ElasticsearchYamlSettings settings)
 		{
 			this.Session.SendProgress(1000, "updating elasticsearch.yml with values from locations model");
-			settings.MaxLocalStorageNodes = this.InstallationModel.ServiceModel.InstallAsService ? (int?) 1 : null;
+
+			//forcefully set max local storage to null, if read as part of an upgrade to 8.0 this now needs to be cleared
+			//as its no longer a valid elasticsearch option.
+			settings.MaxLocalStorageNodes = null;
 		}
 
 		private void ApplyLocationsModel(ElasticsearchYamlSettings settings, LocationsModel locations)

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlServiceModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlServiceModelTaskTests.cs
@@ -38,7 +38,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 				}
 			);
 
-		[Fact] void MaxLocalStorageNodesShouldBeSetWhenInstallingAsService() => DefaultValidModelForTasks(s => s
+		[Fact] void MaxLocalStorageNodesShouldNotBeSetWhenInstallingAsService() => DefaultValidModelForTasks(s => s
 				.Elasticsearch(es => es
 					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
 				)
@@ -59,8 +59,37 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x");
 					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
 					var s = config.Settings;
-					//because we do not install as service
-					s.MaxLocalStorageNodes.Should().Be(1);
+					// We no longer set max local nodes when running as a service
+					s.MaxLocalStorageNodes.Should().NotHaveValue();
+				});
+		
+		[Fact] void MaxLocalStorageNodesShouldBeUnset() => DefaultValidModelForTasks(s => s
+				.Elasticsearch(es => es
+					.EsConfigMachineVariable(LocationsModel.DefaultConfigDirectory)
+				)
+				.FileSystem(fs =>
+				{
+					fs.AddFile(Path.Combine(LocationsModel.DefaultConfigDirectory, "elasticsearch.yml"), new MockFileData(@"
+node.max_local_storage_nodes: 4
+"));
+					return fs;
+				})
+			)
+			.OnStep(m => m.ServiceModel, s => s.InstallAsService = true)
+			.AssertTask(
+				(m, s, fs) => new EditElasticsearchYamlTask(m, s, fs),
+				(m, t) =>
+				{
+					var dir = m.LocationsModel.ConfigDirectory;
+					var yaml = Path.Combine(dir, "elasticsearch.yml");
+					var yamlContents = t.FileSystem.File.ReadAllText(yaml);
+					yamlContents.Should().NotBeEmpty().And.NotBe("cluster.name: x")
+						.And.NotContain("max_local_storage_nodes");
+					var config = ElasticsearchYamlConfiguration.FromFolder(dir, t.FileSystem);
+					var s = config.Settings;
+					// We no longer set max local nodes when running as a service
+#pragma warning disable once 618
+					s.MaxLocalStorageNodes.Should().NotHaveValue();
 				});
 
 	}

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlTaskTests.cs
@@ -67,8 +67,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 					s.MemoryLock.Should().Be(ConfigurationModel.DefaultMemoryLock);
 					s.LogsPath.Should().Be(LocationsModel.DefaultLogsDirectory);
 					s.DataPath.Should().Be(LocationsModel.DefaultDataDirectory);
-					//because install as service is enabled by default
-					s.MaxLocalStorageNodes.Should().Be(1);
+					s.MaxLocalStorageNodes.Should().NotHaveValue();
 					s.NetworkHost.Should().BeNullOrEmpty();
 					s.HttpPortString.Should().Be("9200");
 					s.TransportTcpPortString.Should().Be("9300");


### PR DESCRIPTION
We use to set this to protect someone starting elasticsearch manually if installed as running as a service.

This option has been removed from Elasticsearch 8.0.

This also ensures the option is cleared if someone is upgrading from `7.x` to `8.x`

relates: https://github.com/elastic/windows-installers/issues/433