### PR TITLE
Switch over to `node.roles`

### DIFF
--- a/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
+++ b/src/Elastic.Configuration/FileBased/Yaml/ElasticsearchYamlSettings.cs
@@ -1,11 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Security.Policy;
 using SharpYaml.Serialization;
 
 namespace Elastic.Configuration.FileBased.Yaml
 {
 	public class ElasticsearchYamlSettings : Dictionary<string, object>, IYamlSettings
 	{
+		private List<string> _nodeRoles;
+
 		[YamlMember("cluster.name", SerializeMemberMode.Content)]
 		[DefaultValue(null)]
 		public string ClusterName { get; set; }
@@ -16,15 +21,75 @@ namespace Elastic.Configuration.FileBased.Yaml
 
 		[YamlMember("node.master")]
 		[DefaultValue(null)]
-		public bool? MasterNode { get; set; }
+		public bool? MasterNode
+		{
+			get => null;
+			set
+			{
+				this._masterNode = value;
+				SetNodeRole("master", value);
+			}
+		}
 
 		[YamlMember("node.data")]
 		[DefaultValue(null)]
-		public bool? DataNode { get; set; }
+		public bool? DataNode
+		{
+			get => null;
+			set
+			{
+				this._dataNode = value;
+				SetNodeRole("data", value);
+			}
+		}
 
 		[YamlMember("node.ingest")]
 		[DefaultValue(null)]
-		public bool? IngestNode { get; set; }
+		public bool? IngestNode
+		{
+			get => null;
+			set
+			{
+				this._ingestNode = value;
+				SetNodeRole("ingest", value);
+			}
+		}
+
+		public bool? HasNodeRole(string role)
+		{
+			if (role == "data" && _dataNode.HasValue) return _dataNode;
+			if (role == "ingest" && _ingestNode.HasValue) return _ingestNode;
+			if (role == "master" && _masterNode.HasValue) return _masterNode;
+			return NodeRoles?.Any(r => r != null && r.Equals(role, StringComparison.InvariantCultureIgnoreCase));
+		}
+
+		public void SetNodeRole(string role, bool? include)
+		{
+			if (_nodeRoles == null) _nodeRoles = new List<string>();
+			if (include.HasValue && include.Value) _nodeRoles.Add(role.ToLowerInvariant());
+			else _nodeRoles.Remove(role.ToLowerInvariant());
+			if (_nodeRoles.Count == 0) _nodeRoles = null;
+			if (_nodeRoles != null) _nodeRoles = new HashSet<string>(_nodeRoles).ToList();
+		}
+
+		private HashSet<string> _allRoles = new HashSet<string>(new [] {"ingest", "data", "master"});
+		private bool? _masterNode;
+		private bool? _dataNode;
+		private bool? _ingestNode;
+
+		[YamlMember("node.roles")]
+		[DefaultValue(null)]
+		public List<string> NodeRoles
+		{
+			get
+			{
+				if (_nodeRoles == null) return null;
+				//if all roles are set prefer not setting roles at all and rely on the defaults
+				return new HashSet<string>(_nodeRoles).SetEquals(_allRoles) ? null : _nodeRoles;
+			}
+			set => _nodeRoles = value;
+		}
+
 
 		[YamlMember("bootstrap.memory_lock")]
 		[DefaultValue(null)]

--- a/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
+++ b/src/Installer/Elastic.Installer.Domain/Model/Elasticsearch/Config/ConfigurationModel.cs
@@ -85,9 +85,9 @@ namespace Elastic.Installer.Domain.Model.Elasticsearch.Config
 		{
 			this.ClusterName = this._yamlSettings?.ClusterName ?? DefaultClusterName;
 			this.NodeName = this._yamlSettings?.NodeName ?? DefaultNodeName;
-			this.MasterNode = this._yamlSettings?.MasterNode ?? DefaultMasterNode;
-			this.DataNode = this._yamlSettings?.DataNode ?? DefaultDataNode;
-			this.IngestNode = this._yamlSettings?.IngestNode ?? DefaultIngestNode;
+			this.MasterNode = this._yamlSettings?.HasNodeRole("master") ?? DefaultMasterNode;
+			this.DataNode = this._yamlSettings?.HasNodeRole("data") ?? DefaultDataNode;
+			this.IngestNode = this._yamlSettings?.HasNodeRole("ingest") ?? DefaultIngestNode;
 			this.SeedHosts = ReadSeedHosts();
 			this.LockMemory = this._yamlSettings?.MemoryLock ?? DefaultMemoryLock;
 			this.TotalPhysicalMemory = DefaultTotalPhysicalMemory;

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/ElasticsearchYamlFileTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/ElasticsearchYamlFileTests.cs
@@ -23,7 +23,7 @@ cluster.name: {clusterName}
 network.host: {networkHost}
 node.data: true
 node.ingest: true
-node.master: true
+node.master: false
 node.max_local_storage_nodes: 1
 node.name: {nodeName}
 path.data: {folder}data
@@ -38,8 +38,10 @@ xpack.random_setting: something
 			settings.NodeName.Should().Be(nodeName);
 			settings.ClusterName.Should().Be(clusterName);
 			settings.NetworkHost.Should().Be(networkHost);
-			settings.DataNode.Should().BeTrue();
-			settings.IngestNode.Should().BeTrue();
+			settings.DataNode.Should().BeNull();
+			settings.IngestNode.Should().BeNull();
+			settings.MasterNode.Should().BeNull();
+			settings.NodeRoles.Should().BeEquivalentTo(new [] {"data", "ingest"});
 			settings.MemoryLock.Should().BeTrue();
 			settings.DataPath.Should().Be(folder + "data");
 			settings.LogsPath.Should().Be(folder + "logs");
@@ -50,7 +52,21 @@ xpack.random_setting: something
 			optsFile.Save();
 
 			var fileContentsAfterSave = fs.File.ReadAllText(_path);
-			fileContentsAfterSave.Replace("\r", "").Should().Be(yaml.Replace("\r", ""));
+			var updatedYaml = $@"bootstrap.memory_lock: true
+cluster.name: {clusterName}
+network.host: {networkHost}
+node.max_local_storage_nodes: 1
+node.name: {nodeName}
+node.roles:
+  - data
+  - ingest
+path.data: {folder}data
+path.logs: {folder}logs
+xpack.license.self_generated.type: trial
+xpack.security.enabled: false
+xpack.random_setting: something
+";
+			fileContentsAfterSave.Replace("\r", "").Should().Be(updatedYaml.Replace("\r", ""));
 
 		}
 		

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/RolesTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Configuration/RolesTests.cs
@@ -46,6 +46,16 @@ node.ingest: false
 			})
 			.CanClickNext();
 
