### PR TITLE
Always prefer java packaged with ES

### DIFF
--- a/src/Elastic.Configuration/EnvironmentBased/Java/JavaConfiguration.cs
+++ b/src/Elastic.Configuration/EnvironmentBased/Java/JavaConfiguration.cs
@@ -41,13 +41,13 @@ namespace Elastic.Configuration.EnvironmentBased.Java
 		public string JavaHomeCanonical => JavaHomeCandidates.FirstOrDefault(j => !string.IsNullOrWhiteSpace(j));
 
 		private List<string> JavaHomeCandidates => new List<string> {
+			JavaFromEsHomeDirectory,
 			_javaStateProvider.EsJavaHomeProcessVariable,
 			_javaStateProvider.EsJavaHomeUserVariable,
 			_javaStateProvider.EsJavaHomeMachineVariable,
 			_javaStateProvider.LegacyJavaHomeProcessVariable,
 			_javaStateProvider.LegacyJavaHomeUserVariable,
 			_javaStateProvider.LegacyJavaHomeMachineVariable,
-			JavaFromEsHomeDirectory
 		};
 
 		private string JavaFromEsHomeDirectory

--- a/src/Elastic.Configuration/EnvironmentBased/Java/JavaConfiguration.cs
+++ b/src/Elastic.Configuration/EnvironmentBased/Java/JavaConfiguration.cs
@@ -41,10 +41,10 @@ namespace Elastic.Configuration.EnvironmentBased.Java
 		public string JavaHomeCanonical => JavaHomeCandidates.FirstOrDefault(j => !string.IsNullOrWhiteSpace(j));
 
 		private List<string> JavaHomeCandidates => new List<string> {
-			JavaFromEsHomeDirectory,
 			_javaStateProvider.EsJavaHomeProcessVariable,
 			_javaStateProvider.EsJavaHomeUserVariable,
 			_javaStateProvider.EsJavaHomeMachineVariable,
+			JavaFromEsHomeDirectory,
 			_javaStateProvider.LegacyJavaHomeProcessVariable,
 			_javaStateProvider.LegacyJavaHomeUserVariable,
 			_javaStateProvider.LegacyJavaHomeMachineVariable,

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/JavaConfigurationTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Configuration/JavaConfigurationTests.cs
@@ -112,7 +112,7 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Configuration
 		);
 
 		[Fact]
-		void MachineBeatsEsHome() => AssertJavaHome(_machineVariable,
+		void EsHomeBeatsLegacyaJavaHome() => AssertJavaHome(Path.Combine(_esHome, "jdk"),
 			m => m.LegacyJavaHomeMachineVariable(_machineVariable),
 			m => m.EsHomeMachineVariable(_esHome)
 		);

--- a/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/JavaHomeAndBinaryTests.cs
+++ b/src/Tests/Elastic.Domain.Tests/Elasticsearch/Process/Paths/JavaHomeAndBinaryTests.cs
@@ -24,16 +24,6 @@ namespace Elastic.Installer.Domain.Tests.Elasticsearch.Process.Paths
 			});
 
 		[Fact]
-		public void UserHomeTakesPrecedenceOverAll() => JavaChangesOnly(j => j
-			.LegacyJavaHomeUserVariable(JavaHomeUser)
-			.LegacyJavaHomeMachineVariable(JavaHomeMachine)
-			)
-			.Start(p =>
-			{
-				p.ObservableProcess.BinaryCalled.Should().Be(JavaExe(JavaHomeUser));
-			});
-
-		[Fact]
 		public void JavaHomeUsesBundledJdk() => JavaChangesOnly(s => s)
 			.Start(p =>
 			{


### PR DESCRIPTION
This should aid with errors related to wrong JAVA_HOME's

`ES_JAVA_HOME` still takes precedence.

Extends: #404