### PR TITLE
Deprecate transport.tcp.port for transport.port

### DIFF
--- a/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
+++ b/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
@@ -69,8 +69,16 @@ namespace Elastic.Configuration.FileBased.Yaml
 		public string HttpPortString { get; set; }
 
 		public int? HttpPort => int.TryParse(HttpPortString, out int port) ? port : (int?)null;
-
+		
 		[YamlMember("transport.tcp.port")]
+		[DefaultValue(null)]
+		public string TransportTcpPortDeprecatedString
+		{
+			get => null;
+			set => this.TransportTcpPortString = value;
+		}
+
+		[YamlMember("transport.port")]
 		[DefaultValue(null)]
 		public string TransportTcpPortString { get; set; }
 		


### PR DESCRIPTION
Since this option is gone in 8.0 we no longer write out `transport.tcp.port`

We do support reading it from elasticsearch.yml to facilitate upgrades though

relates: https://github.com/elastic/windows-installers/issues/433