+		[Fact] void SeedsNodeRolesArraryFromElasticsearchYaml() => WithExistingElasticsearchYaml($@"
+node.roles: [""ingest""]
+"
+				)
+				.OnStep(m => m.ConfigurationModel, step =>
+				{
+					step.DataNode.Should().BeFalse();
+					step.IngestNode.Should().BeTrue();
+					step.MasterNode.Should().BeFalse();
+				});
 			
 	}
 }

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlConfigurationModelTaskTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Models/Tasks/Install/EditElasticsearchYaml/EditElasticsearchYamlConfigurationModelTaskTests.cs
@@ -50,8 +50,9 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Models.Tasks.Install.Edit
 					var s = config.Settings;
 					s.ClusterName.Should().Be("x");
 					s.NodeName.Should().Be("x");
-					s.MasterNode.Should().BeFalse();
-					s.IngestNode.Should().BeFalse();
+					s.MasterNode.Should().BeNull();
+					s.IngestNode.Should().BeNull();
+					s.NodeRoles.Should().BeNullOrEmpty();
 					s.MemoryLock.Should().BeFalse();
 					s.NetworkHost.Should().Be("xyz");
 					s.HttpPort.Should().Be(80);


### PR DESCRIPTION
This makes sure the installer always generates roles under `node.roles`

The installer still reads `node.{data|ingest|master}` to facilitate upgrades, converting them over automatically.

relates: #433